### PR TITLE
Added collection of side-artifacts via channel

### DIFF
--- a/src/horus_builtin/target/local.py
+++ b/src/horus_builtin/target/local.py
@@ -29,7 +29,7 @@ from typing import ClassVar
 
 from horus_runtime.core.artifact.base import BaseArtifact
 from horus_runtime.core.target.base import BaseTarget
-from horus_runtime.core.target.channel import ChannelProcess
+from horus_runtime.core.target.channel import ChannelProcess, RemoteDirEntry
 
 
 class LocalChannelProcess(ChannelProcess):
@@ -185,3 +185,36 @@ class LocalTarget(BaseTarget):
             path: Directory to create (mapped to a local ``Path``).
         """
         Path(path).mkdir(parents=True, exist_ok=True)
+
+    async def list_dir(self, path: str) -> list[RemoteDirEntry]:
+        """
+        List the immediate children of *path* on the local filesystem.
+
+        Uses ``pathlib`` (no shell, OS-agnostic) and skips symlinks.
+
+        Args:
+            path: Directory to list (mapped to a local ``Path``).
+
+        Returns:
+            One :class:`RemoteDirEntry` per child, or ``[]`` if *path* is not a
+            directory.
+        """
+        base = Path(path)
+        if not base.is_dir():
+            return []
+
+        entries: list[RemoteDirEntry] = []
+        for child in base.iterdir():
+            if child.is_symlink():
+                continue
+            is_dir = child.is_dir()
+            size = 0 if is_dir else child.stat().st_size
+            entries.append(
+                RemoteDirEntry(
+                    name=child.name,
+                    path=child.as_posix(),
+                    is_dir=is_dir,
+                    size=size,
+                )
+            )
+        return entries

--- a/src/horus_builtin/target/local.py
+++ b/src/horus_builtin/target/local.py
@@ -190,8 +190,6 @@ class LocalTarget(BaseTarget):
         """
         List the immediate children of *path* on the local filesystem.
 
-        Uses ``pathlib`` (no shell, OS-agnostic) and skips symlinks.
-
         Args:
             path: Directory to list (mapped to a local ``Path``).
 

--- a/src/horus_runtime/core/executor/base.py
+++ b/src/horus_runtime/core/executor/base.py
@@ -23,6 +23,7 @@ specified runtime in a certain environment, for example running it locally as
 a command or running it inside a SLURM job, either remote or locally.
 """
 
+import tempfile
 from abc import abstractmethod
 from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar, final
@@ -31,11 +32,13 @@ from horus_builtin.artifact.file import FileArtifact
 from horus_builtin.artifact.folder import FolderArtifact
 from horus_runtime.core.runtime.base import BaseRuntime
 from horus_runtime.i18n import tr as _
+from horus_runtime.logging import horus_logger
 from horus_runtime.middleware.executor import (
     ExecutorMiddleware,
     ExecutorMiddlewareContext,
 )
 from horus_runtime.registry.auto_registry import AutoRegistry
+from horus_runtime.settings import runtime_settings
 
 if TYPE_CHECKING:
     from horus_runtime.core.task.base import BaseTask
@@ -104,37 +107,113 @@ class BaseExecutor(AutoRegistry, entry_point="executor"):
 
     async def collect_side_artifacts(self, task: "BaseTask") -> None:
         """
-        Collect side artifacts produced during task execution.
+        Collect side artifacts produced during task execution and bring them
+        back to the orchestrator's local filesystem.
 
-        For ``LocalTarget`` (and any target whose ``side_artifacts_dir`` is
-        accessible as a local path), this iterates the directory and registers
-        every file and folder as a side artifact on the task.
+        Side artifacts live in ``task.side_artifacts_dir`` on the **target**
+        host, which is not necessarily the orchestrator's filesystem. They are
+        listed and transferred over the target channel (``list_dir`` +
+        ``get_file``) into a local temporary directory, then registered as
+        :class:`FileArtifact` (top-level files) or :class:`FolderArtifact`
+        (top-level folders, with their nested contents reconstructed locally).
 
-        For remote targets the directory is not locally accessible, so this
-        method is best-effort: it attempts a local ``Path`` walk and silently
-        skips collection when the path does not exist locally.
+        Side artifacts are meant to be small, inspectable outputs (logs,
+        plots, small intermediates). Files larger than
+        ``runtime_settings.MAX_SIDE_ARTIFACT_BYTES`` are skipped with a
+        warning; large data should be declared as task inputs/outputs, which
+        have their own transfer strategies.
 
