### PR TITLE
Added AutoRegistryProduct

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,7 @@ ignore = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**/*.py" = ["SLF001"]
+"tests/**/*.py" = ["SLF001"] # Allow private method access in tests
 
 [tool.ruff.format]
 quote-style = "double"

--- a/src/horus_runtime/core/interaction/renderer.py
+++ b/src/horus_runtime/core/interaction/renderer.py
@@ -24,13 +24,16 @@ from abc import abstractmethod
 from typing import TYPE_CHECKING, Any, ClassVar, Self
 
 from horus_runtime.registry.auto_registry import AutoRegistry
+from horus_runtime.registry.auto_registry_product import AutoRegistryProduct
 
 if TYPE_CHECKING:
     from horus_runtime.core.interaction.base import BaseInteraction
     from horus_runtime.core.interaction.transport import (
         BaseInteractionTransport,
     )
-# Type aliases for renderer class attributes.
+
+# Type aliases for the renderer class attributes that identify which
+# transport and interaction types a renderer handles.
 HandlesTransportType = type["BaseInteractionTransport"]
 HandlesInteractionType = type["BaseInteraction[Any]"]
 
@@ -38,51 +41,18 @@ HandlesInteractionType = type["BaseInteraction[Any]"]
 class BaseInteractionRenderer[
     T: "BaseInteractionTransport" = "BaseInteractionTransport",
     I: "BaseInteraction[Any]" = "BaseInteraction[Any]",
-](AutoRegistry, entry_point="interaction_renderer"):
+](AutoRegistryProduct, AutoRegistry, entry_point="interaction_renderer"):
     """
     Maps one interaction type to one transport type. Defines how to render
     an interaction and collect a raw answer from the user.
     """
 
-    registry_key: ClassVar[str] = "render_key"
+    registry_key: ClassVar[str] = (
+        "render_key:handles_transport.handles_interaction"
+    )
     render_key: str | None = None
