### PR TITLE
Support OpenAPI schemas

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,13 +81,13 @@ clean:
 	rm -rf *.egg-info/ build/ dist/
 
 babel-extract:
-	pybabel extract -F $(BABEL_CFG) \
+	uv run pybabel extract -F $(BABEL_CFG) \
 		--project=$(PROJECT_NAME) \
 		--copyright-holder="$(ORGANIZATION)" \
 		-o $(MESSAGES_POT) $(SOURCE_DIR)
 
 babel-update:
-	pybabel update -i $(MESSAGES_POT) -d $(LOCALE_DIR) -D $(DOMAIN) --no-fuzzy-matching
+	uv run pybabel update -i $(MESSAGES_POT) -d $(LOCALE_DIR) -D $(DOMAIN) --no-fuzzy-matching
 
 babel-refresh: babel-extract babel-update
 
@@ -102,7 +102,7 @@ babel-check:
 		fi; \
 	done
 	@echo "Success: All strings are translated."
-	pybabel compile -d $(LOCALE_DIR) -D $(DOMAIN) --statistics
+	uv run pybabel compile -d $(LOCALE_DIR) -D $(DOMAIN) --statistics
 
 babel-add:
-	pybabel init -i $(MESSAGES_POT) -d $(LOCALE_DIR) -l $(LANG) -D $(DOMAIN)
+	uv run pybabel init -i $(MESSAGES_POT) -d $(LOCALE_DIR) -l $(LANG) -D $(DOMAIN)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,44 +1,21 @@
-[build-system]
-requires = ["hatchling>=1.29,<2.0", "uv-dynamic-versioning>=0.14.0,<1.0"]
-build-backend = "hatchling.build"
-
 [project]
 name = "horus-runtime"
 description = "The Horus workflow manager runtime. Execute advanced workflows with multi-environment support, HPC integration, automatic artifact management, and more."
+license-files = ["LICENSE"]
 dynamic = ["version"]
+
 requires-python = ">=3.13"
-license = { file = "LICENSE" }
 classifiers = [
-    "License :: OSI Approved :: GNU Affero General Public License v3",
-    "Programming Language :: Python :: 3",
+  "License :: OSI Approved :: GNU Affero General Public License v3",
+  "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "pydantic~=2.0",
-    "pydantic_settings~=2.0",
-    "pyyaml~=6.0",
-    "loguru~=0.7",
-    "click>=8.3.3",
+  "click>=8.3.3",
+  "loguru~=0.7",
+  "pydantic~=2.0",
+  "pydantic_settings~=2.0",
+  "pyyaml~=6.0",
 ]
-
-[dependency-groups]
-dev = [
-    "ruff~=0.15",
-    "mypy~=1.19",
-    "pytest~=9.0",
-    "pytest-asyncio~=1.3.0",
-    "pytest-cov~=7.0",
-    "pre_commit~=4.0",
-    "licenseheaders~=0.8",
-    "babel~=2.0",
-    "types-PyYAML~=6.0",
-    "uv-dynamic-versioning>=0.14.0",
-]
-
-[tool.hatch.version]
-source = "uv-dynamic-versioning"
-
-[tool.uv-dynamic-versioning]
-fallback-version = "0.0.1"
 
 [project.scripts]
 horus = "horus_runtime.cli:main"
@@ -57,34 +34,14 @@ shell = "horus_builtin.executor.shell"
 python_exec = "horus_builtin.executor.python_exec"
 python_fn = "horus_builtin.executor.python_fn"
 
-[project.entry-points."horus.runtime"]
-command = "horus_builtin.runtime.command"
-python_string = "horus_builtin.runtime.python_string"
-python = "horus_builtin.runtime.python"
-
 [project.entry-points."horus.interaction"]
 common = "horus_builtin.interaction.common"
-
-[project.entry-points."horus.interaction_transport"]
-cli = "horus_builtin.interaction.cli"
 
 [project.entry-points."horus.interaction_renderer"]
 cli = "horus_builtin.interaction.cli"
 
-[project.entry-points."horus.task"]
-horus_task = "horus_builtin.task.horus_task"
-
-[project.entry-points."horus.target"]
-local = "horus_builtin.target.local"
-
-[project.entry-points."horus.workflow"]
-horus_workflow = "horus_builtin.workflow.horus_workflow"
-
-[project.entry-points."horus.subscriber"]
-log_event_subscriber = "horus_builtin.event.log_subscriber"
-
-[project.entry-points."horus.transfer"]
-local_to_local = "horus_builtin.transfer.local_noop"
+[project.entry-points."horus.interaction_transport"]
+cli = "horus_builtin.interaction.cli"
 
 [project.entry-points."horus.middleware.task"]
 task_time = "horus_builtin.middleware.task_time"
@@ -92,68 +49,47 @@ task_time = "horus_builtin.middleware.task_time"
 [project.entry-points."horus.middleware.workflow"]
 workflow_time = "horus_builtin.middleware.workflow_time"
 
