### PR TITLE
Task paths are now `str`

### DIFF
--- a/src/horus_builtin/target/local.py
+++ b/src/horus_builtin/target/local.py
@@ -29,7 +29,7 @@ from typing import ClassVar
 
 from horus_runtime.core.artifact.base import BaseArtifact
 from horus_runtime.core.target.base import BaseTarget
-from horus_runtime.core.target.channel import ChannelProcess, RemotePath
+from horus_runtime.core.target.channel import ChannelProcess
 
 
 class LocalChannelProcess(ChannelProcess):
@@ -111,7 +111,7 @@ class LocalTarget(BaseTarget):
         self,
         cmd: str,
         *,
-        cwd: RemotePath | None = None,
+        cwd: str | None = None,
         env: dict[str, str] | None = None,
     ) -> ChannelProcess:
         """
@@ -119,8 +119,7 @@ class LocalTarget(BaseTarget):
 
         Args:
             cmd: Shell command string.
-            cwd: Working directory on the local filesystem (mapped from
-                ``RemotePath`` to ``Path``).
+            cwd: Working directory on the local filesystem
             env: Extra variables merged onto ``os.environ``.
 
         Returns:
@@ -148,7 +147,7 @@ class LocalTarget(BaseTarget):
     async def put_file(
         self,
         content: bytes | Path,
-        remote_path: RemotePath,
+        remote_path: str,
     ) -> None:
         """
         Write *content* to *remote_path* on the local filesystem.
@@ -157,14 +156,14 @@ class LocalTarget(BaseTarget):
             content: Raw bytes or a local ``Path`` whose contents are copied.
             remote_path: Destination path (mapped to a local ``Path``).
         """
-        dest = Path(str(remote_path))
+        dest = Path(remote_path)
         dest.parent.mkdir(parents=True, exist_ok=True)
         if isinstance(content, (bytes, bytearray)):
             dest.write_bytes(content)
         else:
             dest.write_bytes(content.read_bytes())
 
-    async def get_file(self, remote_path: RemotePath) -> bytes:
+    async def get_file(self, remote_path: str) -> bytes:
         """
         Read *remote_path* from the local filesystem and return its bytes.
 
@@ -174,9 +173,9 @@ class LocalTarget(BaseTarget):
         Returns:
             File contents as :class:`bytes`.
         """
-        return Path(str(remote_path)).read_bytes()
+        return Path(remote_path).read_bytes()
 
-    async def mkdir(self, path: RemotePath) -> None:
+    async def mkdir(self, path: str) -> None:
         """
         Create *path* (and all missing parents) on the local filesystem.
 
@@ -185,4 +184,4 @@ class LocalTarget(BaseTarget):
         Args:
             path: Directory to create (mapped to a local ``Path``).
         """
-        Path(str(path)).mkdir(parents=True, exist_ok=True)
+        Path(path).mkdir(parents=True, exist_ok=True)

--- a/src/horus_runtime/core/target/base.py
+++ b/src/horus_runtime/core/target/base.py
@@ -26,7 +26,7 @@ from typing import TYPE_CHECKING, ClassVar, final
 
 from pydantic import Field, PrivateAttr
 
-from horus_runtime.core.target.channel import ChannelProcess, RemotePath
+from horus_runtime.core.target.channel import ChannelProcess
 from horus_runtime.core.task.exceptions import TaskExecutionError
 from horus_runtime.core.task.status import TaskStatus
 from horus_runtime.i18n import tr as _
@@ -61,8 +61,8 @@ class BaseTarget(AutoRegistry, entry_point="target"):
     Human-friendly description of this kind of target.
     """
 
