### PR TITLE
Target task placement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,9 @@ cli = "horus_builtin.interaction.cli"
 [project.entry-points."horus.task"]
 horus_task = "horus_builtin.task.horus_task"
 
+[project.entry-points."horus.target"]
+local = "horus_builtin.target.local"
+
 [project.entry-points."horus.workflow"]
 horus_workflow = "horus_builtin.workflow.horus_workflow"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,7 @@ select = [
     "B",   # flake8-bugbear
     "PL",  # pylint
     "RUF", # ruff-specific
+    "ARG", # ruff-arglint
 ]
 extend-select = ["T201"] # Prevent use of print()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,8 +112,10 @@ select = [
     "PL",  # pylint
     "RUF", # ruff-specific
     "ARG", # ruff-arglint
+    "SLF", # ruff-slf
 ]
 extend-select = ["T201"] # Prevent use of print()
+
 
 ignore = [
     "E203", # Whitespace before ':', conflicts with formatter
@@ -122,6 +124,9 @@ ignore = [
     "D212", # Multi-line docstring summary should start at the first line
     "D200", # One-line docstring should fit on one line
 ]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**/*.py" = ["SLF001"]
 
 [tool.ruff.format]
 quote-style = "double"

--- a/src/horus_builtin/runtime/python_string.py
+++ b/src/horus_builtin/runtime/python_string.py
@@ -39,7 +39,7 @@ class PythonCodeStringRuntime(BaseRuntime[str]):
     The Python code to execute.
     """
 
-    def setup_runtime(self, task: "BaseTask") -> str:
+    def setup_runtime(self, _: "BaseTask") -> str:
         """
         For the PythonCodeStringRuntime, setting up the runtime simply involves
         returning the code as is.

--- a/src/horus_builtin/target/__init__.py
+++ b/src/horus_builtin/target/__init__.py
@@ -1,0 +1,17 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#

--- a/src/horus_builtin/target/local.py
+++ b/src/horus_builtin/target/local.py
@@ -52,7 +52,7 @@ class LocalTarget(BaseTarget):
         """
         return f"local://{socket.gethostname()}"
 
-    async def dispatch(self, task: BaseTask) -> None:
+    async def _dispatch(self, task: BaseTask) -> None:
         """
         Schedule the task as a running ``asyncio.Task`` in the current event
         loop. The task starts executing immediately; call ``wait()`` to block

--- a/src/horus_builtin/target/local.py
+++ b/src/horus_builtin/target/local.py
@@ -31,6 +31,8 @@ from horus_runtime.core.target.base import BaseTarget
 from horus_runtime.core.task.base import BaseTask
 from horus_runtime.core.task.exceptions import TaskExecutionError
 from horus_runtime.core.task.status import TaskStatus
+from horus_runtime.i18n import tr as _
+from horus_runtime.logging import horus_logger
 
 
 class LocalTarget(BaseTarget):
@@ -61,6 +63,10 @@ class LocalTarget(BaseTarget):
 
         self._task = task
         self._task_future = asyncio.create_task(self._task.run())
+        horus_logger.log.debug(
+            _("Dispatched task '%(task_name)s' to local target")
+            % {"task_name": task.name}
+        )
 
     async def wait(self) -> None:
         """
@@ -70,8 +76,12 @@ class LocalTarget(BaseTarget):
             TaskExecutionError: If the task has not been dispatched yet.
         """
         if self._task_future is None:
-            raise TaskExecutionError("Task has not been dispatched yet.")
+            raise TaskExecutionError(_("Task has not been dispatched yet."))
 
+        horus_logger.log.debug(
+            _("Waiting for task '%(task_name)s' to complete on local target")
+            % {"task_name": self._task.name if self._task else "unknown"}
+        )
         await self._task_future
 
     async def cancel(self) -> None:
@@ -81,6 +91,10 @@ class LocalTarget(BaseTarget):
         """
         if self._task_future is None or self._task_future.done():
             return
+        horus_logger.log.debug(
+            _("Cancelling task '%(task_name)s' on local target")
+            % {"task_name": self._task.name if self._task else "unknown"}
+        )
         self._task_future.cancel()
         try:
             await self._task_future
@@ -92,7 +106,7 @@ class LocalTarget(BaseTarget):
         Get the current status of the task.
         """
         if self._task is None:
-            raise TaskExecutionError("Task has not been dispatched yet.")
+            raise TaskExecutionError(_("Task has not been dispatched yet."))
         return self._task.status
 
     def access_cost(self, artifact: BaseArtifact) -> float | None:

--- a/src/horus_builtin/target/local.py
+++ b/src/horus_builtin/target/local.py
@@ -1,0 +1,107 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Local target implementation for executing tasks on the local machine
+(in-process).
+"""
+
+import asyncio
+import socket
+from urllib.parse import urlparse
+
+from pydantic import PrivateAttr
+
+from horus_runtime.core.artifact.base import BaseArtifact
+from horus_runtime.core.target.base import BaseTarget
+from horus_runtime.core.task.base import BaseTask
+from horus_runtime.core.task.exceptions import TaskExecutionError
+from horus_runtime.core.task.status import TaskStatus
+
+
+class LocalTarget(BaseTarget):
+    """
+    Executes tasks directly in the current process.
+    """
+
+    kind: str = "local"
+    _task: BaseTask | None = PrivateAttr(default=None)
+    _task_future: asyncio.Task[None] | None = PrivateAttr(default=None)
+
+    @property
+    def location_id(self) -> str:
+        """
+        All ``LocalTarget`` instances on the same host share the local
+        filesystem, so the hostname alone is a sufficient location key.
+        """
+        return f"local://{socket.gethostname()}"
+
+    async def dispatch(self, task: BaseTask) -> None:
+        """
+        Schedule the task as a running ``asyncio.Task`` in the current event
+        loop. The task starts executing immediately; call ``wait()`` to block
+        until it finishes.
+        """
+        # TODO: Implement transfer_strategy to ensure artifacts are
+        # available to the task.
+
+        self._task = task
+        self._task_future = asyncio.create_task(self._task.run())
+
+    async def wait(self) -> None:
+        """
+        Wait for the task to complete.
+
+        Raises:
+            TaskExecutionError: If the task has not been dispatched yet.
+        """
+        if self._task_future is None:
+            raise TaskExecutionError("Task has not been dispatched yet.")
+
+        await self._task_future
+
+    async def cancel(self) -> None:
+        """
+        Cancel the running task by injecting ``CancelledError`` at its next
+        ``await`` point, then wait for it to finish any cleanup.
+        """
+        if self._task_future is None or self._task_future.done():
+            return
+        self._task_future.cancel()
+        try:
+            await self._task_future
+        except asyncio.CancelledError:
+            pass
+
+    async def get_status(self) -> TaskStatus:
+        """
+        Get the current status of the task.
+        """
+        if self._task is None:
+            raise TaskExecutionError("Task has not been dispatched yet.")
+        return self._task.status
+
+    def access_cost(self, artifact: BaseArtifact) -> float | None:
+        """
+        Return ``0.0`` for artifacts that are natively readable in-process:
+        local filesystem URIs (``file://`` scheme or bare paths). Returns
+        ``None`` for any other scheme, signalling that a transfer is required.
+        """
+        parsed = urlparse(artifact.uri)
+        if parsed.scheme in ("", "file"):
+            return 0.0
+        return None

--- a/src/horus_builtin/target/local.py
+++ b/src/horus_builtin/target/local.py
@@ -57,9 +57,19 @@ class LocalTarget(BaseTarget):
         Schedule the task as a running ``asyncio.Task`` in the current event
         loop. The task starts executing immediately; call ``wait()`` to block
         until it finishes.
+
+        Raises:
+            TaskExecutionError: If the task is already running on this target.
         """
         # TODO: Implement transfer_strategy to ensure artifacts are
         # available to the task.
+
+        # If the task is already running, don't start it again
+        if self._task_future is not None and not self._task_future.done():
+            raise TaskExecutionError(
+                _("Task '%(task_name)s' is already running on this target.")
+                % {"task_name": task.name}
+            )
 
         self._task = task
         self._task_future = asyncio.create_task(self._task.run())

--- a/src/horus_builtin/task/horus_task.py
+++ b/src/horus_builtin/task/horus_task.py
@@ -67,7 +67,8 @@ class HorusTask(BaseTask):
         ) in self.inputs.items():
             if not artifact.exists():
                 raise ArtifactDoesNotExistError(
-                    f"Input artifact {input_name} does not exist"
+                    _("Input artifact %(input_name)s does not exist")
+                    % {"input_name": input_name}
                 )
 
         # Execute the command using the executor
@@ -94,7 +95,8 @@ class HorusTask(BaseTask):
 
         if return_code != 0:
             raise TaskExecutionError(
-                f"Task execution failed with return code {return_code}"
+                _("Task execution failed with return code %(return_code)s")
+                % {"return_code": return_code}
             )
 
     def is_complete(self) -> bool:

--- a/src/horus_builtin/task/horus_task.py
+++ b/src/horus_builtin/task/horus_task.py
@@ -20,8 +20,10 @@ Default Horus task implementation.
 """
 
 from horus_builtin.event.task_event import HorusTaskEvent
+from horus_builtin.target.local import LocalTarget
 from horus_runtime.context import HorusContext
 from horus_runtime.core.artifact.exceptions import ArtifactDoesNotExistError
+from horus_runtime.core.target.base import BaseTarget
 from horus_runtime.core.task.base import BaseTask
 from horus_runtime.core.task.exceptions import TaskExecutionError
 from horus_runtime.i18n import tr as _
@@ -35,7 +37,12 @@ class HorusTask(BaseTask):
 
     kind: str = "horus_task"
 
-    async def run(self) -> None:
+    target: BaseTarget = LocalTarget()
+    """
+    The default target for a HorusTask is LocalTarget (in-process).
+    """
+
+    async def _run(self) -> None:
         """
         For a HorusTask, nothing needs to be done here, as the command is
         already specified in the runtime and will be executed by the executor.

--- a/src/horus_builtin/task/horus_task.py
+++ b/src/horus_builtin/task/horus_task.py
@@ -115,7 +115,7 @@ class HorusTask(BaseTask):
 
         return True
 
-    def reset(self) -> None:
+    def _reset(self) -> None:
         """
         Reset the task by deleting all output artifacts. This allows the task
         to be re-run from scratch.

--- a/src/horus_builtin/workflow/horus_workflow.py
+++ b/src/horus_builtin/workflow/horus_workflow.py
@@ -91,7 +91,7 @@ class HorusWorkflow(BaseWorkflow):
             # Wait for the task to complete and check for failure
             await task.target.wait()
 
-    def reset(self) -> None:
+    def _reset(self) -> None:
         """
         Reset the workflow by deleting all output artifacts of all tasks in the
         workflow. This allows the workflow to be re-run from scratch.

--- a/src/horus_builtin/workflow/horus_workflow.py
+++ b/src/horus_builtin/workflow/horus_workflow.py
@@ -77,8 +77,12 @@ class HorusWorkflow(BaseWorkflow):
 
             if task.task_id is None:
                 raise TaskMissingIdError(
-                    f"Task '{task.name}' has no task_id. Ensure tasks added "
-                    "after workflow construction have task_id explicitly set."
+                    _(
+                        "Task '%(task_name)s' has no task_id. Ensure tasks"
+                        " added after workflow construction have task_id"
+                        " explicitly set."
+                    )
+                    % {"task_name": task.name}
                 )
 
             # Execute the task on its target

--- a/src/horus_builtin/workflow/horus_workflow.py
+++ b/src/horus_builtin/workflow/horus_workflow.py
@@ -53,7 +53,7 @@ class HorusWorkflow(BaseWorkflow):
         with Path(path).open("r", encoding="utf-8") as fh:
             return cls.model_validate(yaml.safe_load(fh))
 
-    async def run(self) -> None:
+    async def _run(self) -> None:
         """
         Tasks are executed in definition order. A task is skipped when all of
         its output artifacts exist (see :meth:`is_complete`).
@@ -81,7 +81,11 @@ class HorusWorkflow(BaseWorkflow):
                     "after workflow construction have task_id explicitly set."
                 )
 
-            await task.run()
+            # Execute the task on its target
+            await task.target.dispatch(task)
+
+            # Wait for the task to complete and check for failure
+            await task.target.wait()
 
     def reset(self) -> None:
         """

--- a/src/horus_runtime/core/target/__init__.py
+++ b/src/horus_runtime/core/target/__init__.py
@@ -1,0 +1,17 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#

--- a/src/horus_runtime/core/target/base.py
+++ b/src/horus_runtime/core/target/base.py
@@ -60,8 +60,7 @@ class BaseTarget(AutoRegistry, entry_point="target"):
     @final
     async def dispatch(self, task: "BaseTask") -> None:
         """
-        Run the task to completion on this target.
-        Raises ``TaskExecutionError`` on failure.
+        Start executing the given task on this target.
         """
         # Set the task to "PENDING" status before dispatching
         task.status = TaskStatus.PENDING

--- a/src/horus_runtime/core/target/base.py
+++ b/src/horus_runtime/core/target/base.py
@@ -20,7 +20,7 @@ The Horus target indicates where a task should be dispatched and executed.
 """
 
 from abc import abstractmethod
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, ClassVar, final
 
 from horus_runtime.core.task.status import TaskStatus
 from horus_runtime.registry.auto_registry import AutoRegistry
@@ -57,11 +57,23 @@ class BaseTarget(AutoRegistry, entry_point="target"):
             ``horus-agent://agent-42``
         """
 
-    @abstractmethod
+    @final
     async def dispatch(self, task: "BaseTask") -> None:
         """
         Run the task to completion on this target.
         Raises ``TaskExecutionError`` on failure.
+        """
+        # Set the task to "PENDING" status before dispatching
+        task.status = TaskStatus.PENDING
+
+        await self._dispatch(task)
+
+    @abstractmethod
+    async def _dispatch(self, task: "BaseTask") -> None:
+        """
+        Internal dispatch method to be implemented by subclasses. This is
+        called by the public dispatch() method, which handles common logic like
+        retries and error handling.
         """
 
     @abstractmethod

--- a/src/horus_runtime/core/target/base.py
+++ b/src/horus_runtime/core/target/base.py
@@ -1,0 +1,111 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+The Horus target indicates where a task should be dispatched and executed.
+"""
+
+from abc import abstractmethod
+from typing import TYPE_CHECKING, ClassVar
+
+from horus_runtime.core.task.status import TaskStatus
+from horus_runtime.registry.auto_registry import AutoRegistry
+
+if TYPE_CHECKING:
+    from horus_runtime.core.artifact.base import BaseArtifact
+    from horus_runtime.core.task.base import BaseTask
+
+
+class BaseTarget(AutoRegistry, entry_point="target"):
+    """
+    Base class for task targets. A target describes *where* a task runs
+    (local, remote agent, provisioned cloud machine, etc.).
+    """
+
+    registry_key: ClassVar[str] = "kind"
+    kind: str
+
+    @property
+    @abstractmethod
+    def location_id(self) -> str:
+        """
+        Stable identifier for the physical location this target runs on.
+        Two targets with the same ``location_id`` share a filesystem, so no
+        artifact transfer is needed between them.
+
+        Implementations should return a URI-like string that is:
+        - deterministic across process restarts on the same host/node
+        - unique across distinct machines or agent instances
+
+        Examples:
+            ``local://hostname``
+            ``ssh://user@gpu-box``
+            ``horus-agent://agent-42``
+        """
+
+    @abstractmethod
+    async def dispatch(self, task: "BaseTask") -> None:
+        """
+        Run the task to completion on this target.
+        Raises ``TaskExecutionError`` on failure.
+        """
+
+    @abstractmethod
+    async def wait(self) -> None:
+        """
+        Wait for the task to complete. Raises ``TaskExecutionError`` if the
+        task fails during execution.
+        """
+
+    @abstractmethod
+    async def cancel(self) -> None:
+        """
+        Cancel the task if it is still running. Raises ``TaskExecutionError``
+        if the task fails to cancel.
+        """
+
+    @abstractmethod
+    async def get_status(self) -> "TaskStatus":
+        """
+        Get the current status of the task.
+        """
+
+    @abstractmethod
+    def access_cost(self, artifact: "BaseArtifact") -> float | None:
+        """
+        Return the estimated cost of reading ``artifact`` from this target,
+        or ``None`` if this target cannot access it at all.
+
+        The value is dimensionless and relative, callers use it to compare
+        sources and decide whether a transfer is preferable:
+
+        - ``0.0``   — zero-cost local read (same filesystem, in-memory, …)
+        - ``> 0.0`` — accessible but non-free (network, agent API, …)
+        - ``None``  — not accessible; transfer required before dispatch
+
+        Implementations must be synchronous and cheap (no I/O). Use
+        ``artifact.uri`` for location/protocol checks and ``artifact.kind``
+        (or the concrete artifact type) for kind-specific cost adjustments.
+        """
+
+    async def recover(self) -> bool:
+        """
+        Attempt to reconnect to a previously dispatched task after
+        orchestrator restart. Returns True if recovery succeeded.
+        By default, recovery is not supported and this method returns False.
+        """
+        return False

--- a/src/horus_runtime/core/task/base.py
+++ b/src/horus_runtime/core/task/base.py
@@ -22,6 +22,7 @@ executing tasks, and should be ingested by the executor.
 """
 
 from abc import abstractmethod
+from asyncio import CancelledError
 from typing import Any, ClassVar, Self
 
 from pydantic import Field, model_validator
@@ -31,6 +32,8 @@ from horus_runtime.core.executor.base import BaseExecutor
 from horus_runtime.core.executor.exceptions import IncompatibleRuntimeError
 from horus_runtime.core.interaction.transport import BaseInteractionTransport
 from horus_runtime.core.runtime.base import BaseRuntime
+from horus_runtime.core.target.base import BaseTarget
+from horus_runtime.core.task.status import TaskStatus
 from horus_runtime.registry.auto_registry import AutoRegistry
 
 
@@ -91,6 +94,16 @@ class BaseTask(AutoRegistry, entry_point="task"):
     the actual command, program or script to run.
     """
 
+    target: BaseTarget
+    """
+    The target that indicates where this task should be dispatched.
+    """
+
+    status: TaskStatus = TaskStatus.IDLE
+    """
+    The current status of the task's execution.
+    """
+
     runs: int = 0
     """
     Number of times this task has been run. This can be used for tracking and
@@ -118,12 +131,47 @@ class BaseTask(AutoRegistry, entry_point="task"):
             )
         return self
 
-    @abstractmethod
     async def run(self) -> None:
         """
-        Run the task. This method should be implemented by subclasses to define
-        the specific logic for running the task based on its context and
-        environment.
+        Execute the task, managing status transitions automatically.
+
+        Subclasses must implement ``_run()`` instead of overriding this method.
+        Status is driven entirely here:
+
+        - ``RUNNING``   — set immediately on entry
+        - ``COMPLETED`` — set on clean exit
+        - ``CANCELED``  — set when ``CancelledError`` is raised
+        - ``FAILED``    — set on any other exception (re-raised after)
+        """
+        self.status = TaskStatus.RUNNING
+        try:
+            await self._run()
+        except CancelledError:
+            self.status = TaskStatus.CANCELED
+            raise
+        except Exception:
+            self.status = TaskStatus.FAILED
+            raise
+        else:
+            self.status = TaskStatus.COMPLETED
+
+    async def sync_status(self) -> TaskStatus:
+        """
+        Refresh ``self.status`` from the target and return the updated value.
+
+        For local in-process targets this is a no-op read. For remote targets
+        (SSH, agent) this performs whatever async probe the target requires
+        (HTTP poll, SSH check, etc.) and caches the result in ``self.status``
+        so that synchronous callers can read it without I/O.
+        """
+        self.status = await self.target.get_status()
+        return self.status
+
+    @abstractmethod
+    async def _run(self) -> None:
+        """
+        Task-specific execution logic. Implement this in subclasses.
+        Do not set ``self.status`` here; ``run()`` manages it.
         """
 
     @abstractmethod
@@ -135,8 +183,19 @@ class BaseTask(AutoRegistry, entry_point="task"):
         based on its outputs.
         """
 
-    @abstractmethod
     def reset(self) -> None:
         """
         Reset the task. This allows the task to be re-run from scratch.
+
+        Resets ``self.status`` to ``IDLE`` and delegates subclass-specific
+        reset logic to ``_reset()``.
+        """
+        self.status = TaskStatus.IDLE
+        self._reset()
+
+    def _reset(self) -> None:
+        """
+        Subclass-specific reset logic. Override this in subclasses when
+        additional state must be cleared on reset. Do not set ``self.status``
+        here; ``reset()`` manages it.
         """

--- a/src/horus_runtime/core/task/base.py
+++ b/src/horus_runtime/core/task/base.py
@@ -23,7 +23,7 @@ executing tasks, and should be ingested by the executor.
 
 from abc import abstractmethod
 from asyncio import CancelledError
-from typing import Any, ClassVar, Self
+from typing import Any, ClassVar, Self, final
 
 from pydantic import Field, model_validator
 
@@ -133,6 +133,7 @@ class BaseTask(AutoRegistry, entry_point="task"):
             )
         return self
 
+    @final
     async def run(self) -> None:
         """
         Execute the task, managing status transitions automatically.
@@ -200,6 +201,7 @@ class BaseTask(AutoRegistry, entry_point="task"):
         based on its outputs.
         """
 
+    @final
     def reset(self) -> None:
         """
         Reset the task. This allows the task to be re-run from scratch.
@@ -213,6 +215,7 @@ class BaseTask(AutoRegistry, entry_point="task"):
         )
         self._reset()
 
+    @abstractmethod
     def _reset(self) -> None:
         """
         Subclass-specific reset logic. Override this in subclasses when

--- a/src/horus_runtime/core/task/base.py
+++ b/src/horus_runtime/core/task/base.py
@@ -34,6 +34,8 @@ from horus_runtime.core.interaction.transport import BaseInteractionTransport
 from horus_runtime.core.runtime.base import BaseRuntime
 from horus_runtime.core.target.base import BaseTarget
 from horus_runtime.core.task.status import TaskStatus
+from horus_runtime.i18n import tr as _
+from horus_runtime.logging import horus_logger
 from horus_runtime.registry.auto_registry import AutoRegistry
 
 
@@ -144,16 +146,31 @@ class BaseTask(AutoRegistry, entry_point="task"):
         - ``FAILED``    — set on any other exception (re-raised after)
         """
         self.status = TaskStatus.RUNNING
+        horus_logger.log.debug(
+            _("Task %(task_name)s status → RUNNING") % {"task_name": self.name}
+        )
         try:
             await self._run()
         except CancelledError:
             self.status = TaskStatus.CANCELED
+            horus_logger.log.debug(
+                _("Task %(task_name)s status → CANCELED")
+                % {"task_name": self.name}
+            )
             raise
         except Exception:
             self.status = TaskStatus.FAILED
+            horus_logger.log.debug(
+                _("Task %(task_name)s status → FAILED")
+                % {"task_name": self.name}
+            )
             raise
         else:
             self.status = TaskStatus.COMPLETED
+            horus_logger.log.debug(
+                _("Task %(task_name)s status → COMPLETED")
+                % {"task_name": self.name}
+            )
 
     async def sync_status(self) -> TaskStatus:
         """
@@ -191,6 +208,9 @@ class BaseTask(AutoRegistry, entry_point="task"):
         reset logic to ``_reset()``.
         """
         self.status = TaskStatus.IDLE
+        horus_logger.log.debug(
+            _("Task %(task_name)s reset → IDLE") % {"task_name": self.name}
+        )
         self._reset()
 
     def _reset(self) -> None:

--- a/src/horus_runtime/core/task/status.py
+++ b/src/horus_runtime/core/task/status.py
@@ -1,0 +1,58 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+TaskStatus represents the current state of a task's execution.
+"""
+
+from enum import Enum
+
+
+class TaskStatus(Enum):
+    """
+    Enumeration of possible task statuses.
+    """
+
+    IDLE = "idle"
+    """
+    The task has been created but not yet dispatched.
+    """
+
+    PENDING = "pending"
+    """
+    The task is dispatched, but has not started executing yet.
+    """
+
+    RUNNING = "running"
+    """
+    The task is currently executing.
+    """
+
+    COMPLETED = "completed"
+    """
+    The task has finished executing successfully.
+    """
+
+    FAILED = "failed"
+    """
+    The task has encountered an error during execution.
+    """
+
+    CANCELED = "canceled"
+    """
+    The task has been canceled before completion.
+    """

--- a/src/horus_runtime/core/workflow/base.py
+++ b/src/horus_runtime/core/workflow/base.py
@@ -30,12 +30,14 @@ responsibility when writing the workflow YAML file.
 """
 
 from abc import abstractmethod
+from asyncio import CancelledError
 from pathlib import Path
 from typing import ClassVar, Self
 
 from pydantic import Field, model_validator
 
 from horus_runtime.core.task.base import BaseTask
+from horus_runtime.core.workflow.status import WorkflowStatus
 from horus_runtime.registry.auto_registry import AutoRegistry
 
 
@@ -63,6 +65,12 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
     Ordered mapping of task names to task instances.
     """
 
+    status: WorkflowStatus = WorkflowStatus.IDLE
+    """
+    Current execution state of the workflow. Updated automatically by
+    ``run()``; do not set manually.
+    """
+
     @model_validator(mode="after")
     def inject_task_ids(self) -> Self:
         """
@@ -86,10 +94,35 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
             A fully constructed :class:`BaseWorkflow` instance.
         """
 
-    @abstractmethod
     async def run(self) -> None:
         """
-        Execute the workflow.
+        Execute the workflow, managing status transitions automatically.
+
+        Subclasses must implement ``_run()`` instead of overriding this method.
+        Status is driven entirely here:
+
+        - ``RUNNING``   — set immediately on entry
+        - ``COMPLETED`` — set on clean exit
+        - ``CANCELED``  — set when ``CancelledError`` is raised
+        - ``FAILED``    — set on any other exception (re-raised after)
+        """
+        self.status = WorkflowStatus.RUNNING
+        try:
+            await self._run()
+        except CancelledError:
+            self.status = WorkflowStatus.CANCELED
+            raise
+        except Exception:
+            self.status = WorkflowStatus.FAILED
+            raise
+        else:
+            self.status = WorkflowStatus.COMPLETED
+
+    @abstractmethod
+    async def _run(self) -> None:
+        """
+        Workflow-specific execution logic. Implement this in subclasses.
+        Do not set ``self.status`` here; ``run()`` manages it.
         """
 
     @abstractmethod

--- a/src/horus_runtime/core/workflow/base.py
+++ b/src/horus_runtime/core/workflow/base.py
@@ -38,6 +38,8 @@ from pydantic import Field, model_validator
 
 from horus_runtime.core.task.base import BaseTask
 from horus_runtime.core.workflow.status import WorkflowStatus
+from horus_runtime.i18n import tr as _
+from horus_runtime.logging import horus_logger
 from horus_runtime.registry.auto_registry import AutoRegistry
 
 
@@ -107,16 +109,32 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
         - ``FAILED``    — set on any other exception (re-raised after)
         """
         self.status = WorkflowStatus.RUNNING
+        horus_logger.log.debug(
+            _("Workflow %(workflow_name)s status → RUNNING")
+            % {"workflow_name": self.name}
+        )
         try:
             await self._run()
         except CancelledError:
             self.status = WorkflowStatus.CANCELED
+            horus_logger.log.debug(
+                _("Workflow %(workflow_name)s status → CANCELED")
+                % {"workflow_name": self.name}
+            )
             raise
         except Exception:
             self.status = WorkflowStatus.FAILED
+            horus_logger.log.debug(
+                _("Workflow %(workflow_name)s status → FAILED")
+                % {"workflow_name": self.name}
+            )
             raise
         else:
             self.status = WorkflowStatus.COMPLETED
+            horus_logger.log.debug(
+                _("Workflow %(workflow_name)s status → COMPLETED")
+                % {"workflow_name": self.name}
+            )
 
     @abstractmethod
     async def _run(self) -> None:

--- a/src/horus_runtime/core/workflow/base.py
+++ b/src/horus_runtime/core/workflow/base.py
@@ -32,7 +32,7 @@ responsibility when writing the workflow YAML file.
 from abc import abstractmethod
 from asyncio import CancelledError
 from pathlib import Path
-from typing import ClassVar, Self
+from typing import ClassVar, Self, final
 
 from pydantic import Field, model_validator
 
@@ -96,6 +96,7 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
             A fully constructed :class:`BaseWorkflow` instance.
         """
 
+    @final
     async def run(self) -> None:
         """
         Execute the workflow, managing status transitions automatically.
@@ -143,8 +144,23 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
         Do not set ``self.status`` here; ``run()`` manages it.
         """
 
-    @abstractmethod
+    @final
     def reset(self) -> None:
         """
-        Reset the workflow by resetting all tasks.
+        Reset the workflow by deleting all output artifacts of all tasks in the
+        workflow. This allows the workflow to be re-run from scratch.
+        """
+        self.status = WorkflowStatus.IDLE
+        horus_logger.log.debug(
+            _("Resetting workflow %(workflow_name)s.")
+            % {"workflow_name": self.name}
+        )
+        self._reset()
+
+    @abstractmethod
+    def _reset(self) -> None:
+        """
+        Subclass-specific reset logic. Override this in subclasses when
+        additional state must be cleared on reset. Do not set ``self.status``
+        here; ``reset()`` manages it.
         """

--- a/src/horus_runtime/core/workflow/status.py
+++ b/src/horus_runtime/core/workflow/status.py
@@ -1,0 +1,63 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+WorkflowStatus represents the current state of a workflow's execution.
+"""
+
+from enum import Enum
+
+
+class WorkflowStatus(Enum):
+    """
+    Enumeration of possible workflow statuses.
+    """
+
+    IDLE = "idle"
+    """
+    The workflow has been created but not yet started.
+    """
+
+    RUNNING = "running"
+    """
+    The workflow is currently executing tasks.
+    """
+
+    COMPLETED = "completed"
+    """
+    All tasks finished successfully or were skipped.
+    """
+
+    FAILED = "failed"
+    """
+    A task failed and the workflow halted. The failed task's status identifies
+    the point of failure.
+    """
+
+    CANCELED = "canceled"
+    """
+    The workflow was explicitly cancelled mid-run. Tasks that had not yet been
+    dispatched remain IDLE.
+    """
+
+    PARTIAL = "partial"
+    """
+    The workflow halted cleanly before completing all tasks (e.g. graceful
+    stop requested). Distinguished from CANCELED to support resumption: a
+    PARTIAL workflow can be resumed from the first incomplete task, whereas
+    CANCELED implies deliberate termination.
+    """

--- a/src/horus_runtime/registry/auto_registry.py
+++ b/src/horus_runtime/registry/auto_registry.py
@@ -243,7 +243,7 @@ class AutoRegistry(BaseModel, ABC):
         # Non-root classes (concrete subclasses) must use Pydantic's default
         # schema generation. If we intercepted here we would recurse infinitely
         # because dispatching calls back into validation.
-        if origin not in origin._registry_roots:
+        if origin not in origin._registry_roots:  # noqa: SLF001
             return handler(source_type)
 
         def validate(data: Any) -> Any:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,7 @@
 Test configuration for pytest.
 """
 
+from collections.abc import Generator
 from pathlib import Path
 from typing import Protocol
 
@@ -27,7 +28,9 @@ import pytest
 
 from horus_builtin.executor.shell import ShellExecutor
 from horus_builtin.runtime.command import CommandRuntime
+from horus_builtin.target.local import LocalTarget
 from horus_builtin.task.horus_task import HorusTask
+from horus_runtime.context import HorusContext, _runtime_ctx
 from horus_runtime.core.artifact.base import BaseArtifact
 from horus_runtime.registry.auto_registry import AutoRegistry
 
@@ -43,20 +46,16 @@ def pytest_configure(config: pytest.Config) -> None:
 
 class MakeTaskType(Protocol):
     """
-    Protocol for a factory function that creates HorusTask instances for
-    testing.
+    Protocol for a factory function that creates ``HorusTask`` instances
+    for testing.
     """
 
     def __call__(
         self,
         cmd: str = ...,
-        inputs: dict[str, "BaseArtifact"] | None = None,
-        task_class: type["HorusTask"] = ...,
-    ) -> "HorusTask":
-        """
-        Create a HorusTask instance with the given command, inputs,
-        and task class.
-        """
+        inputs: dict[str, BaseArtifact] | None = ...,
+    ) -> HorusTask:
+        """Create a HorusTask with the given command and inputs."""
         ...
 
 
@@ -66,21 +65,17 @@ def make_shell_task() -> MakeTaskType:
     Fixture to create HorusTask instances with CommandRuntime for testing.
     """
 
-    # Factory function to create a HorusTask with a given command
     def _make_shell_task(
         cmd: str = "echo 'Hello World'",
-        inputs: dict[str, "BaseArtifact"] | None = None,
-        task_class: type["HorusTask"] = HorusTask,
-    ) -> "HorusTask":
-
-        runtime = CommandRuntime(command=cmd)
-
-        return task_class(
+        inputs: dict[str, BaseArtifact] | None = None,
+    ) -> HorusTask:
+        return HorusTask(
             name="test_task",
             inputs=inputs or {},
             outputs={},
-            runtime=runtime,
+            runtime=CommandRuntime(command=cmd),
             executor=ShellExecutor(),
+            target=LocalTarget(),
         )
 
     return _make_shell_task
@@ -119,3 +114,18 @@ def init_registry() -> None:
     Load all built-in plugins once for the entire test session.
     """
     AutoRegistry.init_registry()
+
+
+@pytest.fixture
+def horus_context() -> Generator[HorusContext]:
+    """
+    Boot a fresh HorusContext for a test and reset the context variable
+    afterwards so tests do not leak state into each other.
+    """
+    ctx = HorusContext()
+    ctx.bus.start()
+    token = _runtime_ctx.set(ctx)
+    try:
+        yield ctx
+    finally:
+        _runtime_ctx.reset(token)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -128,4 +128,5 @@ def horus_context() -> Generator[HorusContext]:
     try:
         yield ctx
     finally:
+        ctx.shutdown()
         _runtime_ctx.reset(token)

--- a/tests/unit/event/test_event_system.py
+++ b/tests/unit/event/test_event_system.py
@@ -192,7 +192,7 @@ class TestHorusEventBusEmit:
         class _FailingTransport(BaseBusTransport):
             transport_type: str = "failing"
 
-            async def publish(self, event: BaseEvent) -> None:
+            async def publish(self, _: BaseEvent) -> None:
                 raise RuntimeError("transport down")
 
             async def start(self) -> None:

--- a/tests/unit/interaction/test_builtin_interactions.py
+++ b/tests/unit/interaction/test_builtin_interactions.py
@@ -339,7 +339,7 @@ class TestCLIRenderers:
         monkeypatch.setattr(
             CLIInteractionTransport,
             "ask_text",
-            lambda self, **kwargs: fake_ask_text(**kwargs),
+            lambda _, **kwargs: fake_ask_text(**kwargs),
         )
 
         result = await CLIStringRenderer().render(transport, interaction)
@@ -373,7 +373,7 @@ class TestCLIRenderers:
         monkeypatch.setattr(
             CLIInteractionTransport,
             "ask_text",
-            lambda self, **kwargs: fake_ask_text(**kwargs),
+            lambda _, **kwargs: fake_ask_text(**kwargs),
         )
 
         result = await CLIConfirmRenderer().render(transport, interaction)
@@ -410,7 +410,7 @@ class TestCLIRenderers:
         monkeypatch.setattr(
             CLIInteractionTransport,
             "ask_text",
-            lambda self, **kwargs: fake_ask_text(**kwargs),
+            lambda _, **kwargs: fake_ask_text(**kwargs),
         )
 
         result = await CLIDropdownRenderer().render(transport, interaction)
@@ -451,7 +451,7 @@ class TestCLIRenderers:
         monkeypatch.setattr(
             CLIInteractionTransport,
             "ask_text",
-            lambda self, **kwargs: fake_ask_text(**kwargs),
+            lambda _, **kwargs: fake_ask_text(**kwargs),
         )
 
         result = await CLIFileRenderer().render(transport, interaction)

--- a/tests/unit/runtime/test_runtime_base.py
+++ b/tests/unit/runtime/test_runtime_base.py
@@ -41,7 +41,7 @@ class ConcreteTestRuntime(BaseRuntime):
 
     kind: str = "test_runtime"
 
-    def setup_runtime(self, task: "BaseTask") -> str:
+    def setup_runtime(self, _: "BaseTask") -> str:
         """
         Test implementation of setup_runtime method.
         """
@@ -122,7 +122,7 @@ class TestBaseRuntimeValidation:
                 Invalid runtime that does not set 'kind' field.
                 """
 
-                def setup_runtime(self, task: "BaseTask") -> str:
+                def setup_runtime(self, _: "BaseTask") -> str:
                     return ""
 
     def test_model_validation_preserves_type_safety(self) -> None:

--- a/tests/unit/target/test_local_target.py
+++ b/tests/unit/target/test_local_target.py
@@ -26,7 +26,9 @@ from unittest.mock import Mock
 import pytest
 
 from horus_builtin.artifact.file import FileArtifact
+from horus_builtin.runtime.python import PythonFunctionRuntime
 from horus_builtin.target.local import LocalTarget
+from horus_builtin.task.function import FunctionTask
 from horus_runtime.context import HorusContext
 from horus_runtime.core.task.exceptions import TaskExecutionError
 from horus_runtime.core.task.status import TaskStatus
@@ -146,25 +148,32 @@ class TestLocalTargetDispatch:
         assert status == TaskStatus.COMPLETED
 
     async def test_cancel_stops_running_task(
-        self, make_shell_task: MakeTaskType
+        self, horus_context: HorusContext
     ) -> None:
         """
         cancel() cancels a still-running task and does not raise.
         """
-        target = LocalTarget()
+        del horus_context  # Fixture is required to set up the runtime context
 
-        # Use a task that blocks indefinitely so cancel() arrives while running
-        async def _slow_run() -> None:
-            await asyncio.sleep(9999)
+        async def run_slow_task() -> None:
+            # Simulate a long-running task by sleeping for a while
+            await asyncio.sleep(10)
 
-        task = make_shell_task()
-        task.target = target
-        task._run = _slow_run  # type: ignore[method-assign]
+        task = FunctionTask(
+            name="slow_task",
+            inputs={},
+            outputs={},
+            runtime=PythonFunctionRuntime(func=run_slow_task),
+        )
 
-        await target.dispatch(task)
+        # Dispatch the task to the LocalTarget
+        await task.target.dispatch(task)
+
         # Yield to the event loop so task.run() can start and reach its first
         # await point before we cancel it.
         await asyncio.sleep(0)
-        await target.cancel()
+
+        # Now cancel the task while it's still running
+        await task.target.cancel()
 
         assert task.status == TaskStatus.CANCELED

--- a/tests/unit/target/test_local_target.py
+++ b/tests/unit/target/test_local_target.py
@@ -1,0 +1,170 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Unit tests for the LocalTarget builtin target.
+"""
+
+import asyncio
+import socket
+from unittest.mock import Mock
+
+import pytest
+
+from horus_builtin.artifact.file import FileArtifact
+from horus_builtin.target.local import LocalTarget
+from horus_runtime.context import HorusContext
+from horus_runtime.core.task.exceptions import TaskExecutionError
+from horus_runtime.core.task.status import TaskStatus
+from tests.conftest import MakeTaskType
+
+
+@pytest.mark.unit
+class TestLocalTargetProperties:
+    """
+    Tests for LocalTarget configuration and metadata.
+    """
+
+    def test_kind_is_local(self) -> None:
+        """
+        The 'kind' field must be 'local'.
+        """
+        assert LocalTarget().kind == "local"
+
+    def test_location_id_uses_local_scheme_and_hostname(self) -> None:
+        """
+        location_id must follow the ``local://<hostname>`` format.
+        """
+        target = LocalTarget()
+        assert target.location_id == f"local://{socket.gethostname()}"
+
+    def test_access_cost_zero_for_bare_path(self) -> None:
+        """
+        A bare filesystem path (no scheme) has zero access cost.
+        """
+        target = LocalTarget()
+        artifact = FileArtifact(uri="/tmp/some_file.txt")
+        assert target.access_cost(artifact) == 0.0
+
+    def test_access_cost_zero_for_file_scheme(self) -> None:
+        """
+        A ``file://`` URI has zero access cost.
+        """
+        target = LocalTarget()
+        artifact = FileArtifact(uri="file:///tmp/some_file.txt")
+        assert target.access_cost(artifact) == 0.0
+
+    def test_access_cost_none_for_remote_scheme(self) -> None:
+        """
+        A remote URI (e.g. ``s3://``) returns None, signalling transfer needed.
+        """
+        target = LocalTarget()
+        artifact = Mock(uri="s3://bucket/key")
+        assert target.access_cost(artifact) is None
+
+
+@pytest.mark.unit
+class TestLocalTargetDispatch:
+    """
+    Tests for LocalTarget task lifecycle: dispatch / wait / cancel / status.
+    """
+
+    async def test_wait_raises_before_dispatch(self) -> None:
+        """
+        Calling wait() before dispatch raises TaskExecutionError.
+        """
+        target = LocalTarget()
+        with pytest.raises(TaskExecutionError):
+            await target.wait()
+
+    async def test_get_status_raises_before_dispatch(self) -> None:
+        """
+        Calling get_status() before dispatch raises TaskExecutionError.
+        """
+        target = LocalTarget()
+        with pytest.raises(TaskExecutionError):
+            await target.get_status()
+
+    async def test_cancel_before_dispatch_is_noop(self) -> None:
+        """
+        cancel() before dispatch does not raise.
+        """
+        target = LocalTarget()
+        await target.cancel()  # should not raise
+
+    async def test_dispatch_and_wait_complete_successfully(
+        self, make_shell_task: MakeTaskType, horus_context: HorusContext
+    ) -> None:
+        """
+        A dispatched task runs to completion; wait() returns without error.
+        """
+        # Fixture is required to set up the runtime context
+        # but not used directly in this test body
+        del horus_context
+
+        target = LocalTarget()
+        task = make_shell_task()
+        task.target = target
+
+        await target.dispatch(task)
+        await target.wait()
+
+        assert task.status == TaskStatus.COMPLETED
+
+    async def test_get_status_reflects_task_status(
+        self, make_shell_task: MakeTaskType, horus_context: HorusContext
+    ) -> None:
+        """
+        get_status() reads the status directly from the dispatched task.
+        """
+        # Fixture is required to set up the runtime context
+        # but not used directly in this test body
+        del horus_context
+
+        target = LocalTarget()
+        task = make_shell_task()
+        task.target = target
+
+        await target.dispatch(task)
+        await target.wait()
+
+        status = await target.get_status()
+        assert status == TaskStatus.COMPLETED
+
+    async def test_cancel_stops_running_task(
+        self, make_shell_task: MakeTaskType
+    ) -> None:
+        """
+        cancel() cancels a still-running task and does not raise.
+        """
+        target = LocalTarget()
+
+        # Use a task that blocks indefinitely so cancel() arrives while running
+        async def _slow_run() -> None:
+            await asyncio.sleep(9999)
+
+        task = make_shell_task()
+        task.target = target
+        task._run = _slow_run  # type: ignore[method-assign]
+
+        await target.dispatch(task)
+        # Yield to the event loop so task.run() can start and reach its first
+        # await point before we cancel it.
+        await asyncio.sleep(0)
+        await target.cancel()
+
+        assert task.status == TaskStatus.CANCELED

--- a/tests/unit/target/test_target_base.py
+++ b/tests/unit/target/test_target_base.py
@@ -45,7 +45,7 @@ class ConcreteTestTarget(BaseTarget):
         """
         return "test://localhost"
 
-    async def dispatch(self, task: BaseTask) -> None:
+    async def _dispatch(self, task: BaseTask) -> None:
         """
         Simulate dispatching a task to this target.
         """

--- a/tests/unit/target/test_target_base.py
+++ b/tests/unit/target/test_target_base.py
@@ -1,0 +1,127 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Unit tests for BaseTarget abstract base class.
+"""
+
+from abc import ABC
+
+import pytest
+from pydantic import BaseModel
+
+from horus_runtime.core.artifact.base import BaseArtifact
+from horus_runtime.core.target.base import BaseTarget
+from horus_runtime.core.task.base import BaseTask
+from horus_runtime.core.task.status import TaskStatus
+from horus_runtime.registry.auto_registry import AutoRegistry
+
+
+class ConcreteTestTarget(BaseTarget):
+    """
+    Minimal concrete implementation of BaseTarget for testing purposes.
+    """
+
+    kind: str = "test_target"
+
+    @property
+    def location_id(self) -> str:
+        """
+        Return the location identifier for this target.
+        """
+        return "test://localhost"
+
+    async def dispatch(self, task: BaseTask) -> None:
+        """
+        Simulate dispatching a task to this target.
+        """
+        pass
+
+    async def wait(self) -> None:
+        """
+        Simulate waiting for a dispatched task to complete.
+        """
+        pass
+
+    async def cancel(self) -> None:
+        """
+        Simulate canceling a dispatched task.
+        """
+        pass
+
+    async def get_status(self) -> TaskStatus:
+        """
+        Simulate retrieving the status of a dispatched task.
+        """
+        return TaskStatus.IDLE
+
+    def access_cost(self, _: BaseArtifact) -> float | None:
+        """
+        Simulate calculating the access cost for an artifact.
+        """
+        return 0.0
+
+
+@pytest.mark.unit
+class TestBaseTarget:
+    """
+    Tests for the BaseTarget abstract base class.
+    """
+
+    def test_base_target_is_abstract(self) -> None:
+        """
+        BaseTarget cannot be instantiated directly.
+        """
+        with pytest.raises(TypeError):
+            BaseTarget()  # type: ignore
+
+    def test_base_target_inherits_correctly(self) -> None:
+        """
+        BaseTarget inherits from AutoRegistry and BaseModel.
+        """
+        assert issubclass(BaseTarget, BaseModel)
+        assert issubclass(BaseTarget, ABC)
+        assert issubclass(BaseTarget, AutoRegistry)
+
+    def test_registry_key_is_kind(self) -> None:
+        """
+        BaseTarget uses 'kind' as its registry discriminator.
+        """
+        assert BaseTarget.registry_key == "kind"
+
+    async def test_recover_returns_false_by_default(self) -> None:
+        """
+        The default recover() implementation returns False without raising.
+        """
+        target = ConcreteTestTarget()
+        result = await target.recover()
+        assert result is False
+
+    def test_concrete_target_instantiates(self) -> None:
+        """
+        A fully-implemented subclass can be instantiated without error.
+        """
+        target = ConcreteTestTarget()
+        assert target.kind == "test_target"
+
+    def test_location_id_is_string(self) -> None:
+        """
+        location_id must return a non-empty string.
+        """
+        target = ConcreteTestTarget()
+        assert isinstance(target.location_id, str)
+        assert target.location_id

--- a/tests/unit/task/test_task_base.py
+++ b/tests/unit/task/test_task_base.py
@@ -19,7 +19,6 @@
 Unit tests for BaseTask abstract base class.
 """
 
-import inspect
 from abc import ABC
 from typing import ClassVar
 
@@ -29,6 +28,8 @@ from pydantic import BaseModel, ValidationError
 from horus_builtin.artifact.file import FileArtifact
 from horus_builtin.executor.shell import ShellExecutor
 from horus_builtin.runtime.command import CommandRuntime
+from horus_builtin.target.local import LocalTarget
+from horus_runtime.core.target.base import BaseTarget
 from horus_runtime.core.task.base import BaseTask
 from horus_runtime.registry.auto_registry import (
     AutoRegistry,
@@ -42,8 +43,9 @@ class ConcreteTestTask(BaseTask):
     """
 
     kind: str = "test_task"
+    target: BaseTarget = LocalTarget()
 
-    async def run(self) -> None:
+    async def _run(self) -> None:
         """
         Test implementation of run method.
         """
@@ -54,7 +56,7 @@ class ConcreteTestTask(BaseTask):
         """
         return True
 
-    def reset(self) -> None:
+    def _reset(self) -> None:
         """
         Do nothing for testing purposes.
         """
@@ -94,23 +96,6 @@ class TestBaseTask:
         # autoregistry. For task, the registry key is 'kind',
         # so we want to make sure that this is set correctly in the base class.
         assert BaseTask.registry_key == "kind"
-
-    def test_run_method_is_abstract(self) -> None:
-        """
-        Test that run method is marked as abstract.
-        """
-        # Check that the run method is in the abstract methods
-        abstract_methods = BaseTask.__abstractmethods__
-        assert "run" in abstract_methods
-
-    def test_run_method_signature(self) -> None:
-        """
-        Test that run method has correct signature.
-        """
-        sig = inspect.signature(BaseTask.run)
-
-        params = list(sig.parameters.keys())
-        assert params == ["self"]
 
     def test_base_task_has_required_fields(self) -> None:
         """
@@ -163,15 +148,18 @@ class TestBaseTaskValidation:
             class InvalidTask(BaseTask):
                 """
                 Invalid task that does not set 'kind' field.
+
+                # Note: We have to define the abstract methods
+                # for the autoregistry to work.
                 """
 
                 def is_complete(self) -> bool:
                     return True
 
-                def reset(self) -> None:
+                def _reset(self) -> None:
                     pass
 
-                async def run(self) -> None:
+                async def _run(self) -> None:
                     pass
 
     def test_model_validation_preserves_type_safety(self) -> None:

--- a/tests/unit/task/test_task_base.py
+++ b/tests/unit/task/test_task_base.py
@@ -298,6 +298,6 @@ class TestBaseTaskReset:
         task.variables["x"] = 1
 
         # Should not raise
-        task._reset()
+        task.reset()
 
         assert task.variables["x"] == 1

--- a/tests/unit/task/test_task_base.py
+++ b/tests/unit/task/test_task_base.py
@@ -31,6 +31,7 @@ from horus_builtin.runtime.command import CommandRuntime
 from horus_builtin.target.local import LocalTarget
 from horus_runtime.core.target.base import BaseTarget
 from horus_runtime.core.task.base import BaseTask
+from horus_runtime.core.task.status import TaskStatus
 from horus_runtime.registry.auto_registry import (
     AutoRegistry,
 )
@@ -61,6 +62,20 @@ class ConcreteTestTask(BaseTask):
         Do nothing for testing purposes.
         """
         pass
+
+
+def _make_concrete_task(cmd: str = "echo test") -> ConcreteTestTask:
+    """
+    Build a ``ConcreteTestTask`` with sensible defaults.
+    """
+    return ConcreteTestTask(
+        name="test_task",
+        inputs={},
+        outputs={},
+        runtime=CommandRuntime(command=cmd),
+        executor=ShellExecutor(),
+        target=LocalTarget(),
+    )
 
 
 @pytest.mark.unit
@@ -251,3 +266,38 @@ class TestBaseTaskValidation:
         assert "output1" in task.outputs
         assert isinstance(task.inputs["input1"], FileArtifact)
         assert isinstance(task.outputs["output1"], FileArtifact)
+
+
+@pytest.mark.unit
+class TestBaseTaskReset:
+    """
+    Tests for the reset / _reset contract on BaseTask.
+    """
+
+    def test_reset_sets_status_to_idle(
+        self,
+    ) -> None:
+        """
+        reset() must restore status to IDLE regardless of the current state.
+        """
+        task = _make_concrete_task()
+        task.status = TaskStatus.COMPLETED
+
+        task.reset()
+
+        assert task.status == TaskStatus.IDLE
+
+    def test_default_reset_is_noop(
+        self,
+    ) -> None:
+        """
+        The default _reset() implementation does not raise and leaves task
+        state intact (beyond what reset() itself changes).
+        """
+        task = _make_concrete_task()
+        task.variables["x"] = 1
+
+        # Should not raise
+        task._reset()
+
+        assert task.variables["x"] == 1

--- a/tests/unit/workflow/test_builtin_workflow.py
+++ b/tests/unit/workflow/test_builtin_workflow.py
@@ -222,8 +222,8 @@ class TestWorkflowRun:
         class TaskWithFailure(HorusTask):
             add_to_registry: ClassVar[bool] = False
 
-            async def run(self) -> None:
-                await super().run()  # Here it calls +1 run count
+            async def _run(self) -> None:
+                await super()._run()  # Here it calls +1 run count
                 raise TaskExecutionError("fail")
 
         task_a = TaskWithFailure(

--- a/tests/unit/workflow/test_builtin_workflow.py
+++ b/tests/unit/workflow/test_builtin_workflow.py
@@ -27,6 +27,9 @@ from unittest.mock import Mock, patch
 import pytest
 
 from horus_builtin.artifact.file import FileArtifact
+from horus_builtin.executor.shell import ShellExecutor
+from horus_builtin.runtime.command import CommandRuntime
+from horus_builtin.target.local import LocalTarget
 from horus_builtin.task.horus_task import HorusTask
 from horus_builtin.workflow.horus_workflow import HorusWorkflow
 from horus_runtime.core.task.exceptions import (
@@ -223,7 +226,14 @@ class TestWorkflowRun:
                 await super().run()  # Here it calls +1 run count
                 raise TaskExecutionError("fail")
 
-        task_a = make_shell_task(cmd="echo A", task_class=TaskWithFailure)
+        task_a = TaskWithFailure(
+            name="test_task",
+            inputs={},
+            outputs={},
+            runtime=CommandRuntime(command="echo A"),
+            executor=ShellExecutor(),
+            target=LocalTarget(),
+        )
         task_b = make_shell_task(cmd="echo B")
 
         wf = HorusWorkflow(name="stop_test", tasks={"a": task_a, "b": task_b})

--- a/tests/unit/workflow/test_builtin_workflow.py
+++ b/tests/unit/workflow/test_builtin_workflow.py
@@ -256,10 +256,13 @@ class TestWorkflowRun:
         task = make_shell_task(cmd="echo test")
         task.task_id = None  # Simulate the pre-fix state
 
-        wf = HorusWorkflow.__new__(HorusWorkflow)
-        # Bypass model_validator (inject_task_ids) to preserve the None id
-        object.__setattr__(wf, "tasks", {"orphan": task})
-        object.__setattr__(wf, "name", "test_wf")
+        wf = HorusWorkflow(
+            name="missing_id",
+            tasks={"orphan": task},
+        )
+
+        # Manually patch the task to remove the ID
+        wf.tasks["orphan"].task_id = None
 
         with (
             patch(

--- a/tests/unit/workflow/test_workflow.py
+++ b/tests/unit/workflow/test_workflow.py
@@ -47,7 +47,7 @@ class ConcreteWorkflow(BaseWorkflow):
             data = yaml.safe_load(fh)
             return cls.model_validate(data)
 
-    async def run(self) -> None:
+    async def _run(self) -> None:
         """
         Run the workflow by executing all its tasks.
         """

--- a/tests/unit/workflow/test_workflow.py
+++ b/tests/unit/workflow/test_workflow.py
@@ -52,7 +52,7 @@ class ConcreteWorkflow(BaseWorkflow):
         Run the workflow by executing all its tasks.
         """
 
-    def reset(self) -> None:
+    def _reset(self) -> None:
         """
         Reset the workflow to its initial state.
         """


### PR DESCRIPTION
## Summary

Introduces the concept of a **target**: the location where a task is dispatched and executed. This decouples *what* runs (the task/runtime/executor) from *where* it runs, enabling future support for remote execution environments (SSH, cloud agents, containers) without changing task or workflow code.

### What Changed

#### New: `BaseTarget` abstraction (`horus_runtime.core.target`)
- Abstract base class defining the target contract: `dispatch()`, `wait()`, `cancel()`, `get_status()`, `access_cost()`, and `recover()`.
- `location_id` property provides a stable identifier for the physical host — used in the future to decide whether artifact transfer is needed before dispatching.
- Registered in the `AutoRegistry` under the `"target"` entry point.

#### New: `LocalTarget` (`horus_builtin.target.local`)
- Concrete `BaseTarget` that executes tasks **in-process** using `asyncio.create_task()`.
- `dispatch()` schedules the task and returns immediately; `wait()` blocks until completion.
- `cancel()` injects `CancelledError` at the next `await` point and awaits cleanup.
- `access_cost()` returns `0.0` for local filesystem artifacts ( or bare paths) and `None` for anything requiring a transfer.

#### New: `TaskStatus` enum (`horus_runtime.core.task.status`)
Tracks a task's execution state: `IDLE → PENDING → RUNNING → COMPLETED / FAILED / CANCELED`.

#### New: `WorkflowStatus` enum (`horus_runtime.core.workflow.status`)
Mirrors `TaskStatus` at the workflow level, adding `PARTIAL` for graceful mid-run stops that support resumption.

#### Changed: `BaseTask`
- Added `target: BaseTarget` and `status: TaskStatus` fields.
- `run()` is now a **non-overridable template method** that manages all status transitions (`RUNNING → COMPLETED / FAILED / CANCELED`). Subclasses implement `_run()`.
- `reset()` is now a **non-overridable template method** that resets `status → IDLE` and delegates to `_reset()`. Subclasses implement `_reset()`.
- Added `sync_status()` for polling remote target status asynchronously.
- All status transitions emit `DEBUG` log lines via `horus_logger` with i18n'd messages.

#### Changed: `BaseWorkflow`
- Added `status: WorkflowStatus` field.
- `run()` is now a template method managing workflow-level status transitions. Subclasses implement `_run()`.
- All status transitions emit `DEBUG` log lines.

#### Changed: `HorusWorkflow._run()`
- Tasks are no longer called with `await task.run()` directly — they are dispatched through their target: `await task.target.dispatch(task)` + `await task.target.wait()`.
- `HorusTask` defaults to `LocalTarget`, so existing behaviour is preserved.

---

### Not in scope
- Artifact transfer strategy before remote dispatch (marked `TODO` in `LocalTarget.dispatch()`).
- Remote target implementations (SSH, Horus Agent).
- `PARTIAL` workflow resumption logic.

## Documentation impact

If a user, plugin, or GUI can observe the difference, it requires documentation.

- [ ] No documentation update required
- [X] Documentation updated / will be updated

If documentation was updated, link the docs PR here:

**horus-docs PR:** ⬇️

https://github.com/temple-compute/horus-docs/pull/13