-# ================
+[project.entry-points."horus.runtime"]
+command = "horus_builtin.runtime.command"
+python_string = "horus_builtin.runtime.python_string"
+python = "horus_builtin.runtime.python"
+
+[project.entry-points."horus.subscriber"]
+log_event_subscriber = "horus_builtin.event.log_subscriber"
+
+[project.entry-points."horus.target"]
+local = "horus_builtin.target.local"
+
+[project.entry-points."horus.task"]
+horus_task = "horus_builtin.task.horus_task"
+
+[project.entry-points."horus.transfer"]
+local_to_local = "horus_builtin.transfer.local_noop"
+
+[project.entry-points."horus.workflow"]
+horus_workflow = "horus_builtin.workflow.horus_workflow"
+
+[dependency-groups]
+dev = [
+  "babel~=2.0",
+  "licenseheaders~=0.8",
+  "mypy~=1.19",
+  "pre_commit~=4.0",
+  "pytest~=9.0",
+  "pytest-asyncio~=1.3.0",
+  "pytest-cov~=7.0",
+  "ruff~=0.15",
+  "types-PyYAML~=6.0",
+  "uv-dynamic-versioning>=0.14.0",
+]
+
+[build-system]
+requires = ["hatchling>=1.29,<2.0", "uv-dynamic-versioning>=0.14.0,<1.0"]
+build-backend = "hatchling.build"
 
 # Other tool configurations
-[tool.setuptools.package-data]
-horus_runtime = ["py.typed", "locale/**/LC_MESSAGES/*.mo"]
-
-[tool.pytest.ini_options]
-minversion = "7.0"
-testpaths = ["tests"]
-python_files = ["test_*.py", "*_test.py"]
-python_classes = ["Test*"]
-python_functions = ["test_*"]
-addopts = """
-    --verbose
-    --cov=src
-    --cov-report=html
-    --cov-report=term-missing
-    --cov-fail-under=90
-"""
-asyncio_mode = "auto"
-
-[tool.ruff]
-line-length = 79
-target-version = "py313"
-exclude = [".git", ".venv", "build", "dist", "__pycache__"]
-
-[tool.ruff.lint.pydocstyle]
-convention = "google"
-
-[tool.ruff.lint]
-select = [
-    "D",   # pydocstyle
-    "E",   # pycodestyle errors
-    "W",   # pycodestyle warnings
-    "F",   # pyflakes
-    "I",   # isort
-    "N",   # pep8-naming
-    "UP",  # pyupgrade
-    "B",   # flake8-bugbear
-    "PL",  # pylint
-    "RUF", # ruff-specific
-    "ARG", # ruff-arglint
-    "SLF", # ruff-slf
-]
-extend-select = ["T201"] # Prevent use of print()
-
-
-ignore = [
-    "E203", # Whitespace before ':', conflicts with formatter
-    "D104", # Missing docstring in class __init__
-    "D107", # Missing docstring in __init__.py
-    "D205", # 1 blank line required between summary line and description
-    "D212", # Multi-line docstring summary should start at the first line
-    "D200", # One-line docstring should fit on one line
-]
-
-[tool.ruff.lint.per-file-ignores]
-"tests/**/*.py" = ["SLF001"] # Allow private method access in tests
-
-[tool.ruff.format]
-quote-style = "double"
-indent-style = "space"
+[tool.hatch.version]
+source = "uv-dynamic-versioning"
 
 [tool.mypy]
 python_version = "3.13"
@@ -165,3 +101,68 @@ plugins = ["pydantic.mypy"]
 init_typed = true
 init_forbid_extra = true
 warn_required_dynamic_aliases = true
