### PR TITLE
Side artifacts

### DIFF
--- a/.github/workflows/python-ci.yaml
+++ b/.github/workflows/python-ci.yaml
@@ -28,9 +28,9 @@ jobs:
       - name: Check license headers
         run: |
           uv run make add-license-headers
-          if ! git diff --quiet; then
+          if ! git diff --quiet -- src tests; then
             echo "License headers are missing or incorrect. Please run 'make add-license-headers' to fix.";
-            git diff --name-only
+            git diff --name-only -- src tests
             exit 1;
           fi
 

--- a/src/horus_builtin/executor/python_exec.py
+++ b/src/horus_builtin/executor/python_exec.py
@@ -26,6 +26,7 @@ from horus_builtin.runtime.python_string import PythonCodeStringRuntime
 from horus_runtime.context import HorusContext
 from horus_runtime.core.executor.base import BaseExecutor, RuntimeFilterType
 from horus_runtime.i18n import tr as _
+from horus_runtime.settings import runtime_settings
 
 if TYPE_CHECKING:
     from horus_runtime.core.task.base import BaseTask
@@ -54,9 +55,13 @@ class PythonExecExecutor(BaseExecutor):
 
         ctx = HorusContext.get_context()
 
+        # Expose side-artifacts directory to the snippet.
         scope = {
             "ctx": ctx,
             "task": task,
+            runtime_settings.SIDE_ARTIFACTS_DIR_ENV: str(
+                task.side_artifacts_dir
+            ),
         }
 
         # Security Warning: using exec to execute arbitrary code can be

--- a/src/horus_builtin/executor/python_fn.py
+++ b/src/horus_builtin/executor/python_fn.py
@@ -24,9 +24,11 @@ from inspect import isawaitable
 from typing import ClassVar
 
 from horus_builtin.runtime.python import PythonFunctionRuntime
+from horus_runtime.core.artifact.base import BaseArtifact
 from horus_runtime.core.executor.base import BaseExecutor, RuntimeFilterType
 from horus_runtime.core.task.base import BaseTask
 from horus_runtime.i18n import tr as _
+from horus_runtime.logging import horus_logger
 
 
 class PythonFunctionExecutor(BaseExecutor):
@@ -45,6 +47,13 @@ class PythonFunctionExecutor(BaseExecutor):
     async def _execute(self, task: "BaseTask") -> None:
         """
         Executes the Python function specified in the task's runtime.
+
+        A function may return a :class:`BaseArtifact` (or list of them) to
+        declare side-products; the returned artifacts are relocated into the
+        task's side-artifacts directory and stored on ``task.side_products``.
+        Capturing the return value here does not change the executor contract:
+        this method still returns ``None`` and raises on execution failure.
+        Side-product handling is best-effort and never fails the task.
         """
         assert isinstance(task.runtime, PythonFunctionRuntime)
 
@@ -52,6 +61,26 @@ class PythonFunctionExecutor(BaseExecutor):
         func, args = await task.runtime.setup_runtime(task)
 
         result = func(**args)
-
         if isawaitable(result):
-            await result
+            result = await result
+
+        if result is None:
+            return
+        if isinstance(result, BaseArtifact):
+            task.side_products = [result]
+            return
+        if isinstance(result, list) and all(
+            isinstance(r, BaseArtifact) for r in result
+        ):
+            task.side_products = result
+            return
+
+        horus_logger.log.warning(
+            _(
+                "Task %(task_id)s returned an unexpected value from its Python"
+                "function "
+                "runtime. Expected BaseArtifact, list[BaseArtifact], or None; "
+                "got: %(result)s. Skipping side artifact handling."
+            )
+            % {"task_id": task.id, "result": result}
+        )

--- a/src/horus_builtin/executor/python_fn.py
+++ b/src/horus_builtin/executor/python_fn.py
@@ -52,11 +52,8 @@ class PythonFunctionExecutor(BaseExecutor):
         Executes the Python function specified in the task's runtime.
 
         A function may return a :class:`BaseArtifact` (or list of them) to