-    handles_transport: ClassVar[type[T]]
-    handles_interaction: ClassVar[type[I]]
-
-    def __init_subclass__(cls, **kwargs: Any) -> None:
-        """
-        Automatically initialize the render_key based on the transport and
-        interaction types.
-        """
-        # Only set the render_key for fully defined subclasses,
-        # not for intermediate ones.
-        if not hasattr(cls, "handles_transport") or not hasattr(
-            cls, "handles_interaction"
-        ):
-            return
-
-        # `kind` is a Pydantic model field (not a ClassVar), so it is not
-        # accessible as a class attribute. Read the registered default value
-        # via model_fields instead.
-        transport_fields = getattr(cls.handles_transport, "model_fields", {})
-        interaction_fields = getattr(
-            cls.handles_interaction, "model_fields", {}
-        )
-
-        if "kind" not in transport_fields or "kind" not in interaction_fields:
-            return
-
-        transport_kind = transport_fields["kind"].default
-        interaction_kind = interaction_fields["kind"].default
-
-        if not transport_kind or not interaction_kind:
-            return
-
-        # Automatically set the render_key based on the transport and
-        # interaction kinds.
-        cls.render_key = f"{transport_kind}:{interaction_kind}"
-
-        super().__init_subclass__(**kwargs)
+    handles_transport: ClassVar[HandlesTransportType]
+    handles_interaction: ClassVar[HandlesInteractionType]
 
     @classmethod
     def get_from_registry(

--- a/src/horus_runtime/core/interaction/renderer.py
+++ b/src/horus_runtime/core/interaction/renderer.py
@@ -63,7 +63,7 @@ class BaseInteractionRenderer[
         """
         Look up the renderer that handles the given transport/interaction pair.
         """
-        return cls.registry.get(f"{transport.kind}:{interaction.kind}")
+        return cls.registry.get(f"{transport.kind}.{interaction.kind}")
 
     @abstractmethod
     async def render(

--- a/src/horus_runtime/registry/auto_registry.py
+++ b/src/horus_runtime/registry/auto_registry.py
@@ -25,9 +25,9 @@ new type to a central registry.
 from abc import ABC
 from importlib.metadata import entry_points
 from inspect import isabstract
-from typing import Any, ClassVar, Self
+from typing import Any, ClassVar, Self, Unpack, final
 
-from pydantic import BaseModel, GetCoreSchemaHandler
+from pydantic import BaseModel, ConfigDict, GetCoreSchemaHandler
 from pydantic_core import CoreSchema, core_schema
 
 from horus_runtime.i18n import tr as _
@@ -109,7 +109,7 @@ class AutoRegistry(BaseModel, ABC):
     def __init_subclass__(
         cls: type[Self],
         entry_point: str | None = None,
-        **kwargs: Any,
+        **kwargs: Unpack[ConfigDict],
     ) -> None:
         """
         Called automatically when a subclass is defined.
@@ -215,6 +215,7 @@ class AutoRegistry(BaseModel, ABC):
         # Register the concrete subclass under its discriminator value.
         cls.registry[key_value] = cls
 
+    @final
     @classmethod
     def __get_pydantic_core_schema__(
         cls,
@@ -246,7 +247,7 @@ class AutoRegistry(BaseModel, ABC):
         if origin not in origin._registry_roots:  # noqa: SLF001
             return handler(source_type)
 
-        def validate(data: Any) -> Any:
+        def validate(data: object) -> object:
             # Already a valid instance of this hierarchy, pass through.
             if isinstance(data, origin):
                 return data
@@ -286,6 +287,7 @@ class AutoRegistry(BaseModel, ABC):
 
         return core_schema.no_info_plain_validator_function(validate)
 
+    @final
     @staticmethod
     def init_registry(bases: list[type["AutoRegistry"]] | None = None) -> None:
         """

--- a/src/horus_runtime/registry/auto_registry_product.py
+++ b/src/horus_runtime/registry/auto_registry_product.py
@@ -1,0 +1,118 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Mixin for registries whose discriminator key is composed from the default
+values of other ``AutoRegistry`` types.
+"""
+
+from inspect import isabstract
+from typing import ClassVar, Unpack, cast
+
+from pydantic import ConfigDict
+from pydantic.fields import FieldInfo
+
+from horus_runtime.registry.auto_registry import AutoRegistry
+
+
+class AutoRegistryProduct:
+    """
+    Mixin that derives a registry key by composing the discriminator defaults
+    of other ``AutoRegistry`` types referenced as ClassVar attributes.
+
+    ``registry_key`` format::
+
+        "<field_name>:<attr1>.<attr2>"
+
+    ``<field_name>`` is the Pydantic field that stores the derived key.
+    ``<attr1>``, ``<attr2>`` … are ClassVar attributes whose types are other
+    ``AutoRegistry`` subclasses; their discriminator field defaults are joined
+    with ``:`` to form the registry key.
+
+    Put this mixin before ``AutoRegistry`` in the base list so the derived key
+    is committed to the class **before** ``super().__init_subclass__`` hands
+    control to ``AutoRegistry``, which reads the key for registration.
+    """
+
+    _KEY_SEPARATOR: ClassVar[str] = ":"
+    _ATTR_SEPARATOR: ClassVar[str] = "."
+
+    def __init_subclass__(cls, **kwargs: Unpack[ConfigDict]) -> None:
+        """
+        Derive the registry key from the referenced attributes and commit it to
+        the class before AutoRegistry's __init_subclass__ runs.
+        """
+        if not issubclass(cls, AutoRegistry):
+            raise TypeError(
+                f"{cls.__name__} uses AutoRegistryProduct but does not "
+                "inherit from AutoRegistry."
+            )
+
+        # Abstract classes and opted-out classes are never registered as
+        # concrete implementations.
+        if isabstract(cls) or not cls.add_to_registry:
+            # Proceed with normal AutoRegistry processing,
+            # which will skip registration for this case, but delegate
+            # other sublcass initialization processing (pydantic model setup,
+            # etc).
+            cast(AutoRegistry, super()).__init_subclass__(**kwargs)
+            return
+
+        if cls._KEY_SEPARATOR not in cls.registry_key:
+            # Warn the user that AutoRegistryProduct is being used without a
+            # composite registry_key, which is useless and likely a mistake.
+            raise ValueError(
+                f"{cls.__name__} uses AutoRegistryProduct but registry_key "
+                "is not in the expected 'field_name:attr1' format."
+            )
+
+        field_name, raw_attrs = cls.registry_key.split(
+            cls._KEY_SEPARATOR, maxsplit=1
+        )
+
+        parts: list[str] = []
+        for attr in raw_attrs.split(cls._ATTR_SEPARATOR):
+            # Resolve the ClassVar attribute to the referenced registry
+            # type.
+            attr_type: type[AutoRegistry] | None = getattr(cls, attr, None)
+
+            if attr_type is None:
+                raise ValueError(
+                    f"{cls.__name__} registry_key references attribute "
+                    f"'{attr}' which does not exist."
+                )
+
+            # Read the discriminator default from that type's model_fields.
+            key_field = attr_type.registry_key
+            field = cast(FieldInfo, attr_type.model_fields.get(key_field))
+            value: object = field.default if field is not None else None
+            if not isinstance(value, str) or not value:
+                raise ValueError(
+                    f"{cls.__name__} registry_key references attribute "
+                    f"'{attr}' whose registry key is not a non-empty string."
+                )
+
+            parts.append(value)
+
+        # All attrs resolved: commit the composed key to the class so
+        # AutoRegistry reads it during super().__init_subclass__.
+        setattr(cls, field_name, cls._KEY_SEPARATOR.join(parts))
+        cls.registry_key = field_name
+
+        # Proceed with normal AutoRegistry processing, which will read the
+        # derived registry_key and register the class.
+        cast(AutoRegistry, super()).__init_subclass__(**kwargs)

--- a/src/horus_runtime/registry/auto_registry_product.py
+++ b/src/horus_runtime/registry/auto_registry_product.py
@@ -34,7 +34,7 @@ class AutoRegistryProduct:
     Mixin that derives a registry key by composing the discriminator defaults
     of other ``AutoRegistry`` types referenced as ClassVar attributes.
 
-    ``registry_key`` format::
+    ``registry_key`` format (declared on the root/abstract class)::
 
         "<field_name>:<attr1>.<attr2>"
 
@@ -43,6 +43,12 @@ class AutoRegistryProduct:
     ``AutoRegistry`` subclasses; their discriminator field defaults are joined
     with ``:`` to form the registry key.
 
+    When a class explicitly declares this composite format, this mixin
+    normalises ``registry_key`` to just ``<field_name>`` immediately (so that
+    ``AutoRegistry`` always sees a plain field name as the discriminator) and
+    stores the full template in ``_product_key_template``, which concrete
+    subclasses inherit and use to drive composition.
+
     Put this mixin before ``AutoRegistry`` in the base list so the derived key
     is committed to the class **before** ``super().__init_subclass__`` hands
     control to ``AutoRegistry``, which reads the key for registration.
@@ -50,6 +56,7 @@ class AutoRegistryProduct:
 
     _KEY_SEPARATOR: ClassVar[str] = ":"
     _ATTR_SEPARATOR: ClassVar[str] = "."
+    _product_key_template: ClassVar[str]
 
     def __init_subclass__(cls, **kwargs: Unpack[ConfigDict]) -> None:
         """
@@ -62,27 +69,38 @@ class AutoRegistryProduct:
                 "inherit from AutoRegistry."
             )
 
+        # If this class explicitly declares a composite registry_key (one that
+        # contains the separator), normalise it to just the field name so that
+        # AutoRegistry always uses a plain field name as the discriminator.
+        # The full template is preserved in _product_key_template so that
+        # concrete subclasses can inherit and use it for composition.
+        if "registry_key" in cls.__dict__:
+            raw_key: str = cls.__dict__["registry_key"]
+            if cls._KEY_SEPARATOR in raw_key:
+                cls._product_key_template = raw_key
+                cls.registry_key = raw_key.split(cls._KEY_SEPARATOR, 1)[0]
+
         # Abstract classes and opted-out classes are never registered as
         # concrete implementations.
         if isabstract(cls) or not cls.add_to_registry:
             # Proceed with normal AutoRegistry processing,
             # which will skip registration for this case, but delegate
-            # other sublcass initialization processing (pydantic model setup,
+            # other subclass initialization processing (pydantic model setup,
             # etc).
             cast(AutoRegistry, super()).__init_subclass__(**kwargs)
             return
 
-        if cls._KEY_SEPARATOR not in cls.registry_key:
-            # Warn the user that AutoRegistryProduct is being used without a
-            # composite registry_key, which is useless and likely a mistake.
+        # Retrieve the composition template stored by the root/intermediate
+        # class that declared the composite registry_key.
+        template: str | None = getattr(cls, "_product_key_template", None)
+        if not template or cls._KEY_SEPARATOR not in template:
             raise ValueError(
-                f"{cls.__name__} uses AutoRegistryProduct but registry_key "
-                "is not in the expected 'field_name:attr1' format."
+                f"{cls.__name__} uses AutoRegistryProduct but no composite "
+                "registry_key template was found. Make sure a base class "
+                "defines registry_key in 'field_name:attr1.attr2' format."
             )
 
-        field_name, raw_attrs = cls.registry_key.split(
-            cls._KEY_SEPARATOR, maxsplit=1
-        )
+        field_name, raw_attrs = template.split(cls._KEY_SEPARATOR, maxsplit=1)
 
         parts: list[str] = []
         for attr in raw_attrs.split(cls._ATTR_SEPARATOR):
@@ -110,7 +128,7 @@ class AutoRegistryProduct:
 
         # All attrs resolved: commit the composed key to the class so
         # AutoRegistry reads it during super().__init_subclass__.
-        setattr(cls, field_name, cls._KEY_SEPARATOR.join(parts))
+        setattr(cls, field_name, cls._ATTR_SEPARATOR.join(parts))
         cls.registry_key = field_name
 
         # Proceed with normal AutoRegistry processing, which will read the

--- a/tests/unit/interaction/test_builtin_interactions.py
+++ b/tests/unit/interaction/test_builtin_interactions.py
@@ -67,16 +67,16 @@ class TestInitRegistry:
         """
         Test that CLI renderers are registered under the expected keys.
         """
-        assert BaseInteractionRenderer.registry["cli:string"] is (
+        assert BaseInteractionRenderer.registry["cli.string"] is (
             CLIStringRenderer
         )
-        assert BaseInteractionRenderer.registry["cli:confirm"] is (
+        assert BaseInteractionRenderer.registry["cli.confirm"] is (
             CLIConfirmRenderer
         )
-        assert BaseInteractionRenderer.registry["cli:dropdown"] is (
+        assert BaseInteractionRenderer.registry["cli.dropdown"] is (
             CLIDropdownRenderer
         )
-        assert BaseInteractionRenderer.registry["cli:file"] is (
+        assert BaseInteractionRenderer.registry["cli.file"] is (
             CLIFileRenderer
         )
 

--- a/tests/unit/interaction/test_interaction.py
+++ b/tests/unit/interaction/test_interaction.py
@@ -68,6 +68,15 @@ class ConcreteTestTransport(BaseInteractionTransport):
     kind: str = "test_transport"
 
 
+class ConcreteTestTransport2(BaseInteractionTransport):
+    """
+    Concrete transport used to validate BaseInteractionTransport behavior.
+    """
+
+    add_to_registry: ClassVar[bool] = False
+    kind: str = "test_transport2"
+
+
 class ConcreteTestRenderer(
     BaseInteractionRenderer[
         ConcreteTestTransport,
@@ -89,6 +98,37 @@ class ConcreteTestRenderer(
     async def render(
         self,
         transport: ConcreteTestTransport,
+        interaction: ConcreteTestInteraction,
+    ) -> object:
+        """
+        Return a fixed raw value for testing.
+        """
+        del transport
+        del interaction
+        return "rendered"
+
+
+class ConcreteTestRendererAddedToRegistry(
+    BaseInteractionRenderer[
+        ConcreteTestTransport2,
+        ConcreteTestInteraction,
+    ]
+):
+    """
+    Concrete renderer that adds itself to the registry.
+    """
+
+    handles_transport: ClassVar[type[ConcreteTestTransport2]] = (
+        ConcreteTestTransport2
+    )
+
+    handles_interaction: ClassVar[type[ConcreteTestInteraction]] = (
+        ConcreteTestInteraction
+    )
+
+    async def render(
+        self,
+        transport: ConcreteTestTransport2,
         interaction: ConcreteTestInteraction,
     ) -> object:
         """
@@ -206,7 +246,9 @@ class TestBaseInteractionRenderer:
         """
         Test that BaseInteractionRenderer uses 'render_key' as registry key.
         """
-        assert BaseInteractionRenderer.registry_key == "render_key"
+        assert BaseInteractionRenderer.registry_key == (
+            "render_key:handles_transport.handles_interaction"
+        )
 
     def test_render_method_is_abstract(self) -> None:
         """
@@ -218,8 +260,8 @@ class TestBaseInteractionRenderer:
         """
         Test that render_key is derived from transport and interaction kinds.
         """
-        assert ConcreteTestRenderer.model_fields["render_key"].default == (
-            "test_transport:test_interaction"
+        assert ConcreteTestRendererAddedToRegistry().render_key == (
+            "test_transport2:test_interaction"
         )
 
     def test_get_from_registry_returns_matching_renderer(self) -> None:

--- a/tests/unit/interaction/test_interaction.py
+++ b/tests/unit/interaction/test_interaction.py
@@ -244,9 +244,12 @@ class TestBaseInteractionRenderer:
 
     def test_registry_key_is_render_key(self) -> None:
         """
-        Test that BaseInteractionRenderer uses 'render_key' as registry key.
+        Test that BaseInteractionRenderer exposes the plain field name as
+        registry_key so that AutoRegistry dispatch uses it as the dict key,
+        and that the full composition template is preserved separately.
         """
-        assert BaseInteractionRenderer.registry_key == (
+        assert BaseInteractionRenderer.registry_key == "render_key"
+        assert BaseInteractionRenderer._product_key_template == (
             "render_key:handles_transport.handles_interaction"
         )
 
@@ -261,7 +264,7 @@ class TestBaseInteractionRenderer:
         Test that render_key is derived from transport and interaction kinds.
         """
         assert ConcreteTestRendererAddedToRegistry().render_key == (
-            "test_transport2:test_interaction"
+            "test_transport2.test_interaction"
         )
 
     def test_get_from_registry_returns_matching_renderer(self) -> None:
@@ -276,7 +279,7 @@ class TestBaseInteractionRenderer:
         )
 
         assert renderer_cls is not None
-        assert renderer_cls.model_fields["render_key"].default == "cli:string"
+        assert renderer_cls.model_fields["render_key"].default == "cli.string"
 
 
 @pytest.mark.unit
@@ -324,7 +327,7 @@ class TestBaseInteractionTransport:
         assert result == "hello world"
         assert len(emitted_events) == no_emitted_events
         assert isinstance(emitted_events[0], InteractionAskedEvent)
-        assert emitted_events[0].renderer_key == "cli:string"
+        assert emitted_events[0].renderer_key == "cli.string"
         assert isinstance(emitted_events[1], InteractionAnsweredEvent)
         assert emitted_events[1].value_key == "batch-1"
 


### PR DESCRIPTION
## Summary

This pull request introduces a new mixin, `AutoRegistryProduct`, to support composite registry keys derived from other `AutoRegistry` types, and refactors the renderer registration logic to use this new system. It also updates the typing and class initialization logic for better type safety and clarity. The test suite is expanded to cover the new composite registry key behavior.

The most important changes are:

### Registry System Enhancements

* Added a new mixin, `AutoRegistryProduct`, which enables classes to derive their registry key by composing the discriminator defaults of other `AutoRegistry` types referenced as `ClassVar` attributes. This allows for more flexible and expressive registration patterns. (`src/horus_runtime/registry/auto_registry_product.py`)
* Refactored `BaseInteractionRenderer` to inherit from both `AutoRegistryProduct` and `AutoRegistry`, and to use a composite `registry_key` format (`"render_key:handles_transport.handles_interaction"`), making registration based on both transport and interaction types. (`src/horus_runtime/core/interaction/renderer.py`)

### Type and Initialization Improvements

* Updated type annotations and method signatures in `AutoRegistry` to use `Unpack[ConfigDict]` for `__init_subclass__` and improved type safety in the validator function. (`src/horus_runtime/registry/auto_registry.py`) [[1]](diffhunk://#diff-2b8c57f0aedc2a279dadb5f4721f7cf455ff05d632aab911fbee669f815f6bbcL28-R30) [[2]](diffhunk://#diff-2b8c57f0aedc2a279dadb5f4721f7cf455ff05d632aab911fbee669f815f6bbcL112-R112) [[3]](diffhunk://#diff-2b8c57f0aedc2a279dadb5f4721f7cf455ff05d632aab911fbee669f815f6bbcL249-R250)
* Marked certain methods as `@final` to prevent them from being overridden in subclasses, ensuring registry behavior is consistent. (`src/horus_runtime/registry/auto_registry.py`) [[1]](diffhunk://#diff-2b8c57f0aedc2a279dadb5f4721f7cf455ff05d632aab911fbee669f815f6bbcR218) [[2]](diffhunk://#diff-2b8c57f0aedc2a279dadb5f4721f7cf455ff05d632aab911fbee669f815f6bbcR290)

### Test Suite Updates

* Added new test classes and assertions to validate the correct derivation and registration of composite registry keys, including `ConcreteTestTransport2` and `ConcreteTestRendererAddedToRegistry`. Updated tests to reflect the new composite key format and ensure correct registration behavior. (`tests/unit/interaction/test_interaction.py`) [[1]](diffhunk://#diff-be7dbbdb0b6fe206bd55d8015f07607fb44f46bbbb9a6e6f0716c49297ab6285R71-R79) [[2]](diffhunk://#diff-be7dbbdb0b6fe206bd55d8015f07607fb44f46bbbb9a6e6f0716c49297ab6285R111-R141) [[3]](diffhunk://#diff-be7dbbdb0b6fe206bd55d8015f07607fb44f46bbbb9a6e6f0716c49297ab6285L209-R251) [[4]](diffhunk://#diff-be7dbbdb0b6fe206bd55d8015f07607fb44f46bbbb9a6e6f0716c49297ab6285L221-R264)

### Linting and Documentation

* Added an explanatory comment to the `pyproject.toml` linter configuration for why private method access is allowed in tests. (`pyproject.toml`)

These changes collectively make the registry system more robust and extensible, especially for scenarios where registration depends on multiple types.
## Documentation impact

If a user, plugin, or GUI can observe the difference, it requires documentation.

- [ ] No documentation update required
- [X] Documentation updated / will be updated

If documentation was updated, link the docs PR here:

**horus-docs PR:** ⬇️

https://github.com/temple-compute/horus-docs/pull/14