-    working_directory: RemotePath = Field(
-        default_factory=lambda: RemotePath(Path.cwd().as_posix())
+    working_directory: str = Field(
+        default_factory=lambda: Path.cwd().as_posix()
     )
     """
     Base directory on the target host where per-task working directories are
@@ -213,7 +213,7 @@ class BaseTarget(AutoRegistry, entry_point="target"):
         self,
         cmd: str,
         *,
-        cwd: RemotePath | None = None,
+        cwd: str | None = None,
         env: dict[str, str] | None = None,
     ) -> ChannelProcess:
         """
@@ -236,7 +236,7 @@ class BaseTarget(AutoRegistry, entry_point="target"):
     async def put_file(
         self,
         content: bytes | Path,
-        remote_path: RemotePath,
+        remote_path: str,
     ) -> None:
         """
         Write *content* to *remote_path* on the target.
@@ -244,14 +244,11 @@ class BaseTarget(AutoRegistry, entry_point="target"):
         Args:
             content: Either raw :class:`bytes` or a local
                 :class:`~pathlib.Path` whose contents are read and sent.
-            remote_path: Destination path on the *target* host.  This is
-                a ``RemotePath`` (``PurePosixPath``) and must not be
-                touched locally except by ``LocalTarget``'s own
-                implementation.
+            remote_path: Destination path on the *target* host.
         """
 
     @abstractmethod
-    async def get_file(self, remote_path: RemotePath) -> bytes:
+    async def get_file(self, remote_path: str) -> bytes:
         """
         Read *remote_path* from the target and return its contents as bytes.
 
@@ -263,7 +260,7 @@ class BaseTarget(AutoRegistry, entry_point="target"):
         """
 
     @abstractmethod
-    async def mkdir(self, path: RemotePath) -> None:
+    async def mkdir(self, path: str) -> None:
         """
         Create *path* (and all missing parents) on the target.
 

--- a/src/horus_runtime/core/target/channel.py
+++ b/src/horus_runtime/core/target/channel.py
@@ -17,28 +17,9 @@
 #
 """
 Channel primitives for agentless target communication.
-
-Key types
----------
-RemotePath
-    A :class:`~pathlib.PurePosixPath` alias.  Target-side paths are always
-    POSIX paths on whatever host the target represents.  They are *never*
-    opened, stat-ed, or walked locally.
-
-ChannelProcess
-    An abstract handle returned by :meth:`BaseTarget.run_command`.  Callers
-    receive it immediately (before the command finishes) and then drive it
-    through :meth:`communicate`, :meth:`wait`, :meth:`kill`, or
-    :meth:`signal`.
 """
 
 from abc import ABC, abstractmethod
-from pathlib import PurePosixPath
-
-# Target-side paths.  These are always POSIX paths on the target host and must
-# never be opened, stat-ed, or iterated locally.  ``LocalTarget`` maps them to
-# ``Path`` only inside its own channel methods.
-RemotePath = PurePosixPath
 
 
 class ChannelProcess(ABC):

--- a/src/horus_runtime/core/task/base.py
+++ b/src/horus_runtime/core/task/base.py
@@ -23,6 +23,7 @@ executing tasks, and should be ingested by the executor.
 
 from abc import abstractmethod
 from asyncio import CancelledError
+from pathlib import Path
 from typing import ClassVar, Self, final
 
 from pydantic import Field, model_validator
@@ -35,7 +36,6 @@ from horus_runtime.core.executor.exceptions import IncompatibleRuntimeError
 from horus_runtime.core.interaction.transport import BaseInteractionTransport
 from horus_runtime.core.runtime.base import BaseRuntime
 from horus_runtime.core.target.base import BaseTarget
-from horus_runtime.core.target.channel import RemotePath
 from horus_runtime.core.task.status import TaskStatus
 from horus_runtime.i18n import tr as _
 from horus_runtime.logging import horus_logger
@@ -140,20 +140,20 @@ class BaseTask(AutoRegistry, entry_point="task"):
     """
 
     @property
-    def working_dir(self) -> RemotePath:
+    def working_dir(self) -> str:
         """
         The task's working directory: a per-task folder under its target's
         working directory. Inputs are materialized here and outputs and
         side-products are written relative to it.
         """
-        return self.target.working_directory / self.id
+        return (Path(self.target.working_directory) / self.id).as_posix()
 
     @property
-    def side_artifacts_dir(self) -> RemotePath:
+    def side_artifacts_dir(self) -> str:
         """
         Directory where side-product artifacts are written by convention.
         """
-        return self.working_dir / "side-artifacts"
+        return (Path(self.working_dir) / "side-artifacts").as_posix()
 
     @model_validator(mode="after")
     def _validate_runtime_compatibility(self) -> Self:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,7 +32,6 @@ from horus_builtin.target.local import LocalTarget
 from horus_builtin.task.horus_task import HorusTask
 from horus_runtime.context import HorusContext, _runtime_ctx
 from horus_runtime.core.artifact.base import BaseArtifact
-from horus_runtime.core.target.channel import RemotePath
 from horus_runtime.middleware.auto_middleware import AutoMiddleware
 from horus_runtime.registry.auto_registry import AutoRegistry
 
@@ -81,7 +80,7 @@ def make_shell_task(tmp_path: Path) -> MakeTaskType:
             outputs=[],
             runtime=CommandRuntime(command=cmd),
             executor=ShellExecutor(),
-            target=LocalTarget(working_directory=RemotePath(tmp_path)),
+            target=LocalTarget(working_directory=tmp_path.as_posix()),
         )
 
     return _make_shell_task