+
+[tool.pytest]
+addopts = [
+  "--cov-fail-under=90",
+  "--cov-report=html",
+  "--cov-report=term-missing",
+  "--cov=src",
+  "--verbose",
+]
+minversion = "7.0"
+python_classes = ["Test*"]
+python_files = ["*_test.py", "test_*.py"]
+python_functions = ["test_*"]
+testpaths = ["tests"]
+asyncio_mode = "auto"
+
+[tool.ruff]
+line-length = 79
+target-version = "py313"
+exclude = [".git", ".venv", "build", "dist", "__pycache__"]
+
+[tool.ruff.lint]
+select = [
+  "D",  # pydocstyle
+  "E",  # pycodestyle errors
+  "W",  # pycodestyle warnings
+  "F",  # pyflakes
+  "I",  # isort
+  "N",  # pep8-naming
+  "UP",  # pyupgrade
+  "B",  # flake8-bugbear
+  "PL",  # pylint
+  "RUF",  # ruff-specific
+  "ARG",  # ruff-arglint
+  "SLF",  # ruff-slf
+]
+extend-select = ["T201"]  # Prevent use of print()
+
+ignore = [
+  "E203",  # Whitespace before ':', conflicts with formatter
+  "D104",  # Missing docstring in class __init__
+  "D107",  # Missing docstring in __init__.py
+  "D205",  # 1 blank line required between summary line and description
+  "D212",  # Multi-line docstring summary should start at the first line
+  "D200",  # One-line docstring should fit on one line
+]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**/*.py" = [
+  "SLF001",  # Allow private method access in tests
+  "PLR2004"  # Magic number in tests is fine
+]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+
+[tool.setuptools.package-data]
+horus_runtime = ["py.typed", "locale/**/LC_MESSAGES/*.mo"]
+
+[tool.uv-dynamic-versioning]
+fallback-version = "0.0.1"

--- a/src/horus_builtin/executor/python_exec.py
+++ b/src/horus_builtin/executor/python_exec.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING, ClassVar
 from horus_builtin.runtime.python_string import PythonCodeStringRuntime
 from horus_runtime.context import HorusContext
 from horus_runtime.core.executor.base import BaseExecutor, RuntimeFilterType
+from horus_runtime.i18n import tr as _
 
 if TYPE_CHECKING:
     from horus_runtime.core.task.base import BaseTask
@@ -36,6 +37,10 @@ class PythonExecExecutor(BaseExecutor):
     """
 
     kind: str = "python"
+    kind_name: ClassVar[str] = "Python Exec"
+    kind_description: ClassVar[str] = _(
+        "Executes a Python code snippet in-process within the Horus runtime."
+    )
 
     runtimes: ClassVar[RuntimeFilterType] = (PythonCodeStringRuntime,)
 

--- a/src/horus_builtin/executor/python_fn.py
+++ b/src/horus_builtin/executor/python_fn.py
@@ -26,6 +26,7 @@ from typing import ClassVar
 from horus_builtin.runtime.python import PythonFunctionRuntime
 from horus_runtime.core.executor.base import BaseExecutor, RuntimeFilterType
 from horus_runtime.core.task.base import BaseTask
+from horus_runtime.i18n import tr as _
 
 
 class PythonFunctionExecutor(BaseExecutor):
@@ -34,6 +35,10 @@ class PythonFunctionExecutor(BaseExecutor):
     """
 
     kind: str = "python_function"
+    kind_name: ClassVar[str] = "Python Function Executor"
+    kind_description: ClassVar[str] = _(
+        "Executes a Python function in-memory within the Horus runtime."
+    )
 
     runtimes: ClassVar[RuntimeFilterType] = (PythonFunctionRuntime,)
 

--- a/src/horus_builtin/executor/shell.py
+++ b/src/horus_builtin/executor/shell.py
@@ -39,6 +39,11 @@ class ShellExecutor(BaseExecutor):
     """
 
     kind: str = "shell"
+    kind_name: ClassVar[str] = "Shell Executor"
+    kind_description: ClassVar[str] = _(
+        "Executes a shell command in the local environment of the Horus "
+        "runtime."
+    )
 
     runtimes: ClassVar[RuntimeFilterType] = (CommandRuntime,)
 

--- a/src/horus_builtin/runtime/command.py
+++ b/src/horus_builtin/runtime/command.py
@@ -19,11 +19,12 @@
 Command implementation for the runtime.
 """
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from horus_runtime.context import HorusContext
 from horus_runtime.core.runtime.base import BaseRuntime
 from horus_runtime.core.runtime.events import RuntimeEvent
+from horus_runtime.i18n import tr as _
 
 if TYPE_CHECKING:
     from horus_runtime.core.task.base import BaseTask
@@ -50,6 +51,10 @@ class CommandRuntime(BaseRuntime[str]):
     """
 
     kind: str = "command"
+    kind_name: ClassVar[str] = "Command"
+    kind_description: ClassVar[str] = _(
+        "Execute a command directly in the local environment."
+    )
 
     command: str
     """

--- a/src/horus_builtin/runtime/python.py
+++ b/src/horus_builtin/runtime/python.py
@@ -21,7 +21,7 @@ Python runtime implementation for in-memory workflows.
 
 from collections.abc import Callable
 from inspect import Parameter, signature
-from typing import Any
+from typing import Any, ClassVar
 
 from pydantic import ConfigDict, Field
 
@@ -39,6 +39,10 @@ class PythonFunctionRuntime(BaseRuntime[PythonFunctionSetupTuple]):
     """
 
     kind: str = "python_function"
+    kind_name: ClassVar[str] = "Python Function"
+    kind_description: ClassVar[str] = _(
+        "Executes a Python function in-memory."
+    )
 
     # Allow callable types in the runtime configuration
     model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/src/horus_builtin/runtime/python_string.py
+++ b/src/horus_builtin/runtime/python_string.py
@@ -19,9 +19,10 @@
 PythonCodeStringRuntime implementation for horus-runtime.
 """
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from horus_runtime.core.runtime.base import BaseRuntime
+from horus_runtime.i18n import tr as _
 
 if TYPE_CHECKING:
     from horus_runtime.core.task.base import BaseTask
@@ -33,6 +34,10 @@ class PythonCodeStringRuntime(BaseRuntime[str]):
     """
 
     kind: str = "python"
+    kind_name: ClassVar[str] = "Python Code String"
+    kind_description: ClassVar[str] = _(
+        "A runtime that executes a Python code snippet provided as a string."
+    )
 
     code: str
     """

--- a/src/horus_builtin/target/local.py
+++ b/src/horus_builtin/target/local.py
@@ -22,6 +22,7 @@ Local target implementation for executing tasks on the local machine
 
 import asyncio
 import socket
+from typing import ClassVar
 
 from pydantic import PrivateAttr
 
@@ -40,6 +41,9 @@ class LocalTarget(BaseTarget):
     """
 
     kind: str = "local"
+    kind_name: ClassVar[str] = "Local"
+    kind_description: ClassVar[str] = "Execute the task on the local machine."
+
     _task: BaseTask | None = PrivateAttr(default=None)
     _task_future: asyncio.Task[None] | None = PrivateAttr(default=None)
 

--- a/src/horus_builtin/target/local.py
+++ b/src/horus_builtin/target/local.py
@@ -42,7 +42,9 @@ class LocalTarget(BaseTarget):
 
     kind: str = "local"
     kind_name: ClassVar[str] = "Local"
-    kind_description: ClassVar[str] = "Execute the task on the local machine."
+    kind_description: ClassVar[str] = _(
+        "Execute the task on the local machine."
+    )
 
     _task: BaseTask | None = PrivateAttr(default=None)
     _task_future: asyncio.Task[None] | None = PrivateAttr(default=None)

--- a/src/horus_builtin/task/horus_task.py
+++ b/src/horus_builtin/task/horus_task.py
@@ -19,6 +19,8 @@
 Default Horus task implementation.
 """
 
+from typing import ClassVar
+
 from horus_builtin.event.task_event import HorusTaskEvent
 from horus_builtin.target.local import LocalTarget
 from horus_runtime.context import HorusContext
@@ -34,6 +36,8 @@ class HorusTask(BaseTask):
     """
 
     kind: str = "horus_task"
+    kind_name: ClassVar[str] = "Horus Task"
+    kind_description: ClassVar[str] = _("Basic Horus task")
 
     target: BaseTarget = LocalTarget()
     """

--- a/src/horus_builtin/workflow/horus_workflow.py
+++ b/src/horus_builtin/workflow/horus_workflow.py
@@ -21,6 +21,7 @@ HorusWorkflow implementation for Horus built-in workflows.
 """
 
 from pathlib import Path
+from typing import ClassVar
 
 import yaml
 
@@ -43,6 +44,10 @@ class HorusWorkflow(BaseWorkflow):
     """
 
     kind: str = "horus_workflow"
+    kind_name: ClassVar[str] = "Horus Workflow"
+    kind_description: ClassVar[str] = _(
+        "The default workflow implementation for Horus built-in workflows."
+    )
 
     orchestrator_target: BaseTarget = LocalTarget()
     """

--- a/src/horus_runtime/core/executor/base.py
+++ b/src/horus_runtime/core/executor/base.py
@@ -27,6 +27,7 @@ from abc import abstractmethod
 from typing import TYPE_CHECKING, ClassVar, final
 
 from horus_runtime.core.runtime.base import BaseRuntime
+from horus_runtime.i18n import tr as _
 from horus_runtime.middleware.executor import (
     ExecutorMiddleware,
     ExecutorMiddlewareContext,
@@ -51,6 +52,16 @@ class BaseExecutor(AutoRegistry, entry_point="executor"):
     kind: str
     """
     The 'kind' field is used to identify the specific type of executor.
+    """
+
+    kind_name: ClassVar[str] = "BaseExecutor"
+    """
+    Human-readable name for this executor type, used in the UI.
+    """
+
+    kind_description: ClassVar[str] = _("Horus base executor")
+    """
+    Description of this executor type, used in the UI.
     """
 
     runtimes: ClassVar[RuntimeFilterType] = (BaseRuntime,)

--- a/src/horus_runtime/core/runtime/base.py
+++ b/src/horus_runtime/core/runtime/base.py
@@ -24,6 +24,7 @@ functionality for executing tasks, and should be ingested by the executor.
 from abc import abstractmethod
 from typing import TYPE_CHECKING, Any, ClassVar, final
 
+from horus_runtime.i18n import tr as _
 from horus_runtime.middleware.runtime import (
     RuntimeMiddleware,
     RuntimeMiddlewareContext,
@@ -45,6 +46,16 @@ class BaseRuntime[T: Any = Any](AutoRegistry, entry_point="runtime"):
     kind: str
     """
     The 'kind' field is used to identify the specific type of runtime.
+    """
+
+    kind_name: ClassVar[str] = "BaseRuntime"
+    """
+    Human-readable name for this runtime type, used in the UI.
+    """
+
+    kind_description: ClassVar[str] = _("Horus base runtime")
+    """
+    Description of this runtime type, used in the UI.
     """
 
     @abstractmethod

--- a/src/horus_runtime/core/target/base.py
+++ b/src/horus_runtime/core/target/base.py
@@ -46,6 +46,16 @@ class BaseTarget(AutoRegistry, entry_point="target"):
     registry_key: ClassVar[str] = "kind"
     kind: str
 
+    kind_name: ClassVar[str]
+    """
+    Human-friendly name of this kind of target.
+    """
+
+    kind_description: ClassVar[str]
+    """
+    Human-friendly description of this kind of target.
+    """
+
     working_directory: Path = Field(default_factory=Path.cwd)
 
     """

--- a/src/horus_runtime/core/task/base.py
+++ b/src/horus_runtime/core/task/base.py
@@ -58,6 +58,16 @@ class BaseTask(AutoRegistry, entry_point="task"):
     The 'kind' field is used to identify the specific type of task.
     """
 
+    kind_name: ClassVar[str] = "BaseTask"
+    """
+    Human-readable name for this task type, used in the UI.
+    """
+
+    kind_description: ClassVar[str] = _("Horus base task")
+    """
+    Description of this task type, used in the UI.
+    """
+
     id: str
     """
     The task ID

--- a/src/horus_runtime/core/workflow/base.py
+++ b/src/horus_runtime/core/workflow/base.py
@@ -65,7 +65,17 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
     The 'kind' field is used to identify the specific type of workflow.
     """
 
-    name: str
+    kind_name: ClassVar[str] = "BaseWorkflow"
+    """
+    Human-readable name for this workflow type, used in the UI.
+    """
+
+    kind_description: ClassVar[str] = _("Horus base workflow")
+    """
+    Description of this workflow type, used in the UI.
+    """
+
+    name: str = Field(min_length=1, pattern=r"^[a-zA-Z0-9 _-]+$")
     """
     Human-readable name for this workflow.
     """

--- a/src/horus_runtime/registry/auto_registry.py
+++ b/src/horus_runtime/registry/auto_registry.py
@@ -25,7 +25,7 @@ new type to a central registry.
 from abc import ABC
 from importlib.metadata import entry_points
 from inspect import isabstract
-from typing import Any, ClassVar, Self, Unpack, final
+from typing import Annotated, Any, ClassVar, Self, Unpack, final
 
 import pydantic
 from pydantic import (
@@ -299,7 +299,12 @@ class AutoRegistry(BaseModel, ABC):
             # __get_pydantic_core_schema__ and cause infinite recursion.
             return target_origin.__pydantic_validator__.validate_python(data)
 
-        return core_schema.no_info_plain_validator_function(validate)
+        base_schema = handler(source_type)
+
+        return core_schema.no_info_before_validator_function(
+            validate,
+            base_schema,
+        )
 
     @final
     @classmethod
@@ -309,12 +314,10 @@ class AutoRegistry(BaseModel, ABC):
         handler: GetJsonSchemaHandler,
     ) -> JsonSchemaValue:
         """
-        Generate a JSON schema for registry root classes.
+        Generate a custom JSON schema for registry root classes.
 
-        For root classes this produces an ``anyOf`` over all currently
-        registered concrete subclasses, enabling OpenAPI / orval type
-        generation. For concrete subclasses the default Pydantic JSON
-        schema is used.
+        This is eeded when making OpenAPI schemas for FastAPI endpoints that
+        use registry fields.
         """
         origin = (
             getattr(cls, "__pydantic_generic_metadata__", {}).get("origin")
@@ -324,30 +327,31 @@ class AutoRegistry(BaseModel, ABC):
         if origin not in origin._registry_roots:  # noqa: SLF001
             return handler(_core_schema)
 
-        # Emit schema from base class fields only.
-        # Concrete subclass fields are plugin-specific and not part of the
-        # contract.
-        #
-        # Build a temporary model from the original field definitions so that
-        # constraints and metadata declared via Field(...) are preserved in the
-        # generated JSON schema.
-        schema_model = pydantic.create_model(
-            f"{origin.__name__}RegistrySchema",
-            __config__=ConfigDict(extra="allow"),
-            **{
-                field_name: (field_info.annotation, field_info)
-                for field_name, field_info in origin.model_fields.items()
-            },
-        )
-        model_schema = schema_model.model_json_schema()
+        properties: dict[str, JsonSchemaValue] = {}
+        required: list[str] = []
+
+        for field_name, field_info in origin.model_fields.items():
+            # Build an Annotated type that carries the FieldInfo so constraints
+            # are preserved, then get its core schema.
+
+            annotated = Annotated[field_info.annotation, field_info]  # type: ignore[name-defined]
+            field_core_schema = pydantic.TypeAdapter(annotated).core_schema
+
+            # Use the parent handler (NOT TypeAdapter.json_schema()) so that
+            # any $defs emitted for complex types are registered in the
+            # caller's GenerateJsonSchema context instead of an isolated one.
+            properties[field_name] = handler(field_core_schema)
+
+            if field_info.is_required():
+                required.append(field_name)
 
         schema: JsonSchemaValue = {
             "type": "object",
-            "properties": model_schema.get("properties", {}),
+            "properties": properties,
             "additionalProperties": True,
         }
-        if "required" in model_schema:
-            schema["required"] = model_schema["required"]
+        if required:
+            schema["required"] = required
 
         return schema
 

--- a/src/horus_runtime/registry/auto_registry.py
+++ b/src/horus_runtime/registry/auto_registry.py
@@ -27,7 +27,14 @@ from importlib.metadata import entry_points
 from inspect import isabstract
 from typing import Any, ClassVar, Self, Unpack, final
 
-from pydantic import BaseModel, ConfigDict, GetCoreSchemaHandler
+import pydantic
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    GetCoreSchemaHandler,
+    GetJsonSchemaHandler,
+)
+from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import CoreSchema, core_schema
 
 from horus_runtime.i18n import tr as _
@@ -293,6 +300,52 @@ class AutoRegistry(BaseModel, ABC):
             return target_origin.__pydantic_validator__.validate_python(data)
 
         return core_schema.no_info_plain_validator_function(validate)
+
+    @final
+    @classmethod
+    def __get_pydantic_json_schema__(
+        cls,
+        _core_schema: CoreSchema,
+        handler: GetJsonSchemaHandler,
+    ) -> JsonSchemaValue:
+        """
+        Generate a JSON schema for registry root classes.
+
+        For root classes this produces an ``anyOf`` over all currently
+        registered concrete subclasses, enabling OpenAPI / orval type
+        generation. For concrete subclasses the default Pydantic JSON
+        schema is used.
+        """
+        origin = (
+            getattr(cls, "__pydantic_generic_metadata__", {}).get("origin")
+            or cls
+        )
+
+        if origin not in origin._registry_roots:  # noqa: SLF001
+            return handler(_core_schema)
+
+        # Emit schema from base class fields only.
+        # Concrete subclass fields are plugin-specific and not part of the
+        # contract.
+        properties: dict[str, JsonSchemaValue] = {}
+        required: list[str] = []
+
+        for field_name, field_info in origin.model_fields.items():
+            properties[field_name] = pydantic.TypeAdapter(
+                field_info.annotation
+            ).json_schema()
+            if field_info.is_required():
+                required.append(field_name)
+
+        schema: JsonSchemaValue = {
+            "type": "object",
+            "properties": properties,
+            "additionalProperties": True,
+        }
+        if required:
+            schema["required"] = required
+
+        return schema
 
     @final
     @staticmethod

--- a/src/horus_runtime/registry/auto_registry.py
+++ b/src/horus_runtime/registry/auto_registry.py
@@ -327,23 +327,27 @@ class AutoRegistry(BaseModel, ABC):
         # Emit schema from base class fields only.
         # Concrete subclass fields are plugin-specific and not part of the
         # contract.
-        properties: dict[str, JsonSchemaValue] = {}
-        required: list[str] = []
-
-        for field_name, field_info in origin.model_fields.items():
-            properties[field_name] = pydantic.TypeAdapter(
-                field_info.annotation
-            ).json_schema()
-            if field_info.is_required():
-                required.append(field_name)
+        #
+        # Build a temporary model from the original field definitions so that
+        # constraints and metadata declared via Field(...) are preserved in the
+        # generated JSON schema.
+        schema_model = pydantic.create_model(
+            f"{origin.__name__}RegistrySchema",
+            __config__=ConfigDict(extra="allow"),
+            **{
+                field_name: (field_info.annotation, field_info)
+                for field_name, field_info in origin.model_fields.items()
+            },
+        )
+        model_schema = schema_model.model_json_schema()
 
         schema: JsonSchemaValue = {
             "type": "object",
-            "properties": properties,
+            "properties": model_schema.get("properties", {}),
             "additionalProperties": True,
         }
-        if required:
-            schema["required"] = required
+        if "required" in model_schema:
+            schema["required"] = model_schema["required"]
 
         return schema
 

--- a/tests/unit/registry/test_schema_generation.py
+++ b/tests/unit/registry/test_schema_generation.py
@@ -1,0 +1,300 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Unit tests for AutoRegistry schema generation and dispatch behavior.
+"""
+
+from typing import ClassVar
+
+import pydantic
+import pytest
+from pydantic import BaseModel, Field
+
+from horus_runtime.registry.auto_registry import AutoRegistry
+
+
+class SchemaRoot(AutoRegistry, entry_point="schema_test"):
+    """
+    Root class used across JSON schema and core schema tests.
+    """
+
+    registry_key: ClassVar[str] = "kind"
+    add_to_registry: ClassVar[bool] = False
+
+    kind: str
+    required_field: str
+    optional_field: str | None = None
+
+
+class SchemaAlpha(SchemaRoot):
+    """
+    Concrete subclass of SchemaRoot.
+    """
+
+    kind: str = "alpha"
+    alpha_specific: str = "alpha_value"
+    add_to_registry: ClassVar[bool] = True
+
+
+class SchemaBeta(SchemaRoot):
+    """
+    Another concrete subclass.
+    """
+
+    kind: str = "beta"
+    beta_specific: int = 0
+    add_to_registry: ClassVar[bool] = True
+
+
+class _SchemaHost(BaseModel):
+    """
+    Wrapper model to trigger Pydantic dispatch through SchemaRoot.
+    """
+
+    item: SchemaRoot
+
+
+@pytest.mark.unit
+class TestAutoRegistryPydanticJsonSchema:
+    """
+    Tests for AutoRegistry.__get_pydantic_json_schema__.
+    """
+
+    def test_root_schema_type_is_object(self) -> None:
+        """
+        Root class schema must declare type: object.
+        """
+        schema = pydantic.TypeAdapter(SchemaRoot).json_schema()
+        assert schema["type"] == "object"
+
+    def test_root_schema_has_additional_properties(self) -> None:
+        """
+        Root class schema must allow additionalProperties for plugin fields.
+        """
+        schema = pydantic.TypeAdapter(SchemaRoot).json_schema()
+        assert schema.get("additionalProperties") is True
+
+    def test_root_schema_includes_root_fields_in_properties(self) -> None:
+        """
+        All root-class fields must appear under 'properties'.
+        """
+        schema = pydantic.TypeAdapter(SchemaRoot).json_schema()
+        properties = schema.get("properties", {})
+        assert "kind" in properties
+        assert "required_field" in properties
+        assert "optional_field" in properties
+
+    def test_root_schema_required_fields_present(self) -> None:
+        """
+        Fields without defaults must appear in 'required'.
+        """
+        schema = pydantic.TypeAdapter(SchemaRoot).json_schema()
+        required = schema.get("required", [])
+        assert "required_field" in required
+
+    def test_root_schema_optional_fields_not_required(self) -> None:
+        """
+        Fields with defaults must not appear in 'required'.
+        """
+        schema = pydantic.TypeAdapter(SchemaRoot).json_schema()
+        required = schema.get("required", [])
+        assert "optional_field" not in required
+
+    def test_root_schema_excludes_concrete_subclass_fields(self) -> None:
+        """
+        Subclass-specific fields must not leak into the root schema.
+        """
+        schema = pydantic.TypeAdapter(SchemaRoot).json_schema()
+        properties = schema.get("properties", {})
+        assert "alpha_specific" not in properties
+        assert "beta_specific" not in properties
+
+    def test_concrete_subclass_uses_default_pydantic_schema(self) -> None:
+        """
+        Concrete subclasses must produce their own Pydantic schema,
+        not the root override.
+        """
+        schema = pydantic.TypeAdapter(SchemaAlpha).json_schema()
+        # Default Pydantic schema for a concrete model includes its own fields
+        properties = schema.get("properties", {})
+        assert "alpha_specific" in properties
+
+    def test_root_without_required_fields_omits_required_key(self) -> None:
+        """
+        If a root class has no required fields the 'required' key must be
+        absent.
+        """
+
+        class AllOptionalRoot(AutoRegistry, entry_point="all_optional_schema"):
+            registry_key: ClassVar[str] = "kind"
+            add_to_registry: ClassVar[bool] = False
+            kind: str = "base"
+            optional_a: str | None = None
+            optional_b: int = 0
+
+        schema = pydantic.TypeAdapter(AllOptionalRoot).json_schema()
+        assert "required" not in schema
+
+
+@pytest.mark.unit
+class TestAutoRegistryPydanticCoreSchema:
+    """
+    Tests for AutoRegistry.__get_pydantic_core_schema__ dispatch logic.
+    """
+
+    def test_valid_dict_dispatches_to_correct_concrete_class(self) -> None:
+        """
+        A dict with a known discriminator value must deserialise to the right
+        class.
+        """
+        result = _SchemaHost.model_validate(
+            {"item": {"kind": "alpha", "required_field": "x"}}
+        )
+        assert isinstance(result.item, SchemaAlpha)
+
+    def test_dispatch_sets_correct_field_values(self) -> None:
+        """
+        After dispatch, all fields including subclass-specific ones must be
+        set.
+        """
+        result = _SchemaHost.model_validate(
+            {
+                "item": {
+                    "kind": "beta",
+                    "required_field": "y",
+                    "beta_specific": 42,
+                }
+            }
+        )
+        assert isinstance(result.item, SchemaBeta)
+        assert result.item.beta_specific == 42
+        assert result.item.required_field == "y"
+
+    def test_existing_instance_passes_through(self) -> None:
+        """
+        An already-instantiated subclass passed as field value must not be
+        re-validated.
+        """
+        instance = SchemaAlpha(required_field="z")
+        result = _SchemaHost.model_validate({"item": instance})
+        assert result.item is instance
+
+    def test_missing_discriminator_raises_value_error(self) -> None:
+        """
+        A dict without the discriminator key must raise ValueError.
+        """
+        with pytest.raises(pydantic.ValidationError) as exc_info:
+            _SchemaHost.model_validate({"item": {"required_field": "x"}})
+        assert "Missing" in str(exc_info.value) or "kind" in str(
+            exc_info.value
+        )
+
+    def test_unknown_discriminator_value_raises_value_error(self) -> None:
+        """
+        A dict with an unregistered discriminator value must raise ValueError.
+        """
+        with pytest.raises(pydantic.ValidationError) as exc_info:
+            _SchemaHost.model_validate(
+                {"item": {"kind": "nonexistent", "required_field": "x"}}
+            )
+        assert "nonexistent" in str(exc_info.value)
+
+    def test_non_dict_non_instance_raises_type_error(self) -> None:
+        """
+        Passing a non-dict, non-AutoRegistry value must raise TypeError.
+        """
+        with pytest.raises(TypeError) as exc_info:
+            _SchemaHost.model_validate({"item": ["not", "a", "dict"]})
+        assert "Expected dict" in str(exc_info.value) or "SchemaRoot" in str(
+            exc_info.value
+        )
+
+    def test_concrete_subclass_validates_normally_without_dispatch(
+        self,
+    ) -> None:
+        """
+        A field typed as a concrete subclass must validate via Pydantic
+        directly, not dispatch.
+        """
+
+        class DirectHost(BaseModel):
+            item: SchemaAlpha
+
+        result = DirectHost.model_validate(
+            {"item": {"kind": "alpha", "required_field": "r"}}
+        )
+        assert isinstance(result.item, SchemaAlpha)
+        assert result.item.required_field == "r"
+
+    def test_dispatch_to_second_registered_class(self) -> None:
+        """
+        Dispatch must correctly route to SchemaBeta, not just the first
+        registered class.
+        """
+        result = _SchemaHost.model_validate(
+            {"item": {"kind": "beta", "required_field": "b"}}
+        )
+        assert isinstance(result.item, SchemaBeta)
+        assert not isinstance(result.item, SchemaAlpha)
+
+    def test_root_schema_with_nested_registry_root_field_does_not_crash(
+        self,
+    ) -> None:
+        """
+        A root class with a dict[str, AutoRegistryRoot] field must not raise
+        PydanticInvalidForJsonSchema during parent-context schema generation.
+        """
+
+        class InnerRoot(AutoRegistry, entry_point="inner_nested"):
+            registry_key: ClassVar[str] = "kind"
+            add_to_registry: ClassVar[bool] = False
+            kind: str
+
+        class OuterRoot(AutoRegistry, entry_point="outer_nested"):
+            registry_key: ClassVar[str] = "kind"
+            add_to_registry: ClassVar[bool] = False
+            kind: str
+            items: dict[str, InnerRoot]
+
+        class Host(BaseModel):
+            payload: OuterRoot
+
+        # Must not raise PydanticInvalidForJsonSchema
+        schema = Host.model_json_schema()
+        assert "payload" in schema["properties"]
+
+    def test_root_schema_preserves_field_constraints(self) -> None:
+        """
+        Field constraints from Field(...) must appear in the emitted JSON
+        schema.
+        """
+
+        class ConstrainedRoot(AutoRegistry, entry_point="constrained_schema"):
+            registry_key: ClassVar[str] = "kind"
+            add_to_registry: ClassVar[bool] = False
+            kind: str
+            name: str = Field(min_length=1, pattern=r"^[a-z_]+$")
+            count: int = Field(ge=0, le=100)
+
+        schema = pydantic.TypeAdapter(ConstrainedRoot).json_schema()
+        properties = schema["properties"]
+
+        assert properties["name"].get("minLength") == 1
+        assert properties["name"].get("pattern") == r"^[a-z_]+$"
+        assert properties["count"].get("minimum") == 0
+        assert properties["count"].get("maximum") == 100


### PR DESCRIPTION
## Summary

- OpenAPI Schemas are now automatically supported for AutoRegistry classes.
- BaseWorkflow, BaseTask, BaseTarget, BaseRuntime and BaseExecutor now support human-readable names and description properties.

## Documentation impact

If a user, plugin, or GUI can observe the difference, it requires documentation.

- [ ] No documentation update required
- [X] Documentation updated / will be updated

If documentation was updated, link the docs PR here:

**horus-docs PR:** ⬇️

https://github.com/temple-compute/horus-docs/pull/19