-        .. ponytail: full remote collection via channel ``ls`` + ``get_file``
-           is the upgrade path (M2.3 follow-up); not needed for the local demo.
+        This runs in ``execute()``'s ``finally`` block, so it is best-effort:
+        any failure is logged and swallowed so it never masks the task's own
+        exception.
         """
-        # TODO: Use the channel to list and retrieve side artifacts from
-        # remote targets.
-        local_path = Path(str(task.side_artifacts_dir))
-        if not local_path.exists():
+        try:
+            entries = await task.target.list_dir(task.side_artifacts_dir)
+        except Exception as exc:
+            horus_logger.log.warning(
+                _(
+                    "Failed to list side artifacts for task "
+                    "%(task_id)s: %(err)s"
+                )
+                % {"task_id": task.id, "err": exc}
+            )
             return
 
-        for artifact_path in local_path.iterdir():
-            if artifact_path.is_file():
-                task.side_artifacts.append(
-                    FileArtifact(
-                        id=f"{task.id}_{artifact_path.name}",
-                        path=artifact_path,
+        if not entries:
+            return
+
+        cap = runtime_settings.MAX_SIDE_ARTIFACT_BYTES
+        landing = Path(tempfile.mkdtemp(prefix=f"horus-side-{task.id}-"))
+
+        for entry in entries:
+            try:
+                if entry.is_dir:
+                    local_path = await self._pull_tree(
+                        task, entry.path, landing / entry.name, cap
                     )
-                )
-            elif artifact_path.is_dir():
-                task.side_artifacts.append(
-                    FolderArtifact(
-                        id=f"{task.id}_{artifact_path.name}",
-                        path=artifact_path,
+                    task.side_artifacts.append(
+                        FolderArtifact(
+                            id=f"{task.id}_{entry.name}", path=local_path
+                        )
                     )
+                else:
+                    if entry.size > cap:
+                        horus_logger.log.warning(
+                            _(
+                                "Skipping large side artifact %(name)s "
+                                "(%(size)d bytes)"
+                            )
+                            % {"name": entry.name, "size": entry.size}
+                        )
+                        continue
+                    local_path = landing / entry.name
+                    local_path.write_bytes(
+                        await task.target.get_file(entry.path)
+                    )
+                    task.side_artifacts.append(
+                        FileArtifact(
+                            id=f"{task.id}_{entry.name}", path=local_path
+                        )
+                    )
+            except Exception as exc:
+                horus_logger.log.warning(
+                    _("Failed to collect side artifact %(name)s: %(err)s")
+                    % {"name": entry.name, "err": exc}
                 )
+
+    async def _pull_tree(
+        self,
+        task: "BaseTask",
+        remote_root: str,
+        local_root: Path,
+        cap: int,
+    ) -> Path:
+        """
+        Reconstruct the target directory tree rooted at *remote_root* under
+        *local_root*, using the channel (``list_dir`` + ``get_file``).
+
+        Walks iteratively (no recursion-depth limit). Every directory is
+        created locally so empty directories are preserved; files larger than
+        *cap* are skipped with a warning. Returns *local_root*.
+        """
+        stack: list[tuple[str, Path]] = [(remote_root, local_root)]
+        while stack:
+            remote_dir, local_dir = stack.pop()
+            local_dir.mkdir(parents=True, exist_ok=True)
+            for child in await task.target.list_dir(remote_dir):
+                local_child = local_dir / child.name
+                if child.is_dir:
+                    stack.append((child.path, local_child))
+                elif child.size > cap:
+                    horus_logger.log.warning(
+                        _(
+                            "Skipping large side artifact %(name)s "
+                            "(%(size)d bytes)"
+                        )
+                        % {"name": child.name, "size": child.size}
+                    )
+                else:
+                    local_child.write_bytes(
+                        await task.target.get_file(child.path)
+                    )
+        return local_root

--- a/src/horus_runtime/core/executor/base.py
+++ b/src/horus_runtime/core/executor/base.py
@@ -122,10 +122,6 @@ class BaseExecutor(AutoRegistry, entry_point="executor"):
         ``runtime_settings.MAX_SIDE_ARTIFACT_BYTES`` are skipped with a
         warning; large data should be declared as task inputs/outputs, which
         have their own transfer strategies.
-
-        This runs in ``execute()``'s ``finally`` block, so it is best-effort:
-        any failure is logged and swallowed so it never masks the task's own
-        exception.
         """
         try:
             entries = await task.target.list_dir(task.side_artifacts_dir)