--- a/tests/unit/middleware/test_middleware.py
+++ b/tests/unit/middleware/test_middleware.py
@@ -31,7 +31,7 @@ from horus_runtime.core.interaction.base import BaseInteraction
 from horus_runtime.core.interaction.renderer import BaseInteractionRenderer
 from horus_runtime.core.interaction.transport import BaseInteractionTransport
 from horus_runtime.core.target.base import BaseTarget
-from horus_runtime.core.target.channel import ChannelProcess, RemotePath
+from horus_runtime.core.target.channel import ChannelProcess
 from horus_runtime.core.task.base import BaseTask
 from horus_runtime.core.task.status import TaskStatus
 from horus_runtime.middleware.auto_middleware import AutoMiddleware
@@ -138,7 +138,7 @@ class TrackingTarget(BaseTarget):
         self,
         cmd: str,
         *,
-        cwd: RemotePath | None = None,
+        cwd: str | None = None,
         env: dict[str, str] | None = None,
     ) -> ChannelProcess:
         """
@@ -149,19 +149,19 @@ class TrackingTarget(BaseTarget):
     async def put_file(
         self,
         content: bytes | Path,
-        remote_path: RemotePath,
+        remote_path: str,
     ) -> None:
         """
         Stub channel method — not used in middleware tests.
         """
 
-    async def get_file(self, _remote_path: RemotePath) -> bytes:
+    async def get_file(self, _remote_path: str) -> bytes:
         """
         Stub channel method — not used in middleware tests.
         """
         return b""
 
-    async def mkdir(self, path: RemotePath) -> None:
+    async def mkdir(self, path: str) -> None:
         """
         Stub channel method — not used in middleware tests.
         """

--- a/tests/unit/target/test_channel.py
+++ b/tests/unit/target/test_channel.py
@@ -16,49 +16,20 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 """
-Unit tests for channel primitives: RemotePath, ChannelProcess ABC,
-and LocalTarget channel implementation (M1.1 / M1.2 / issue #65 / #66).
+Unit tests for channel primitives: ChannelProcess ABC, and LocalTarget channel
+implementation.
 """
 
 import os
 import signal
 import sys
 import time
-from pathlib import Path, PurePosixPath
+from pathlib import Path
 
 import pytest
 
 from horus_builtin.target.local import LocalChannelProcess, LocalTarget
-from horus_runtime.core.target.channel import ChannelProcess, RemotePath
-
-
-@pytest.mark.unit
-class TestRemotePath:
-    """
-    Tests for the RemotePath type alias.
-    """
-
-    def test_remote_path_is_pure_posix_path(self) -> None:
-        """
-        RemotePath must be PurePosixPath — the SSH agent builds to this alias.
-        """
-        assert RemotePath is PurePosixPath
-
-    def test_remote_path_construction(self) -> None:
-        """
-        RemotePath can be constructed and used like PurePosixPath.
-        """
-        p = RemotePath("/home/user/work")
-        assert str(p) == "/home/user/work"
-        assert p.name == "work"
-
-    def test_remote_path_division(self) -> None:
-        """
-        RemotePath supports / operator like PurePosixPath.
-        """
-        base = RemotePath("/home/user")
-        child = base / "task_id" / "side-artifacts"
-        assert str(child) == "/home/user/task_id/side-artifacts"
+from horus_runtime.core.target.channel import ChannelProcess
 
 
 @pytest.mark.unit
@@ -112,7 +83,7 @@ class TestLocalTargetRunCommand:
         """
         run_command returns a ChannelProcess instance.
         """
-        target = LocalTarget(working_directory=RemotePath(tmp_path))
+        target = LocalTarget(working_directory=tmp_path.as_posix())
         proc = await target.run_command("echo hello")
         stdout, _stderr = await proc.communicate()
         assert isinstance(proc, ChannelProcess)
@@ -125,7 +96,7 @@ class TestLocalTargetRunCommand:
         """
         communicate() returns (stdout, stderr) as raw bytes.
         """
-        target = LocalTarget(working_directory=RemotePath(tmp_path))
+        target = LocalTarget(working_directory=tmp_path.as_posix())
         proc = await target.run_command("echo 'hello world'")
         stdout, stderr = await proc.communicate()
         assert b"hello world" in stdout
@@ -137,7 +108,7 @@ class TestLocalTargetRunCommand:
         """
         Stderr bytes are available via communicate().
         """
-        target = LocalTarget(working_directory=RemotePath(tmp_path))
+        target = LocalTarget(working_directory=tmp_path.as_posix())
         proc = await target.run_command("echo err >&2")
         _stdout, stderr = await proc.communicate()
         assert b"err" in stderr
@@ -148,7 +119,7 @@ class TestLocalTargetRunCommand:
         """
         Return code is 0 for a successful command.
         """
-        target = LocalTarget(working_directory=RemotePath(tmp_path))
+        target = LocalTarget(working_directory=tmp_path.as_posix())
         proc = await target.run_command("true")
         await proc.wait()
         assert proc.returncode == 0
@@ -159,7 +130,7 @@ class TestLocalTargetRunCommand:
         """
         Return code is non-zero for a failing command.
         """
-        target = LocalTarget(working_directory=RemotePath(tmp_path))
+        target = LocalTarget(working_directory=tmp_path.as_posix())
         proc = await target.run_command("false")
         await proc.wait()
         assert proc.returncode != 0
@@ -168,7 +139,7 @@ class TestLocalTargetRunCommand:
         """
         Extra env vars from the ``env`` kwarg are present in the subprocess.
         """
-        target = LocalTarget(working_directory=RemotePath(tmp_path))
+        target = LocalTarget(working_directory=tmp_path.as_posix())
         proc = await target.run_command(
             "echo $MY_TEST_VAR",
             env={"MY_TEST_VAR": "channel_works"},
@@ -180,10 +151,10 @@ class TestLocalTargetRunCommand:
         """
         The ``cwd`` kwarg sets the working directory for the subprocess.
         """
-        target = LocalTarget(working_directory=RemotePath(tmp_path))
+        target = LocalTarget(working_directory=tmp_path.as_posix())
         proc = await target.run_command(
             "pwd",
-            cwd=RemotePath(tmp_path),
+            cwd=tmp_path.as_posix(),
         )
         stdout, _ = await proc.communicate()
         # tmp_path may contain symlinks; resolve both sides.
@@ -195,7 +166,7 @@ class TestLocalTargetRunCommand:
         """
         wait() returns the integer exit code.
         """
-        target = LocalTarget(working_directory=RemotePath(tmp_path))
+        target = LocalTarget(working_directory=tmp_path.as_posix())
         proc = await target.run_command(
             "exit 42",
         )
@@ -208,7 +179,7 @@ class TestLocalTargetRunCommand:
         """
         signal() delivers the given signal to the process group.
         """
-        target = LocalTarget(working_directory=RemotePath(tmp_path))
+        target = LocalTarget(working_directory=tmp_path.as_posix())
         proc = await target.run_command("sleep 30")
         proc.signal(signal.SIGTERM)
         code = await proc.wait()
@@ -237,7 +208,7 @@ class TestLocalTargetGroupKill:
         Spawn ``sh -c 'sleep 60 & echo $!'``, capture the grandchild PID,
         call kill(), then assert the grandchild is gone.
         """
-        target = LocalTarget(working_directory=RemotePath(tmp_path))
+        target = LocalTarget(working_directory=tmp_path.as_posix())
 
         # The grandchild PID is printed to stdout so we can probe it later.
         proc = await target.run_command(
@@ -288,8 +259,8 @@ class TestLocalTargetFileOps:
         """
         put_file(bytes) then get_file returns the original bytes.
         """
-        target = LocalTarget(working_directory=RemotePath(tmp_path))
-        dest = RemotePath(tmp_path / "test_file.bin")
+        target = LocalTarget(working_directory=tmp_path.as_posix())
+        dest = (tmp_path / "test_file.bin").as_posix()
         content = b"\x00\x01\x02hello"
 
         await target.put_file(content, dest)
@@ -306,8 +277,8 @@ class TestLocalTargetFileOps:
         src = tmp_path / "src.txt"
         src.write_bytes(b"from path")
 
-        target = LocalTarget(working_directory=RemotePath(tmp_path))
-        dest = RemotePath(tmp_path / "subdir" / "dst.txt")
+        target = LocalTarget(working_directory=tmp_path.as_posix())
+        dest = (tmp_path / "subdir" / "dst.txt").as_posix()
 
         await target.put_file(src, dest)
         result = await target.get_file(dest)
@@ -318,31 +289,31 @@ class TestLocalTargetFileOps:
         """
         put_file creates missing parent directories automatically.
         """
-        target = LocalTarget(working_directory=RemotePath(tmp_path))
-        dest = RemotePath(tmp_path / "a" / "b" / "c" / "file.txt")
+        target = LocalTarget(working_directory=tmp_path.as_posix())
+        dest = (tmp_path / "a" / "b" / "c" / "file.txt").as_posix()
 
         await target.put_file(b"nested", dest)
 
-        assert Path(str(dest)).exists()
+        assert Path(dest).exists()
 
     async def test_mkdir_creates_directory(self, tmp_path: Path) -> None:
         """
         The mkdir method creates the directory on the local filesystem.
         """
-        target = LocalTarget(working_directory=RemotePath(tmp_path))
-        new_dir = RemotePath(tmp_path / "new_dir")
+        target = LocalTarget(working_directory=tmp_path.as_posix())
+        new_dir = (tmp_path / "new_dir").as_posix()
 
         await target.mkdir(new_dir)
 
-        assert Path(str(new_dir)).is_dir()
+        assert Path(new_dir).is_dir()
 
     async def test_mkdir_is_idempotent(self, tmp_path: Path) -> None:
         """
         The mkdir method does not raise when the directory exists (mkdir -p).
         """
-        target = LocalTarget(working_directory=RemotePath(tmp_path))
-        existing = RemotePath(tmp_path / "already_there")
-        Path(str(existing)).mkdir()
+        target = LocalTarget(working_directory=tmp_path.as_posix())
+        existing = (tmp_path / "already_there").as_posix()
+        Path(existing).mkdir()
 
         await target.mkdir(existing)  # must not raise
 
@@ -350,9 +321,9 @@ class TestLocalTargetFileOps:
         """
         The mkdir method creates all intermediate parents (mkdir -p semantics).
         """
-        target = LocalTarget(working_directory=RemotePath(tmp_path))
-        deep = RemotePath(tmp_path / "x" / "y" / "z")
+        target = LocalTarget(working_directory=tmp_path.as_posix())
+        deep = (tmp_path / "x" / "y" / "z").as_posix()
 
         await target.mkdir(deep)
 
-        assert Path(str(deep)).is_dir()
+        assert Path(deep).is_dir()

--- a/tests/unit/target/test_target_base.py
+++ b/tests/unit/target/test_target_base.py
@@ -27,7 +27,7 @@ from pydantic import BaseModel
 
 from horus_runtime.core.artifact.base import BaseArtifact
 from horus_runtime.core.target.base import BaseTarget
-from horus_runtime.core.target.channel import ChannelProcess, RemotePath
+from horus_runtime.core.target.channel import ChannelProcess
 from horus_runtime.registry.auto_registry import AutoRegistry
 
 
@@ -55,7 +55,7 @@ class ConcreteTestTarget(BaseTarget):
         self,
         cmd: str,
         *,
-        cwd: RemotePath | None = None,
+        cwd: str | None = None,
         env: dict[str, str] | None = None,
     ) -> ChannelProcess:
         """
@@ -66,19 +66,19 @@ class ConcreteTestTarget(BaseTarget):
     async def put_file(
         self,
         content: bytes | Path,
-        remote_path: RemotePath,
+        remote_path: str,
     ) -> None:
         """
         Stub channel method — not used in base-class tests.
         """
 
-    async def get_file(self, _remote_path: RemotePath) -> bytes:
+    async def get_file(self, _remote_path: str) -> bytes:
         """
         Stub channel method — not used in base-class tests.
         """
         return b""
 
-    async def mkdir(self, _path: RemotePath) -> None:
+    async def mkdir(self, _path: str) -> None:
         """
         Stub channel method — not used in base-class tests.
         """

--- a/tests/unit/task/test_builtin_function_task.py
+++ b/tests/unit/task/test_builtin_function_task.py
@@ -34,7 +34,6 @@ from horus_builtin.task.horus_task import HorusTask
 from horus_builtin.workflow.horus_workflow import HorusWorkflow
 from horus_runtime.context import HorusContext
 from horus_runtime.core.artifact.base import BaseArtifact
-from horus_runtime.core.target.channel import RemotePath
 from horus_runtime.core.task.base import BaseTask
 
 
@@ -507,16 +506,14 @@ class TestFunctionTaskSideArtifacts:
         )
 
         def func(task: BaseTask) -> FileArtifact:
-            # side_artifacts_dir is a RemotePath (PurePosixPath); map to a
-            # local Path inside the in-process function.
-            Path(str(task.side_artifacts_dir / "fs.txt")).write_text("from fs")
+            (Path(task.side_artifacts_dir) / "fs.txt").write_text("from fs")
             return returned_artifact
 
         task = FunctionTask(
             id="merge_task",
             name="merge_task",
             runtime=PythonFunctionRuntime(func=func),
-            target=LocalTarget(working_directory=RemotePath(tmp_path)),
+            target=LocalTarget(working_directory=tmp_path.as_posix()),
         )
 
         await task.run()

--- a/tests/unit/transfer/test_transfer.py
+++ b/tests/unit/transfer/test_transfer.py
@@ -27,7 +27,7 @@ from horus_builtin.target.local import LocalTarget
 from horus_builtin.transfer.local_noop import LocalNoOpTransfer
 from horus_runtime.core.artifact.base import BaseArtifact
 from horus_runtime.core.target.base import BaseTarget
-from horus_runtime.core.target.channel import ChannelProcess, RemotePath
+from horus_runtime.core.target.channel import ChannelProcess
 from horus_runtime.core.task.base import BaseTask
 from horus_runtime.core.task.status import TaskStatus
 from horus_runtime.core.transfer.strategy import BaseTransferStrategy
@@ -67,7 +67,7 @@ class _UnregisteredTarget(BaseTarget):
         self,
         cmd: str,
         *,
-        cwd: RemotePath | None = None,
+        cwd: str | None = None,
         env: dict[str, str] | None = None,
     ) -> ChannelProcess:
         """
@@ -78,19 +78,19 @@ class _UnregisteredTarget(BaseTarget):
     async def put_file(
         self,
         content: bytes | Path,
-        remote_path: RemotePath,
+        remote_path: str,
     ) -> None:
         """
         Not used in transfer tests.
         """
 
-    async def get_file(self, _remote_path: RemotePath) -> bytes:
+    async def get_file(self, _remote_path: str) -> bytes:
         """
         Not used in transfer tests.
         """
         return b""
 
-    async def mkdir(self, path: RemotePath) -> None:
+    async def mkdir(self, path: str) -> None:
         """
         Not used in transfer tests.
         """


### PR DESCRIPTION
## Summary

For making the SDK easier to use, all paths have been converted to `str`. Having remote paths with the `Path` class does not make sense, as the paths do not exist locally.

## Documentation impact

If a user, plugin, or GUI can observe the difference, it requires documentation.

- [ ] No documentation update required
- [x] Documentation updated / will be updated

If documentation was updated, link the docs PR here:

**horus-docs PR:** ⬇️

https://github.com/temple-compute/horus-docs/pull/24
