### PR TITLE
chdir for local functions

### DIFF
--- a/src/horus_builtin/executor/_cwd_lock.py
+++ b/src/horus_builtin/executor/_cwd_lock.py
@@ -1,0 +1,46 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Shared cwd guard for the in-process Python executors.
+"""
+
+import asyncio
+import contextlib
+import os
+from collections.abc import AsyncIterator
+
+# ponytail: os.chdir is process-global, so concurrently dispatched in-process
+# tasks (different LocalTargets, same event loop) would clobber each other's
+# cwd. This lock serializes the chdir window across both Python executors.
+# Drop it only if these executors stop using chdir.
+_cwd_lock = asyncio.Lock()
+
+# TODO: Consider parallel task execution with a per-task cwd. Currently the
+# lock is held for the entire duration of the task execution, which is not
+# ideal.
+
+
+@contextlib.asynccontextmanager
+async def chdir_locked(path: os.PathLike[str] | str) -> AsyncIterator[None]:
+    """
+    Change the process cwd to *path* for the duration of the block, holding a
+    shared lock so concurrent in-process tasks can't observe each other's cwd.
+    """
+    async with _cwd_lock:
+        with contextlib.chdir(path):
+            yield

--- a/src/horus_builtin/executor/python_exec.py
+++ b/src/horus_builtin/executor/python_exec.py
@@ -20,9 +20,9 @@ Defines the PythonExecExecutor class, which represents an executor that runs a
 a Python code task in-process in the Horus runtime.
 """
 
-import contextlib
 from typing import TYPE_CHECKING, ClassVar
 
+from horus_builtin.executor._cwd_lock import chdir_locked
 from horus_builtin.runtime.python_string import PythonCodeStringRuntime
 from horus_runtime.context import HorusContext
 from horus_runtime.core.executor.base import BaseExecutor, RuntimeFilterType
@@ -68,5 +68,5 @@ class PythonExecExecutor(BaseExecutor):
         # Security Warning: using exec to execute arbitrary code can be
         # dangerous and should be done with caution.
         # Run in the task's working dir so relative paths match ShellExecutor.
-        with contextlib.chdir(task.working_dir):
+        async with chdir_locked(task.working_dir):
             exec(code, scope)

--- a/src/horus_builtin/executor/python_exec.py
+++ b/src/horus_builtin/executor/python_exec.py
@@ -20,6 +20,7 @@ Defines the PythonExecExecutor class, which represents an executor that runs a
 a Python code task in-process in the Horus runtime.
 """
 
+import contextlib
 from typing import TYPE_CHECKING, ClassVar
 
 from horus_builtin.runtime.python_string import PythonCodeStringRuntime
@@ -66,4 +67,6 @@ class PythonExecExecutor(BaseExecutor):
 
         # Security Warning: using exec to execute arbitrary code can be
         # dangerous and should be done with caution.
-        exec(code, scope)
+        # Run in the task's working dir so relative paths match ShellExecutor.
+        with contextlib.chdir(task.working_dir):
+            exec(code, scope)

--- a/src/horus_builtin/executor/python_fn.py
+++ b/src/horus_builtin/executor/python_fn.py
@@ -20,6 +20,7 @@ Python executor for in-memory workflows in horus-runtime. (Function
 executor).
 """
 
+import contextlib
 from inspect import isawaitable
 from typing import ClassVar
 
@@ -60,7 +61,13 @@ class PythonFunctionExecutor(BaseExecutor):
         # Get the function and resolved arguments from the runtime.
         func, args = await task.runtime.setup_runtime(task)
 
-        result = func(**args)
+        # Run in the task's working dir so relative paths match ShellExecutor.
+        # Resolve the awaitable inside the block so async functions run under
+        # the working dir too.
+        with contextlib.chdir(task.working_dir):
+            result = func(**args)
+            if isawaitable(result):
+                result = await result
 
         await self._parse_result_artifacts(task, result)
 