-        declare side-products; the returned artifacts are relocated into the
-        task's side-artifacts directory and stored on ``task.side_products``.
-        Capturing the return value here does not change the executor contract:
-        this method still returns ``None`` and raises on execution failure.
-        Side-product handling is best-effort and never fails the task.
+        declare side-artifacts; the returned artifacts stored on
+        ``task.side_artifacts``.
         """
         assert isinstance(task.runtime, PythonFunctionRuntime)
 
@@ -90,10 +87,10 @@ class PythonFunctionExecutor(BaseExecutor):
 
         horus_logger.log.warning(
             _(
-                "Task %(task_id)s returned an unexpected value from its Python"
-                "function "
-                "runtime. Expected BaseArtifact, list[BaseArtifact], or None; "
-                "got: %(result)s. Skipping side artifact handling."
+                "Task %(task_id)s returned an unexpected value from its "
+                "Python function runtime. Expected BaseArtifact, "
+                "list[BaseArtifact], or None; got: %(result)s. Skipping side "
+                "artifact handling."
             )
             % {"task_id": task.id, "result": result}
         )

--- a/src/horus_builtin/executor/python_fn.py
+++ b/src/horus_builtin/executor/python_fn.py
@@ -23,7 +23,10 @@ executor).
 from inspect import isawaitable
 from typing import ClassVar
 
-from horus_builtin.runtime.python import PythonFunctionRuntime
+from horus_builtin.runtime.python import (
+    PythonFunctionReturnType,
+    PythonFunctionRuntime,
+)
 from horus_runtime.core.artifact.base import BaseArtifact
 from horus_runtime.core.executor.base import BaseExecutor, RuntimeFilterType
 from horus_runtime.core.task.base import BaseTask
@@ -61,18 +64,28 @@ class PythonFunctionExecutor(BaseExecutor):
         func, args = await task.runtime.setup_runtime(task)
 
         result = func(**args)
+
+        await self._parse_result_artifacts(task, result)
+
+    async def _parse_result_artifacts(
+        self, task: BaseTask, result: PythonFunctionReturnType
+    ) -> None:
+        """
+        Parse the result of a Python function execution to extract any declared
+        side-product artifacts.
+        """
         if isawaitable(result):
             result = await result
 
         if result is None:
             return
         if isinstance(result, BaseArtifact):
-            task.side_products = [result]
+            task.side_artifacts = [result]
             return
         if isinstance(result, list) and all(
             isinstance(r, BaseArtifact) for r in result
         ):
-            task.side_products = result
+            task.side_artifacts = result
             return
 
         horus_logger.log.warning(

--- a/src/horus_builtin/executor/shell.py
+++ b/src/horus_builtin/executor/shell.py
@@ -21,6 +21,7 @@ task locally in the Horus runtime.
 """
 
 import asyncio
+import os
 from typing import TYPE_CHECKING, ClassVar
 
 from horus_builtin.runtime.command import CommandRuntime
@@ -28,6 +29,7 @@ from horus_runtime.core.executor.base import BaseExecutor, RuntimeFilterType
 from horus_runtime.core.task.exceptions import TaskExecutionError
 from horus_runtime.i18n import tr as _
 from horus_runtime.logging import horus_logger
+from horus_runtime.settings import runtime_settings
 
 if TYPE_CHECKING:
     from horus_runtime.core.task.base import BaseTask
@@ -59,6 +61,14 @@ class ShellExecutor(BaseExecutor):
             % {"task_id": task.id, "command": prepared_command}
         )
 
+        # Let scripts drop side-product files in a well-known directory.
+        env = {
+            **os.environ,
+            runtime_settings.SIDE_ARTIFACTS_DIR_ENV: str(
+                task.side_artifacts_dir
+            ),
+        }
+
         # Security Warning:
         # This method uses a shell to execute the prepared command, which
         # poses a security risk if `cmd` contains untrusted input. Shell