--- a/src/horus_runtime/core/executor/base.py
+++ b/src/horus_runtime/core/executor/base.py
@@ -46,6 +46,25 @@ if TYPE_CHECKING:
 RuntimeFilterType = tuple[type[BaseRuntime], ...]
 
 
+def _is_safe_component(name: str) -> bool:
+    """
+    True if *name* is a single, safe path component.
+
+    Side-artifact entry names come from a target's ``list_dir`` (possibly a
+    remote, untrusted channel), so reject path separators and parent refs to
+    prevent traversal when building local paths.
+
+    ponytail: explicit separator check (not ``Path``) so it is correct on both
+    POSIX and Windows orchestrators regardless of the listing's origin.
+    """
+    return (
+        name not in ("", ".", "..")
+        and "/" not in name
+        and "\\" not in name
+        and "\x00" not in name
+    )
+
+
 class BaseExecutor(AutoRegistry, entry_point="executor"):
     """
     The base executor represents the abstract concept of an executor in the
@@ -139,10 +158,19 @@ class BaseExecutor(AutoRegistry, entry_point="executor"):
             return
 
         cap = runtime_settings.MAX_SIDE_ARTIFACT_BYTES
-        landing = Path(tempfile.mkdtemp(prefix=f"horus-side-{task.id}-"))
+        safe_id = "".join(
+            c if (c.isalnum() or c in "-_.") else "_" for c in task.id
+        )
+        landing = Path(tempfile.mkdtemp(prefix=f"horus-side-{safe_id}-"))
 
         for entry in entries:
             try:
+                if not _is_safe_component(entry.name):
+                    horus_logger.log.warning(
+                        _("Skipping side artifact with unsafe name %(name)s")
+                        % {"name": entry.name}
+                    )
+                    continue
                 if entry.is_dir:
                     local_path = await self._pull_tree(
                         task, entry.path, landing / entry.name, cap
@@ -197,6 +225,12 @@ class BaseExecutor(AutoRegistry, entry_point="executor"):
             remote_dir, local_dir = stack.pop()
             local_dir.mkdir(parents=True, exist_ok=True)
             for child in await task.target.list_dir(remote_dir):
+                if not _is_safe_component(child.name):
+                    horus_logger.log.warning(
+                        _("Skipping side artifact with unsafe name %(name)s")
+                        % {"name": child.name}
+                    )
+                    continue
                 local_child = local_dir / child.name
                 if child.is_dir:
                     stack.append((child.path, local_child))

--- a/src/horus_runtime/core/target/base.py
+++ b/src/horus_runtime/core/target/base.py
@@ -26,7 +26,7 @@ from typing import TYPE_CHECKING, ClassVar, final
 
 from pydantic import Field, PrivateAttr
 
-from horus_runtime.core.target.channel import ChannelProcess
+from horus_runtime.core.target.channel import ChannelProcess, RemoteDirEntry
 from horus_runtime.core.task.exceptions import TaskExecutionError
 from horus_runtime.core.task.status import TaskStatus
 from horus_runtime.i18n import tr as _
@@ -282,4 +282,25 @@ class BaseTarget(AutoRegistry, entry_point="target"):
 
         Args:
             path: Directory path to create on the *target* host.
+        """
+
+    @abstractmethod
+    async def list_dir(self, path: str) -> list[RemoteDirEntry]:
+        """
+        List the immediate children of *path* on the target host
+        (non-recursive).
+
+        Implementations must use a **native, non-shell** mechanism so this is
+        OS-agnostic (``pathlib`` locally, SFTP/agent API remotely) and must
+        **skip symlinks** (they cause cycles and are almost always noise in a
+        side-artifacts directory). Each :class:`.RemoteDirEntry` carries the
+        file ``size`` (``0`` for directories) so callers can enforce a size cap
+        before transferring.
+
+        Args:
+            path: Directory path on the *target* host to list.
+
+        Returns:
+            One :class:`.RemoteDirEntry` per top-level child, or an empty list
+            if *path* does not exist or is not a directory.
         """