--- a/src/horus_builtin/executor/python_fn.py
+++ b/src/horus_builtin/executor/python_fn.py
@@ -20,10 +20,10 @@ Python executor for in-memory workflows in horus-runtime. (Function
 executor).
 """
 
-import contextlib
 from inspect import isawaitable
 from typing import ClassVar
 
+from horus_builtin.executor._cwd_lock import chdir_locked
 from horus_builtin.runtime.python import (
     PythonFunctionReturnType,
     PythonFunctionRuntime,
@@ -64,7 +64,7 @@ class PythonFunctionExecutor(BaseExecutor):
         # Run in the task's working dir so relative paths match ShellExecutor.
         # Resolve the awaitable inside the block so async functions run under
         # the working dir too.
-        with contextlib.chdir(task.working_dir):
+        async with chdir_locked(task.working_dir):
             result = func(**args)
             if isawaitable(result):
                 result = await result

--- a/tests/unit/executor/test_builtin_executor.py
+++ b/tests/unit/executor/test_builtin_executor.py
@@ -28,7 +28,9 @@ import pytest
 from pydantic import BaseModel, ValidationError
 
 from horus_builtin.executor.python_exec import PythonExecExecutor
+from horus_builtin.executor.python_fn import PythonFunctionExecutor
 from horus_builtin.executor.shell import ShellExecutor
+from horus_builtin.runtime.python import PythonFunctionRuntime
 from horus_builtin.runtime.python_string import PythonCodeStringRuntime
 from horus_builtin.target.local import LocalTarget
 from horus_builtin.task.horus_task import HorusTask
@@ -219,14 +221,57 @@ class TestPythonExecExecutor:
             inputs=[],
             outputs=[],
             runtime=PythonCodeStringRuntime(
-                code="open('out.txt', 'w').write('ok')"
+                code="from pathlib import Path; "
+                "Path('out.txt').write_text('ok')"
             ),
             executor=PythonExecExecutor(),
             target=LocalTarget(working_directory=tmp_path.as_posix()),
         )
 
         cwd_before = os.getcwd()
-        await PythonExecExecutor().execute(task)
+        await task.executor.execute(task)
+
+        assert (Path(task.working_dir) / "out.txt").read_text() == "ok"
+        assert os.getcwd() == cwd_before
+
+
+@pytest.mark.unit
+class TestPythonFunctionExecutor:
+    """
+    Test that the in-process Python function executor runs in the task
+    working dir (issue #82), for both sync and async functions.
+    """
+
+    @pytest.mark.parametrize("use_async", [False, True])
+    async def test_function_runs_in_task_working_dir(
+        self, use_async: bool, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """
+        Relative paths in the wrapped function resolve to ``task.working_dir``,
+        and the process cwd is restored afterwards.
+        """
+        del horus_context
+
+        def sync_fn() -> None:
+            Path("out.txt").write_text("ok")
+
+        async def async_fn() -> None:
+            Path("out.txt").write_text("ok")
+
+        task = HorusTask(
+            name="fn_task",
+            id="fn_task_id",
+            inputs=[],
+            outputs=[],
+            runtime=PythonFunctionRuntime(
+                func=async_fn if use_async else sync_fn
+            ),
+            executor=PythonFunctionExecutor(),
+            target=LocalTarget(working_directory=tmp_path.as_posix()),
+        )
+
+        cwd_before = os.getcwd()
+        await task.executor.execute(task)
 
         assert (Path(task.working_dir) / "out.txt").read_text() == "ok"
         assert os.getcwd() == cwd_before

--- a/tests/unit/executor/test_builtin_executor.py
+++ b/tests/unit/executor/test_builtin_executor.py
@@ -20,13 +20,18 @@
 Unit tests for ShellExecutor and related builtin executors.
 """
 
+import os
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from pydantic import BaseModel, ValidationError
 
+from horus_builtin.executor.python_exec import PythonExecExecutor
 from horus_builtin.executor.shell import ShellExecutor
+from horus_builtin.runtime.python_string import PythonCodeStringRuntime
 from horus_builtin.target.local import LocalTarget
+from horus_builtin.task.horus_task import HorusTask
 from horus_runtime.context import HorusContext
 from horus_runtime.core.executor.base import BaseExecutor
 from horus_runtime.core.task.exceptions import TaskExecutionError
@@ -191,3 +196,37 @@ class TestShellExecutorIntegration:
         # Use 'true' command which should always exit with 0
         task = make_shell_task("true")
         await executor.execute(task)
+
+
+@pytest.mark.unit
+class TestPythonExecExecutor:
+    """
+    Test that the in-process Python executor runs in the task working dir.
+    """
+
+    async def test_exec_runs_in_task_working_dir(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """
+        Relative paths in exec'd code resolve to ``task.working_dir`` (issue
+        #82), and the process cwd is restored afterwards.
+        """
+        del horus_context
+
+        task = HorusTask(
+            name="py_task",
+            id="py_task_id",
+            inputs=[],
+            outputs=[],
+            runtime=PythonCodeStringRuntime(
+                code="open('out.txt', 'w').write('ok')"
+            ),
+            executor=PythonExecExecutor(),
+            target=LocalTarget(working_directory=tmp_path.as_posix()),
+        )
+
+        cwd_before = os.getcwd()
+        await PythonExecExecutor().execute(task)
+
+        assert (Path(task.working_dir) / "out.txt").read_text() == "ok"
+        assert os.getcwd() == cwd_before


### PR DESCRIPTION
## Summary

Use `contextlib` to chdir python functions to the task working directory.

## Documentation impact

If a user, plugin, or GUI can observe the difference, it requires documentation.

- [x] No documentation update required
- [ ] Documentation updated / will be updated