@@ -72,6 +82,7 @@ class ShellExecutor(BaseExecutor):
             prepared_command,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            env=env,
         )
         try:
             __, stderr = await process.communicate()

--- a/src/horus_builtin/runtime/python.py
+++ b/src/horus_builtin/runtime/python.py
@@ -30,12 +30,13 @@ from horus_runtime.core.runtime.base import BaseRuntime
 from horus_runtime.core.task.base import BaseTask
 from horus_runtime.i18n import tr as _
 
-PythonFunctionReturnType = BaseArtifact | list[BaseArtifact] | None
+_PythonFunctionReturnType = BaseArtifact | list[BaseArtifact] | None
+PythonFunctionReturnType = (
+    _PythonFunctionReturnType | Awaitable[_PythonFunctionReturnType]
+)
 
 PythonFunctionSetupTuple = tuple[
-    Callable[
-        ..., Awaitable[PythonFunctionReturnType] | PythonFunctionReturnType
-    ],
+    Callable[..., PythonFunctionReturnType],
     dict[str, Any],
 ]
 
@@ -54,9 +55,7 @@ class PythonFunctionRuntime(BaseRuntime[PythonFunctionSetupTuple]):
     # Allow callable types in the runtime configuration
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    func: Callable[
-        ..., Awaitable[PythonFunctionReturnType] | PythonFunctionReturnType
-    ] = Field(..., exclude=True)
+    func: Callable[..., PythonFunctionReturnType] = Field(..., exclude=True)
 
     async def _setup_runtime(
         self, task: "BaseTask"

--- a/src/horus_builtin/runtime/python.py
+++ b/src/horus_builtin/runtime/python.py
@@ -19,7 +19,7 @@
 Python runtime implementation for in-memory workflows.
 """
 
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from inspect import Parameter, signature
 from typing import Any, ClassVar
 
@@ -30,7 +30,14 @@ from horus_runtime.core.runtime.base import BaseRuntime
 from horus_runtime.core.task.base import BaseTask
 from horus_runtime.i18n import tr as _
 
-PythonFunctionSetupTuple = tuple[Callable[..., Any], dict[str, Any]]
+PythonFunctionReturnType = BaseArtifact | list[BaseArtifact] | None
+
+PythonFunctionSetupTuple = tuple[
+    Callable[
+        ..., Awaitable[PythonFunctionReturnType] | PythonFunctionReturnType
+    ],
+    dict[str, Any],
+]
 
 
 class PythonFunctionRuntime(BaseRuntime[PythonFunctionSetupTuple]):
@@ -47,7 +54,9 @@ class PythonFunctionRuntime(BaseRuntime[PythonFunctionSetupTuple]):
     # Allow callable types in the runtime configuration
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    func: Callable[..., Any] = Field(..., exclude=True)
+    func: Callable[
+        ..., Awaitable[PythonFunctionReturnType] | PythonFunctionReturnType
+    ] = Field(..., exclude=True)
 
     async def _setup_runtime(
         self, task: "BaseTask"

--- a/src/horus_runtime/core/executor/base.py
+++ b/src/horus_runtime/core/executor/base.py
@@ -26,6 +26,8 @@ a command or running it inside a SLURM job, either remote or locally.
 from abc import abstractmethod
 from typing import TYPE_CHECKING, ClassVar, final
 
+from horus_builtin.artifact.file import FileArtifact
+from horus_builtin.artifact.folder import FolderArtifact
 from horus_runtime.core.runtime.base import BaseRuntime
 from horus_runtime.i18n import tr as _
 from horus_runtime.middleware.executor import (
@@ -87,6 +89,9 @@ class BaseExecutor(AutoRegistry, entry_point="executor"):
             lambda: self._execute(task),
         )
 
+        # Collect side artifacts after execution.
+        await self.collect_side_artifacts(task)
+
     @abstractmethod
     async def _execute(self, task: "BaseTask") -> None:
         """
@@ -94,3 +99,29 @@ class BaseExecutor(AutoRegistry, entry_point="executor"):
         This method should be implemented by subclasses to define the specific
         execution logic for different types of executors.
         """
+
+    async def collect_side_artifacts(self, task: "BaseTask") -> None:
+        """
+        Collect side artifacts produced during task execution.
+
+        By default, it iterates the side-artifacts directory for any files
+        produced and adds them as side-products to the task.
+        """
+        if not task.side_artifacts_dir.exists():
+            return
+
+        for artifact_path in task.side_artifacts_dir.iterdir():
+            if artifact_path.is_file():
+                task.side_artifacts.append(
+                    FileArtifact(
+                        id=artifact_path.stem, path=artifact_path, kind="file"
+                    )
+                )
+            elif artifact_path.is_dir():
+                task.side_artifacts.append(
+                    FolderArtifact(
+                        id=artifact_path.stem,
+                        path=artifact_path,
+                        kind="folder",
+                    )
+                )

--- a/src/horus_runtime/core/executor/base.py
+++ b/src/horus_runtime/core/executor/base.py
@@ -78,6 +78,10 @@ class BaseExecutor(AutoRegistry, entry_point="executor"):
         subclasses should implement the `_execute` method, which contains the
         specific execution logic for different types of executors.
         """
+        # The task's side-artifacts directory is created here so every executor
+        # can rely on it existing without recreating it.
+        task.side_artifacts_dir.mkdir(parents=True, exist_ok=True)
+
         await ExecutorMiddleware.call_with_middleware(
             ExecutorMiddlewareContext(executor=self, task=task),
             lambda: self._execute(task),

--- a/src/horus_runtime/core/executor/base.py
+++ b/src/horus_runtime/core/executor/base.py
@@ -84,13 +84,14 @@ class BaseExecutor(AutoRegistry, entry_point="executor"):
         # can rely on it existing without recreating it.
         task.side_artifacts_dir.mkdir(parents=True, exist_ok=True)
 
-        await ExecutorMiddleware.call_with_middleware(
-            ExecutorMiddlewareContext(executor=self, task=task),
-            lambda: self._execute(task),
-        )
-
-        # Collect side artifacts after execution.
-        await self.collect_side_artifacts(task)
+        try:
+            await ExecutorMiddleware.call_with_middleware(
+                ExecutorMiddlewareContext(executor=self, task=task),
+                lambda: self._execute(task),
+            )
+        finally:
+            # Collect side artifacts after execution.
+            await self.collect_side_artifacts(task)
 
     @abstractmethod
     async def _execute(self, task: "BaseTask") -> None:
@@ -105,7 +106,7 @@ class BaseExecutor(AutoRegistry, entry_point="executor"):
         Collect side artifacts produced during task execution.
 
         By default, it iterates the side-artifacts directory for any files
-        produced and adds them as side-products to the task.
+        produced and adds them as side-artifacts to the task.
         """
         if not task.side_artifacts_dir.exists():
             return
@@ -114,14 +115,14 @@ class BaseExecutor(AutoRegistry, entry_point="executor"):
             if artifact_path.is_file():
                 task.side_artifacts.append(
                     FileArtifact(
-                        id=artifact_path.stem, path=artifact_path, kind="file"
+                        id=f"{task.id}_{artifact_path.name}",
+                        path=artifact_path,
                     )
                 )
             elif artifact_path.is_dir():
                 task.side_artifacts.append(
                     FolderArtifact(
-                        id=artifact_path.stem,
+                        id=f"{task.id}_{artifact_path.name}",
                         path=artifact_path,
-                        kind="folder",
                     )
                 )

--- a/src/horus_runtime/core/target/base.py
+++ b/src/horus_runtime/core/target/base.py
@@ -57,7 +57,6 @@ class BaseTarget(AutoRegistry, entry_point="target"):
     """
 
     working_directory: Path = Field(default_factory=Path.cwd)
-
     """
     Base directory on the remote host where per-task working directories are
     created.

--- a/src/horus_runtime/core/task/base.py
+++ b/src/horus_runtime/core/task/base.py
@@ -91,7 +91,7 @@ class BaseTask(AutoRegistry, entry_point="task"):
     produces.
     """
 
-    side_products: list[BaseArtifact] = Field(
+    side_artifacts: list[BaseArtifact] = Field(
         default_factory=list, exclude=True
     )
     """

--- a/src/horus_runtime/core/task/base.py
+++ b/src/horus_runtime/core/task/base.py
@@ -23,6 +23,7 @@ executing tasks, and should be ingested by the executor.
 
 from abc import abstractmethod
 from asyncio import CancelledError
+from pathlib import Path
 from typing import ClassVar, Self, final
 
 from pydantic import Field, model_validator
@@ -90,6 +91,15 @@ class BaseTask(AutoRegistry, entry_point="task"):
     produces.
     """
 
+    side_products: list[BaseArtifact] = Field(
+        default_factory=list, exclude=True
+    )
+    """
+    Transient, undeclared artifacts produced by the task that the user may want
+    to inspect (logs, intermediate files, etc.) but which are not consumed by
+    any downstream task.
+    """
+
     executor: BaseExecutor
     """
     The executor that should execute this task. The executor is responsible for
@@ -128,6 +138,22 @@ class BaseTask(AutoRegistry, entry_point="task"):
     """
     The interaction transport currently associated with the task run.
     """
+
+    @property
+    def working_dir(self) -> Path:
+        """
+        The task's working directory: a per-task folder under its target's
+        working directory. Inputs are materialized here and outputs and
+        side-products are written relative to it.
+        """
+        return self.target.working_directory / self.id
+
+    @property
+    def side_artifacts_dir(self) -> Path:
+        """
+        Directory where side-product artifacts are written by convention.
+        """
+        return self.working_dir / "side-artifacts"
 
     @model_validator(mode="after")
     def _validate_runtime_compatibility(self) -> Self:

--- a/src/horus_runtime/settings.py
+++ b/src/horus_runtime/settings.py
@@ -1,0 +1,37 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Settings and configuration for Horus Runtime.
+"""
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class HorusRuntimeSettings(BaseSettings):
+    """
+    Settings for Horus Runtime.
+    """
+
+    model_config = SettingsConfigDict(env_prefix="HORUS_RUNTIME_")
+
+    SIDE_ARTIFACTS_DIR_ENV: str = "HORUS_SIDE_ARTIFACTS_DIR"
+
+
+runtime_settings = HorusRuntimeSettings()
+
+__all__ = ["runtime_settings"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,9 +61,12 @@ class MakeTaskType(Protocol):
 
 
 @pytest.fixture
-def make_shell_task() -> MakeTaskType:
+def make_shell_task(tmp_path: Path) -> MakeTaskType:
     """
     Fixture to create HorusTask instances with CommandRuntime for testing.
+
+    The task target uses a temporary working directory so the executor's
+    side-artifacts directory is created under it rather than in the repo.
     """
 
     def _make_shell_task(
@@ -77,7 +80,7 @@ def make_shell_task() -> MakeTaskType:
             outputs=[],
             runtime=CommandRuntime(command=cmd),
             executor=ShellExecutor(),
-            target=LocalTarget(),
+            target=LocalTarget(working_directory=tmp_path),
         )
 
     return _make_shell_task

--- a/tests/unit/executor/test_builtin_executor.py
+++ b/tests/unit/executor/test_builtin_executor.py
@@ -30,6 +30,7 @@ from horus_builtin.executor.shell import ShellExecutor
 from horus_runtime.context import HorusContext
 from horus_runtime.core.executor.base import BaseExecutor
 from horus_runtime.core.task.exceptions import TaskExecutionError
+from horus_runtime.settings import runtime_settings
 from tests.conftest import MakeTaskType
 
 
@@ -128,10 +129,16 @@ class TestShellExecutor:
         executor = ShellExecutor()
         await executor.execute(hello_world_task)
 
-        mock_run.assert_called_once_with(
-            "echo 'Hello World'",
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
+        mock_run.assert_called_once()
+        args, kwargs = mock_run.call_args
+        assert args == ("echo 'Hello World'",)
+        assert kwargs["stdout"] == asyncio.subprocess.PIPE
+        assert kwargs["stderr"] == asyncio.subprocess.PIPE
+        # The executor injects the per-task side-artifacts directory into the
+        # subprocess environment.
+        assert runtime_settings.SIDE_ARTIFACTS_DIR_ENV in kwargs["env"]
+        assert kwargs["env"][runtime_settings.SIDE_ARTIFACTS_DIR_ENV].endswith(
+            "side-artifacts"
         )
 
 

--- a/tests/unit/task/test_builtin_function_task.py
+++ b/tests/unit/task/test_builtin_function_task.py
@@ -21,16 +21,19 @@ Unit tests for FunctionTask.
 """
 
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from horus_builtin.artifact.file import FileArtifact
 from horus_builtin.executor.python_fn import PythonFunctionExecutor
 from horus_builtin.runtime.python import PythonFunctionRuntime
+from horus_builtin.target.local import LocalTarget
 from horus_builtin.task.function import FunctionTask
 from horus_builtin.task.horus_task import HorusTask
 from horus_builtin.workflow.horus_workflow import HorusWorkflow
 from horus_runtime.context import HorusContext
+from horus_runtime.core.artifact.base import BaseArtifact
 from horus_runtime.core.task.base import BaseTask
 
 
@@ -359,3 +362,162 @@ class TestFunctionTaskExecution:
         await task.run()
 
         assert output_artifact.path.read_text() == "HELLO"
+
+
+@pytest.mark.unit
+class TestFunctionTaskSideArtifacts:
+    """
+    Test cases for side artifact capture via Python function return values.
+    """
+
+    async def test_sync_function_returning_single_artifact_captured(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """
+        A sync function returning a single BaseArtifact populates
+        task.side_artifacts with that artifact.
+        """
+        artifact = FileArtifact(id="out", path=tmp_path / "out.txt")
+
+        task = FunctionTask(
+            id="side_task",
+            name="side_task",
+            runtime=PythonFunctionRuntime(func=lambda: artifact),
+        )
+
+        await task.run()
+
+        assert task.side_artifacts == [artifact]
+
+    async def test_sync_function_returning_list_of_artifacts_captured(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """
+        A sync function returning list[BaseArtifact] populates
+        task.side_artifacts with all artifacts in order.
+        """
+        art1 = FileArtifact(id="art1", path=tmp_path / "a.txt")
+        art2 = FileArtifact(id="art2", path=tmp_path / "b.txt")
+
+        task = FunctionTask(
+            id="side_task",
+            name="side_task",
+            runtime=PythonFunctionRuntime(func=lambda: [art1, art2]),
+        )
+
+        await task.run()
+
+        assert task.side_artifacts == [art1, art2]
+
+    async def test_async_function_returning_single_artifact_captured(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """
+        An async function returning a single BaseArtifact is awaited and the
+        artifact is captured on task.side_artifacts.
+        """
+        artifact = FileArtifact(id="async_out", path=tmp_path / "out.txt")
+
+        async def async_func() -> FileArtifact:
+            return artifact
+
+        task = FunctionTask(
+            id="async_side_task",
+            name="async_side_task",
+            runtime=PythonFunctionRuntime(func=async_func),
+        )
+
+        await task.run()
+
+        assert task.side_artifacts == [artifact]
+
+    async def test_async_function_returning_list_of_artifacts_captured(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """
+        An async function returning list[BaseArtifact] is awaited and all
+        artifacts are captured on task.side_artifacts.
+        """
+        art1 = FileArtifact(id="a1", path=tmp_path / "a.txt")
+        art2 = FileArtifact(id="a2", path=tmp_path / "b.txt")
+
+        async def async_func() -> list[BaseArtifact]:
+            return [art1, art2]
+
+        task = FunctionTask(
+            id="async_list_task",
+            name="async_list_task",
+            runtime=PythonFunctionRuntime(func=async_func),
+        )
+
+        await task.run()
+
+        assert task.side_artifacts == [art1, art2]
+
+    async def test_none_return_leaves_side_artifacts_empty(self) -> None:
+        """
+        A function returning None leaves task.side_artifacts empty.
+        """
+        task = FunctionTask(
+            id="none_task",
+            name="none_task",
+            runtime=PythonFunctionRuntime(func=lambda: None),
+        )
+
+        await task.run()
+
+        assert task.side_artifacts == []
+
+    @patch("horus_builtin.executor.python_fn.horus_logger")
+    async def test_unexpected_return_type_logs_warning_and_skips(
+        self,
+        mock_logger: MagicMock,
+    ) -> None:
+        """
+        A function returning an unexpected type (not BaseArtifact, list, or
+        None) leaves side_artifacts empty and logs a warning.
+        """
+        task = FunctionTask(
+            id="bad_return_task",
+            name="bad_return_task",
+            runtime=PythonFunctionRuntime(func=lambda: 42),  # type: ignore[return-value, arg-type]
+        )
+
+        await task.run()
+
+        assert task.side_artifacts == []
+        mock_logger.log.warning.assert_called_once()
+
+    async def test_returned_and_filesystem_artifacts_are_both_captured(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """
+        When a function both returns a BaseArtifact and writes a file to
+        task.side_artifacts_dir, the returned artifact appears first (index 0)
+        and the filesystem-collected artifact is appended after (index 1).
+        """
+        returned_artifact = FileArtifact(
+            id="returned", path=tmp_path / "returned.txt"
+        )
+
+        def func(task: BaseTask) -> FileArtifact:
+            (task.side_artifacts_dir / "fs.txt").write_text("from fs")
+            return returned_artifact
+
+        task = FunctionTask(
+            id="merge_task",
+            name="merge_task",
+            runtime=PythonFunctionRuntime(func=func),
+            target=LocalTarget(working_directory=tmp_path),
+        )
+
+        await task.run()
+
+        assert len(task.side_artifacts) == 2
+        assert task.side_artifacts[0] is returned_artifact
+        assert task.side_artifacts[1].id == "merge_task_fs.txt"

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,10 @@ version = 1
 revision = 3
 requires-python = ">=3.13"
 
+[options]
+exclude-newer = "2026-06-02T08:28:40.322068Z"
+exclude-newer-span = "P2D"
+
 [[package]]
 name = "annotated-types"
 version = "0.7.0"


### PR DESCRIPTION
## Side Artifacts Support

Adds a mechanism for tasks to produce side artifacts: transient, undeclared outputs (logs, intermediate files, etc.) that aren't consumed by downstream tasks but may be useful for inspection.

What changed
- `BaseTask` gains a side_artifacts: `list[BaseArtifact]` field and two new properties: `working_dir` and `side_artifacts_dir` (a side-artifacts/ subfolder under the task's working directory).
- `BaseExecutor` now creates the side_artifacts_dir before execution and auto-collects any files/folders written there as FileArtifact/FolderArtifact instances after execution completes.
- `PythonFunctionExecutor` parses the return value of Python function runtimes: functions may now return a `BaseArtifact`, `list[BaseArtifact]`, or `None` to explicitly declare side products. Unexpected return types log a warning and are silently ignored .
- `PythonFunctionRuntime` updates its func type signature to reflect the new `PythonFunctionReturnType` (`BaseArtifact | list[BaseArtifact] | None`, sync or async).
- `HorusRuntimeSettings` is introduced as a new pydantic-settings backed config class with an env_prefix="HORUS_RUNTIME_".
- Shell and Python exec executors also get minor side artifact plumbing.

## Documentation impact

If a user, plugin, or GUI can observe the difference, it requires documentation.

- [ ] No documentation update required
- [X] Documentation updated / will be updated

If documentation was updated, link the docs PR here:

**horus-docs PR:** ⬇️

https://github.com/temple-compute/horus-docs/pull/22