--- a/src/horus_runtime/core/target/channel.py
+++ b/src/horus_runtime/core/target/channel.py
@@ -20,6 +20,26 @@ Channel primitives for agentless target communication.
 """
 
 from abc import ABC, abstractmethod
+from typing import NamedTuple
+
+
+class RemoteDirEntry(NamedTuple):
+    """
+    One entry in a target directory listing, returned by
+    :meth:`~horus_runtime.core.target.base.BaseTarget.list_dir`.
+    """
+
+    name: str
+    """Basename of the entry (the executor builds local paths from names)."""
+
+    path: str
+    """Absolute path of the entry on the **target** host."""
+
+    is_dir: bool
+    """Whether the entry is a directory."""
+
+    size: int
+    """File size in bytes; ``0`` for directories."""
 
 
 class ChannelProcess(ABC):

--- a/src/horus_runtime/core/task/base.py
+++ b/src/horus_runtime/core/task/base.py
@@ -96,8 +96,8 @@ class BaseTask(AutoRegistry, entry_point="task"):
     )
     """
     Transient, undeclared artifacts produced by the task that the user may want
-    to inspect (logs, intermediate files, etc.) but which are not consumed by
-    any downstream task.
+    to inspect (logs, plots, small intermediate files, etc.) but which are not
+    consumed by any downstream task.
     """
 
     executor: BaseExecutor
@@ -151,7 +151,10 @@ class BaseTask(AutoRegistry, entry_point="task"):
     @property
     def side_artifacts_dir(self) -> str:
         """
