### PR TITLE
Fix middleware next-call wrap not properly catching exceptions

### DIFF
--- a/src/horus_runtime/middleware/auto_middleware.py
+++ b/src/horus_runtime/middleware/auto_middleware.py
@@ -142,9 +142,13 @@ class AutoMiddleware[T = Any](ABC):
                 return await call_next()
 
             middleware = middlewares[index]
+
+            async def next_call() -> R:
+                return await invoke(index + 1)
+
             return await middleware.wrap(
                 context,
-                lambda: invoke(index + 1),
+                next_call,
             )
 
         return await invoke(0)


### PR DESCRIPTION
## Summary

Small fix for middleware wrap functions. Before exceptions / try / excepts where not handled properly.

## Documentation impact

If a user, plugin, or GUI can observe the difference, it requires documentation.

- [X] No documentation update required
- [ ] Documentation updated / will be updated