-        Directory where side-product artifacts are written by convention.
+        Directory **on the target host** where side-product artifacts are
+        written by convention. This is a target-side path: it must not be
+        opened with local filesystem operations for remote targets. Use the
+        target channel (``list_dir`` / ``get_file``) to read it.
         """
         return (Path(self.working_dir) / "side-artifacts").as_posix()
 

--- a/src/horus_runtime/settings.py
+++ b/src/horus_runtime/settings.py
@@ -31,6 +31,13 @@ class HorusRuntimeSettings(BaseSettings):
 
     SIDE_ARTIFACTS_DIR_ENV: str = "HORUS_SIDE_ARTIFACTS_DIR"
 
+    MAX_SIDE_ARTIFACT_BYTES: int = 100 * 1024 * 1024
+    """
+    Maximum size (bytes) of a single side-artifact file collected back to
+    the orchestrator. Files above this are skipped with a warning; large
+    data should be declared as task inputs/outputs instead.
+    """
+
 
 runtime_settings = HorusRuntimeSettings()
 

--- a/tests/unit/executor/test_collect_side_artifacts.py
+++ b/tests/unit/executor/test_collect_side_artifacts.py
@@ -212,3 +212,80 @@ class TestCollectRemoteSideArtifacts:
         sub = by_id["job_sub"]
         assert isinstance(sub, FolderArtifact)
         assert (sub.path / "inner.bin").read_bytes() == b"\x00\x01\x02"
+
+
+class _MaliciousRemoteTarget(BaseTarget):
+    """
+    A target whose channel returns entry names containing path separators /
+    parent refs, to verify collection rejects them (no path traversal).
+    """
+
+    add_to_registry: ClassVar[bool] = False
+    kind: str = "_malicious_remote"
+
+    @property
+    def location_id(self) -> str:
+        return "inmem://malicious"
+
+    def access_cost(self, _: BaseArtifact) -> float | None:
+        return None
+
+    async def run_command(
+        self,
+        cmd: str,
+        *,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> ChannelProcess:
+        raise NotImplementedError
+
+    async def put_file(
+        self, content: bytes | Path, remote_path: str
+    ) -> None: ...
+
+    async def get_file(self, _remote_path: str) -> bytes:
+        return b"evil"
+
+    async def mkdir(self, path: str) -> None: ...
+
+    async def list_dir(self, path: str) -> list[RemoteDirEntry]:
+        if path.endswith("/sub"):
+            # A nested traversal child, to exercise the _pull_tree guard.
+            return [RemoteDirEntry("..", f"{path}/..", False, 4)]
+        return [
+            RemoteDirEntry("../evil.txt", f"{path}/../evil.txt", False, 4),
+            RemoteDirEntry("sub", f"{path}/sub", True, 0),
+        ]
+
+
+@pytest.mark.unit
+class TestCollectRejectsUnsafeNames:
+    """
+    Path-traversal protection against untrusted channel listings.
+    """
+
+    async def test_rejects_unsafe_entry_names(self) -> None:
+        """
+        Entries whose name is not a single path component are skipped, both at
+        the top level and inside reconstructed folders.
+        """
+        target = _MaliciousRemoteTarget(working_directory="/remote")
+        task = HorusTask(
+            name="t",
+            id="job",
+            inputs=[],
+            outputs=[],
+            runtime=CommandRuntime(command="noop"),
+            executor=ShellExecutor(),
+            target=target,
+        )
+
+        await task.executor.collect_side_artifacts(task)
+
+        by_id = {a.id: a for a in task.side_artifacts}
+        # Top-level "../evil.txt" is rejected; only the safe folder remains.
+        assert set(by_id) == {"job_sub"}
+        sub = by_id["job_sub"]
+        assert isinstance(sub, FolderArtifact)
+        # The nested ".." child was rejected, so the folder stays empty.
+        assert list(sub.path.iterdir()) == []

--- a/tests/unit/executor/test_collect_side_artifacts.py
+++ b/tests/unit/executor/test_collect_side_artifacts.py
@@ -1,0 +1,214 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Unit tests for ``BaseExecutor.collect_side_artifacts`` — collecting side
+artifacts back to the orchestrator over the target channel.
+"""
+
+from pathlib import Path, PurePosixPath
+from typing import ClassVar
+
+import pytest
+from pydantic import PrivateAttr
+
+from horus_builtin.artifact.file import FileArtifact
+from horus_builtin.artifact.folder import FolderArtifact
+from horus_builtin.executor.shell import ShellExecutor
+from horus_builtin.runtime.command import CommandRuntime
+from horus_builtin.task.horus_task import HorusTask
+from horus_runtime.core.artifact.base import BaseArtifact
+from horus_runtime.core.target.base import BaseTarget
+from horus_runtime.core.target.channel import ChannelProcess, RemoteDirEntry
+from horus_runtime.settings import runtime_settings
+from tests.conftest import MakeTaskType
+
+
+@pytest.mark.unit
+class TestCollectLocalSideArtifacts:
+    """
+    Collection from a ``LocalTarget``, exercising the full channel path
+    (``list_dir`` + ``get_file`` into a temp landing dir).
+    """
+
+    async def test_collects_files_and_folders(
+        self, make_shell_task: MakeTaskType
+    ) -> None:
+        """
+        Top-level files become FileArtifacts and top-level folders become
+        FolderArtifacts, with nested and empty directories reconstructed
+        locally and the bytes transferred out of the source directory.
+        """
+        task = make_shell_task()
+        sad = Path(task.side_artifacts_dir)
+        sad.mkdir(parents=True)
+        (sad / "log.txt").write_text("hello")
+        (sad / "sub").mkdir()
+        (sad / "sub" / "nested.txt").write_text("deep")
+        (sad / "empty").mkdir()
+
+        await task.executor.collect_side_artifacts(task)
+
+        by_id = {a.id: a for a in task.side_artifacts}
+        assert set(by_id) == {
+            "test_task_id_log.txt",
+            "test_task_id_sub",
+            "test_task_id_empty",
+        }
+
+        log = by_id["test_task_id_log.txt"]
+        assert isinstance(log, FileArtifact)
+        assert log.path.read_text() == "hello"
+        # Transferred: it landed somewhere other than the source dir.
+        assert log.path.parent != sad.resolve()
+
+        sub = by_id["test_task_id_sub"]
+        assert isinstance(sub, FolderArtifact)
+        assert (sub.path / "nested.txt").read_text() == "deep"
+
+        empty = by_id["test_task_id_empty"]
+        assert isinstance(empty, FolderArtifact)
+        assert empty.path.is_dir()
+
+    async def test_skips_files_over_cap(
+        self, make_shell_task: MakeTaskType, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        Files larger than ``MAX_SIDE_ARTIFACT_BYTES`` are skipped; smaller
+        ones are still collected.
+        """
+        monkeypatch.setattr(runtime_settings, "MAX_SIDE_ARTIFACT_BYTES", 10)
+        task = make_shell_task()
+        sad = Path(task.side_artifacts_dir)
+        sad.mkdir(parents=True)
+        (sad / "small.txt").write_text("ok")
+        (sad / "big.txt").write_text("x" * 100)
+
+        await task.executor.collect_side_artifacts(task)
+
+        collected = {a.id for a in task.side_artifacts}
+        assert collected == {"test_task_id_small.txt"}
+
+    async def test_missing_dir_is_noop(
+        self, make_shell_task: MakeTaskType
+    ) -> None:
+        """
+        A missing side-artifacts dir collects nothing and does not raise.
+        """
+        task = make_shell_task()  # side_artifacts_dir never created
+        await task.executor.collect_side_artifacts(task)
+        assert task.side_artifacts == []
+
+
+class _InMemoryRemoteTarget(BaseTarget):
+    """
+    A target whose filesystem is NOT the orchestrator's: it serves an in-memory
+    tree over the channel, proving collection works with no shared filesystem.
+    """
+
+    add_to_registry: ClassVar[bool] = False
+    kind: str = "_inmem_remote"
+    # path -> bytes (file) or None (directory)
+    _tree: dict[str, bytes | None] = PrivateAttr(default_factory=dict)
+
+    @property
+    def location_id(self) -> str:
+        return "inmem://remote"
+
+    def access_cost(self, _: BaseArtifact) -> float | None:
+        return None  # not accessible on the orchestrator fs
+
+    async def run_command(
+        self,
+        cmd: str,
+        *,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> ChannelProcess:
+        raise NotImplementedError
+
+    async def put_file(
+        self, content: bytes | Path, remote_path: str
+    ) -> None: ...
+
+    async def get_file(self, remote_path: str) -> bytes:
+        data = self._tree[remote_path]
+        assert data is not None
+        return data
+
+    async def mkdir(self, path: str) -> None:
+        self._tree.setdefault(path, None)
+
+    async def list_dir(self, path: str) -> list[RemoteDirEntry]:
+        parent = PurePosixPath(path)
+        out: list[RemoteDirEntry] = []
+        for entry_path, data in self._tree.items():
+            pp = PurePosixPath(entry_path)
+            if pp != parent and pp.parent == parent:
+                out.append(
+                    RemoteDirEntry(
+                        name=pp.name,
+                        path=entry_path,
+                        is_dir=data is None,
+                        size=0 if data is None else len(data),
+                    )
+                )
+        return out
+
+
+@pytest.mark.unit
+class TestCollectRemoteSideArtifacts:
+    """
+    Collection from a non-local target, purely over the channel.
+    """
+
+    async def test_collects_from_remote_target_via_channel(self) -> None:
+        """
+        Files/folders described only by the channel are pulled to a real local
+        path on the orchestrator and registered.
+        """
+        target = _InMemoryRemoteTarget(working_directory="/remote")
+        task = HorusTask(
+            name="t",
+            id="job",
+            inputs=[],
+            outputs=[],
+            runtime=CommandRuntime(command="noop"),
+            executor=ShellExecutor(),
+            target=target,
+        )
+        sad = task.side_artifacts_dir  # /remote/job/side-artifacts
+        target._tree = {
+            sad: None,
+            f"{sad}/out.txt": b"remote-bytes",
+            f"{sad}/sub": None,
+            f"{sad}/sub/inner.bin": b"\x00\x01\x02",
+        }
+
+        await task.executor.collect_side_artifacts(task)
+
+        by_id = {a.id: a for a in task.side_artifacts}
+        assert set(by_id) == {"job_out.txt", "job_sub"}
+
+        out = by_id["job_out.txt"]
+        assert isinstance(out, FileArtifact)
+        assert out.path.exists()  # landed on the local fs
+        assert out.path.read_bytes() == b"remote-bytes"
+
+        sub = by_id["job_sub"]
+        assert isinstance(sub, FolderArtifact)
+        assert (sub.path / "inner.bin").read_bytes() == b"\x00\x01\x02"

--- a/tests/unit/middleware/test_middleware.py
+++ b/tests/unit/middleware/test_middleware.py
@@ -31,7 +31,7 @@ from horus_runtime.core.interaction.base import BaseInteraction
 from horus_runtime.core.interaction.renderer import BaseInteractionRenderer
 from horus_runtime.core.interaction.transport import BaseInteractionTransport
 from horus_runtime.core.target.base import BaseTarget
-from horus_runtime.core.target.channel import ChannelProcess
+from horus_runtime.core.target.channel import ChannelProcess, RemoteDirEntry
 from horus_runtime.core.task.base import BaseTask
 from horus_runtime.core.task.status import TaskStatus
 from horus_runtime.middleware.auto_middleware import AutoMiddleware
@@ -165,6 +165,12 @@ class TrackingTarget(BaseTarget):
         """
         Stub channel method — not used in middleware tests.
         """
+
+    async def list_dir(self, _path: str) -> list[RemoteDirEntry]:
+        """
+        Stub channel method — not used in middleware tests.
+        """
+        return []
 
 
 class DummyInteraction(BaseInteraction[str]):

--- a/tests/unit/target/test_local_target.py
+++ b/tests/unit/target/test_local_target.py
@@ -176,3 +176,50 @@ class TestLocalTargetDispatch:
         await task.target.cancel()
 
         assert task.status == TaskStatus.CANCELED
+
+
+@pytest.mark.unit
+class TestLocalTargetListDir:
+    """
+    Tests for LocalTarget.list_dir.
+    """
+
+    async def test_lists_files_and_dirs_with_sizes(
+        self, tmp_path: Path
+    ) -> None:
+        """
+        Files report their size; directories report 0 and is_dir=True.
+        """
+        (tmp_path / "a.txt").write_text("hello")  # 5 bytes
+        (tmp_path / "sub").mkdir()
+
+        target = LocalTarget()
+        entries = {
+            e.name: e for e in await target.list_dir(tmp_path.as_posix())
+        }
+
+        assert set(entries) == {"a.txt", "sub"}
+        assert entries["a.txt"].is_dir is False
+        assert entries["a.txt"].size == 5
+        assert entries["a.txt"].path == (tmp_path / "a.txt").as_posix()
+        assert entries["sub"].is_dir is True
+        assert entries["sub"].size == 0
+
+    async def test_skips_symlinks(self, tmp_path: Path) -> None:
+        """
+        Symlinks are not listed (cycle/noise protection).
+        """
+        (tmp_path / "real.txt").write_text("x")
+        (tmp_path / "link.txt").symlink_to(tmp_path / "real.txt")
+
+        target = LocalTarget()
+        names = {e.name for e in await target.list_dir(tmp_path.as_posix())}
+
+        assert names == {"real.txt"}
+
+    async def test_missing_dir_returns_empty(self, tmp_path: Path) -> None:
+        """
+        Listing a non-existent path returns an empty list.
+        """
+        target = LocalTarget()
+        assert await target.list_dir((tmp_path / "nope").as_posix()) == []

--- a/tests/unit/target/test_target_base.py
+++ b/tests/unit/target/test_target_base.py
@@ -27,7 +27,7 @@ from pydantic import BaseModel
 
 from horus_runtime.core.artifact.base import BaseArtifact
 from horus_runtime.core.target.base import BaseTarget
-from horus_runtime.core.target.channel import ChannelProcess
+from horus_runtime.core.target.channel import ChannelProcess, RemoteDirEntry
 from horus_runtime.registry.auto_registry import AutoRegistry
 
 
@@ -82,6 +82,12 @@ class ConcreteTestTarget(BaseTarget):
         """
         Stub channel method — not used in base-class tests.
         """
+
+    async def list_dir(self, _path: str) -> list[RemoteDirEntry]:
+        """
+        Stub channel method — not used in base-class tests.
+        """
+        return []
 
 
 @pytest.mark.unit

--- a/tests/unit/transfer/test_transfer.py
+++ b/tests/unit/transfer/test_transfer.py
@@ -27,7 +27,7 @@ from horus_builtin.target.local import LocalTarget
 from horus_builtin.transfer.local_noop import LocalNoOpTransfer
 from horus_runtime.core.artifact.base import BaseArtifact
 from horus_runtime.core.target.base import BaseTarget
-from horus_runtime.core.target.channel import ChannelProcess
+from horus_runtime.core.target.channel import ChannelProcess, RemoteDirEntry
 from horus_runtime.core.task.base import BaseTask
 from horus_runtime.core.task.status import TaskStatus
 from horus_runtime.core.transfer.strategy import BaseTransferStrategy
@@ -94,6 +94,12 @@ class _UnregisteredTarget(BaseTarget):
         """
         Not used in transfer tests.
         """
+
+    async def list_dir(self, _path: str) -> list[RemoteDirEntry]:
+        """
+        Not used in transfer tests.
+        """
+        return []
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

Side-Artifacts are now collected using the BaseTarget channel.

## Documentation impact

If a user, plugin, or GUI can observe the difference, it requires documentation.

- [ ] No documentation update required
- [x] Documentation updated / will be updated

If documentation was updated, link the docs PR here:

**horus-docs PR:** ⬇️
https://github.com/temple-compute/horus-docs/pull/25
