### PR TITLE
feat(runtime): unify artifact substitution on $ across runtimes

### DIFF
--- a/src/horus_builtin/runtime/command.py
+++ b/src/horus_builtin/runtime/command.py
@@ -21,62 +21,14 @@ Command implementation for the runtime.
 
 from typing import TYPE_CHECKING, ClassVar
 
+from horus_builtin.runtime.substitution import substitute
 from horus_runtime.context import HorusContext
 from horus_runtime.core.runtime.base import BaseRuntime
 from horus_runtime.core.runtime.events import RuntimeEvent
 from horus_runtime.i18n import tr as _
 
 if TYPE_CHECKING:
-    from horus_runtime.core.artifact.base import BaseArtifact
-    from horus_runtime.core.target.base import BaseTarget
     from horus_runtime.core.task.base import BaseTask
-
-
-# Wraps an artifact so that "{script}" in a command formats to the artifact's
-# path *on the task's target* (target.path_on_target), while "{script.path}",
-# "{script.id}", etc. still forward to the artifact. This is what lets a
-# command be written once and run unchanged on a local or remote target.
-class _ArtifactRef:
-    def __init__(self, artifact: "BaseArtifact", target: "BaseTarget"):
-        self._a = artifact
-        self._t = target
-
-    def __getattr__(self, name: str) -> object:
-        if name.startswith("__") and name.endswith("__"):
-            raise AttributeError(name)
-        return getattr(self._a, name)
-
-    def __format__(self, spec: str) -> str:
-        return format(self._t.path_on_target(self._a), spec)
-
-
-# Create a namespace object to allow for attribute-style access to task
-# variables and inputs in the command formatting. This allows users to
-# write commands like "echo {task.input1.path}" in the workflow yaml
-class _TaskNamespace:
-    def __init__(self, task: "BaseTask"):
-        for name, value in vars(task).items():
-            setattr(self, name, value)
-        for artifact in (*task.inputs, *task.outputs):
-            setattr(self, artifact.id, _ArtifactRef(artifact, task.target))
-
-
-def format_command(template: str, task: "BaseTask") -> str:
-    """
-    Render *template* against *task*: artifacts are exposed by id (``{script}``
-    resolves to the artifact's on-target path) and via the ``task`` namespace.
-    """
-    artifacts = (*task.inputs, *task.outputs)
-    if any(a.id == "task" for a in artifacts):
-        raise ValueError(
-            _(
-                "Artifact id 'task' is reserved for command templates. "
-                "Please rename this artifact."
-            )
-        )
-    refs = {a.id: _ArtifactRef(a, task.target) for a in artifacts}
-
-    return template.format(task=_TaskNamespace(task), **refs)
 
 
 class CommandRuntime(BaseRuntime[str]):
@@ -94,7 +46,9 @@ class CommandRuntime(BaseRuntime[str]):
 
     command: str
     """
-    The command to execute.
+    The command to execute. Supports ``$id`` / ``${id}`` / ``${id.attr}`` /
+    ``${task.attr}`` placeholders (``string.Template`` syntax). ``{}`` passes
+    through untouched.
     """
 
     formatted_command: str = ""
@@ -104,11 +58,10 @@ class CommandRuntime(BaseRuntime[str]):
 
     async def _setup_runtime(self, task: "BaseTask") -> str:
         """
-        For the CommandRuntime, setting up the runtime simply involves
-        returning the command as is, since there are no placeholders to
-        replace.
+        Render ``$``/``${}`` placeholders in the command against *task*'s
+        artifacts and task namespace, then emit a ``RuntimeEvent``.
         """
-        fmt = format_command(self.command, task)
+        fmt = substitute(self.command, task)
 
         self.formatted_command = fmt
 

--- a/src/horus_builtin/runtime/python_script.py
+++ b/src/horus_builtin/runtime/python_script.py
@@ -24,7 +24,8 @@ import shlex
 from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar
 
-from horus_builtin.runtime.command import CommandRuntime, format_command
+from horus_builtin.runtime.command import CommandRuntime
+from horus_builtin.runtime.substitution import substitute
 from horus_runtime.context import HorusContext
 from horus_runtime.core.runtime.events import RuntimeEvent
 from horus_runtime.i18n import tr as _
@@ -57,8 +58,8 @@ class PythonScriptRuntime(CommandRuntime):
     """Local path to the ``.py`` file to run."""
 
     args: str = ""
-    """Extra CLI args appended after the script; supports ``{input}`` /
-    ``{output}`` placeholders (resolved to their on-target paths)."""
+    """Extra CLI args appended after the script; supports ``$input`` /
+    ``${output}`` placeholders (resolved to their on-target paths)."""
 
     python: str = "python"
     """Interpreter to invoke on the target (override if not ``python``)."""
@@ -72,7 +73,7 @@ class PythonScriptRuntime(CommandRuntime):
         # the executor uses as cwd and where the script's outputs land.
         await task.target.put_file(self.script, remote_path)
 
-        args = format_command(self.args, task) if self.args else ""
+        args = substitute(self.args, task) if self.args else ""
         cmd = f"{self.python} {shlex.quote(remote_path)} {args}".rstrip()
         self.formatted_command = cmd
 

--- a/src/horus_builtin/runtime/python_string.py
+++ b/src/horus_builtin/runtime/python_string.py
@@ -19,9 +19,9 @@
 PythonCodeStringRuntime implementation for horus-runtime.
 """
 
-from string import Template
 from typing import TYPE_CHECKING, ClassVar
 
+from horus_builtin.runtime.substitution import substitute
 from horus_runtime.core.runtime.base import BaseRuntime
 from horus_runtime.i18n import tr as _
 
@@ -47,15 +47,12 @@ class PythonCodeStringRuntime(BaseRuntime[str]):
 
     async def _setup_runtime(self, task: "BaseTask") -> str:
         """
-        Substitute ``$input`` / ``${output}`` placeholders with artifact paths.
+        Substitute ``$input`` / ``${output}`` / ``${id.attr}`` /
+        ``${task.attr}`` placeholders with artifact paths.
 
         Uses ``string.Template`` (not ``str.format``) so Python's ``{}`` —
         dict/set literals, f-strings, comprehensions — is left untouched.
-        Placeholders are artifact ids mapping to their on-target path;
-        unknown ``$name`` references are left as-is via ``safe_substitute``.
+        Unknown ``$name`` references are left as-is via ``safe_substitute``.
+        Use ``$$`` to emit a literal ``$``.
         """
-        paths = {
-            a.id: str(task.target.path_on_target(a))
-            for a in (*task.inputs, *task.outputs)
-        }
-        return Template(self.code).safe_substitute(paths)
+        return substitute(self.code, task)

--- a/src/horus_builtin/runtime/substitution.py
+++ b/src/horus_builtin/runtime/substitution.py
@@ -80,7 +80,8 @@ class _TaskNamespace:
             if hasattr(self, artifact.id):
                 raise ValueError(
                     _(
-                        "Artifact id '%(id)s' conflicts with a task attribute in templates. "
+                        "Artifact id '%(id)s' conflicts with a task attribute"
+                        " in templates. "
                         "Please rename this artifact."
                     )
                     % {"id": artifact.id}

--- a/src/horus_builtin/runtime/substitution.py
+++ b/src/horus_builtin/runtime/substitution.py
@@ -77,6 +77,14 @@ class _TaskNamespace:
         for name, value in vars(task).items():
             setattr(self, name, value)
         for artifact in (*task.inputs, *task.outputs):
+            if hasattr(self, artifact.id):
+                raise ValueError(
+                    _(
+                        "Artifact id '%(id)s' conflicts with a task attribute in templates. "
+                        "Please rename this artifact."
+                    )
+                    % {"id": artifact.id}
+                )
             setattr(self, artifact.id, _ArtifactRef(artifact, task.target))
 
 

--- a/src/horus_builtin/runtime/substitution.py
+++ b/src/horus_builtin/runtime/substitution.py
@@ -1,0 +1,148 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Shared artifact substitution helper for string-templating runtimes.
+
+All runtimes that do string substitution (``command``, ``python_script``,
+``python``) use a single entry point: :func:`substitute`.  Placeholders follow
+``string.Template`` ``$``/``${}`` syntax — ``str.format`` ``{}`` is **not**
+supported and passes through unchanged.
+
+Supported placeholder forms
+----------------------------
+* ``$id``          — on-target path of the artifact whose id is *id*
+* ``${id}``        — same, braced form (use when a letter/digit follows)
+* ``${id.attr}``   — attribute of the artifact (e.g. ``${result.path}``,
+                     ``${result.id}``)
+* ``${task.attr}`` — attribute of the task (e.g. ``${task.name}``)
+
+Unknown ``$name`` references are left as-is (``safe_substitute`` semantics).
+Use ``$$`` to emit a literal ``$``.
+"""
+
+from collections.abc import Iterator, Mapping
+from string import Template
+from typing import TYPE_CHECKING
+
+from horus_runtime.i18n import tr as _
+
+if TYPE_CHECKING:
+    from horus_runtime.core.artifact.base import BaseArtifact
+    from horus_runtime.core.target.base import BaseTarget
+    from horus_runtime.core.task.base import BaseTask
+
+
+# Wraps an artifact so that ``$id`` in a template formats to the artifact's
+# path *on the task's target* (target.path_on_target), while ``${id.path}``,
+# ``${id.id}``, etc. still forward to the artifact.  This is what lets a
+# command or script be written once and run unchanged on a local or remote
+# target.
+class _ArtifactRef:
+    def __init__(self, artifact: "BaseArtifact", target: "BaseTarget") -> None:
+        self._a = artifact
+        self._t = target
+
+    def __getattr__(self, name: str) -> object:
+        if name.startswith("__") and name.endswith("__"):
+            raise AttributeError(name)
+        return getattr(self._a, name)
+
+    def __str__(self) -> str:
+        return str(self._t.path_on_target(self._a))
+
+    def __format__(self, spec: str) -> str:
+        return format(self._t.path_on_target(self._a), spec)
+
+
+# Create a namespace object to allow for attribute-style access to task
+# variables in template placeholders.  This allows users to write placeholders
+# like ``${task.name}`` in a workflow YAML.
+class _TaskNamespace:
+    def __init__(self, task: "BaseTask") -> None:
+        for name, value in vars(task).items():
+            setattr(self, name, value)
+        for artifact in (*task.inputs, *task.outputs):
+            setattr(self, artifact.id, _ArtifactRef(artifact, task.target))
+
+
+class _DotTemplate(Template):
+    """Template subclass that allows dotted names like ``${result.path}``."""
+
+    braceidpattern = r"(?a:[_a-z][_a-z0-9]*(?:\.[_a-z0-9]+)*)"
+
+
+class _Resolver(Mapping[str, str]):
+    """
+    Mapping that resolves dotted placeholder keys against task artifacts and
+    the task namespace itself.
+
+    Keys are of the form ``id``, ``id.attr``, or ``task.attr``.  The root
+    segments map to :class:`_ArtifactRef` objects (for artifact ids) and a
+    :class:`_TaskNamespace` (for the ``task`` key).  Attribute chains are
+    resolved via :func:`getattr`; :exc:`AttributeError` is converted to
+    :exc:`KeyError` so ``safe_substitute`` leaves the placeholder intact.
+    """
+
+    def __init__(self, task: "BaseTask") -> None:
+        self._roots: dict[str, object] = {
+            a.id: _ArtifactRef(a, task.target)
+            for a in (*task.inputs, *task.outputs)
+        }
+        self._roots["task"] = _TaskNamespace(task)
+
+    def __getitem__(self, key: str) -> str:
+        parts = key.split(".")
+        if parts[0] not in self._roots:
+            raise KeyError(key)
+        obj: object = self._roots[parts[0]]
+        for part in parts[1:]:
+            try:
+                obj = getattr(obj, part)
+            except AttributeError as exc:
+                raise KeyError(key) from exc
+        return str(obj)
+
+    def __iter__(self) -> "Iterator[str]":
+        return iter(self._roots)
+
+    def __len__(self) -> int:
+        return len(self._roots)
+
+
+def substitute(template: str, task: "BaseTask") -> str:
+    """
+    Render *template* against *task* using ``string.Template`` ``$``/``${}``
+    syntax.
+
+    * ``$id`` / ``${id}`` — on-target path of the artifact whose id is *id*
+    * ``${id.attr}``       — attribute of that artifact
+    * ``${task.attr}``     — attribute of the task
+    * Unknown placeholders are left as-is (``safe_substitute`` semantics).
+    * ``$$`` emits a literal ``$``.
+
+    Raises :exc:`ValueError` if any artifact has the reserved id ``"task"``.
+    """
+    artifacts = (*task.inputs, *task.outputs)
+    if any(a.id == "task" for a in artifacts):
+        raise ValueError(
+            _(
+                "Artifact id 'task' is reserved for templates. "
+                "Please rename this artifact."
+            )
+        )
+    return _DotTemplate(template).safe_substitute(_Resolver(task))

--- a/tests/unit/runtime/test_builtin_runtime.py
+++ b/tests/unit/runtime/test_builtin_runtime.py
@@ -113,14 +113,14 @@ class TestCommandRuntime:
         """
         del horus_context
         task = make_shell_task(
-            cmd="echo 'Input artifact path is {input1.path}'",
+            cmd="echo 'Input artifact path is ${input1.path}'",
             inputs=[FileArtifact(id="input1", path=Path("test"))],
         )
 
         formatted_cmd = await task.runtime.setup_runtime(task)
 
         assert "Input artifact path is" in formatted_cmd
-        assert "{input1.path}" not in formatted_cmd
+        assert "${input1.path}" not in formatted_cmd
 
     async def test_command_runtime_formats_command_with_task_variables(
         self, make_shell_task: MakeTaskType, horus_context: HorusContext
@@ -130,7 +130,7 @@ class TestCommandRuntime:
         formatting.
         """
         del horus_context
-        task = make_shell_task("echo 'Task kind is {task.kind}'")
+        task = make_shell_task("echo 'Task kind is ${task.kind}'")
 
         formatted_cmd = await task.runtime.setup_runtime(task)
 

--- a/tests/unit/runtime/test_python_script.py
+++ b/tests/unit/runtime/test_python_script.py
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 """
-Tests for PythonScriptRuntime and target-aware command formatting.
+Tests for PythonScriptRuntime and target-aware artifact substitution.
 """
 
 import shlex
@@ -27,12 +27,9 @@ import pytest
 
 from horus_builtin.artifact.json import JSONArtifact
 from horus_builtin.executor.shell import ShellExecutor
-from horus_builtin.runtime.command import (
-    CommandRuntime,
-    _ArtifactRef,
-    format_command,
-)
+from horus_builtin.runtime.command import CommandRuntime
 from horus_builtin.runtime.python_script import PythonScriptRuntime
+from horus_builtin.runtime.substitution import _ArtifactRef, substitute
 from horus_builtin.target.local import LocalTarget
 from horus_builtin.task.horus_task import HorusTask
 from horus_runtime.core.artifact.base import BaseArtifact
@@ -66,7 +63,7 @@ async def test_python_script_ships_script_and_builds_command(
     result = JSONArtifact(id="result", path=tmp_path / "out" / "result.json")
     task = _task(
         tmp_path,
-        PythonScriptRuntime(script=script, args="{result}"),
+        PythonScriptRuntime(script=script, args="$result"),
         result,
     )
 
@@ -108,7 +105,7 @@ async def test_python_script_quotes_remote_path_with_spaces(
 
 
 def test_artifact_ref_resolves_on_target_path(tmp_path: Path) -> None:
-    """{x} -> path_on_target; {x.path}/{x.id} forward to the artifact."""
+    """str(ref) -> path_on_target; ref.path/ref.id forward to the artifact."""
 
     class _StubTarget:
         def path_on_target(self, artifact: BaseArtifact) -> str:
@@ -123,17 +120,18 @@ def test_artifact_ref_resolves_on_target_path(tmp_path: Path) -> None:
     )
 
     assert f"{ref}" == "/remote/result.json"
+    assert str(ref) == "/remote/result.json"
     assert str(ref.path) == str(result.path)
     assert ref.id == "result"
 
 
-def test_format_command_uses_local_path_for_local_target(
+def test_substitute_uses_local_path_for_local_target(
     tmp_path: Path,
 ) -> None:
-    """On a LocalTarget, {result} resolves to the local artifact path."""
+    """On a LocalTarget, $result resolves to the local artifact path."""
     result = JSONArtifact(id="result", path=tmp_path / "result.json")
     task = _task(tmp_path, CommandRuntime(command="x"), result)
 
-    assert format_command("{result}", task) == str(result.path)
-    assert format_command("{result.path}", task) == str(result.path)
-    assert format_command("{result.id}", task) == "result"
+    assert substitute("$result", task) == str(result.path)
+    assert substitute("${result.path}", task) == str(result.path)
+    assert substitute("${result.id}", task) == "result"

--- a/tests/unit/runtime/test_substitution.py
+++ b/tests/unit/runtime/test_substitution.py
@@ -1,0 +1,130 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Unit tests for the shared ``substitute`` helper in
+``horus_builtin.runtime.substitution``.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from horus_builtin.artifact.json import JSONArtifact
+from horus_builtin.executor.python_exec import PythonExecExecutor
+from horus_builtin.executor.shell import ShellExecutor
+from horus_builtin.runtime.command import CommandRuntime
+from horus_builtin.runtime.python_string import PythonCodeStringRuntime
+from horus_builtin.runtime.substitution import substitute
+from horus_builtin.target.local import LocalTarget
+from horus_builtin.task.horus_task import HorusTask
+
+
+def _shell_task(
+    tmp_path: Path, command: str, output: JSONArtifact
+) -> HorusTask:
+    return HorusTask(
+        id="run",
+        name="my_task",
+        runtime=CommandRuntime(command=command),
+        executor=ShellExecutor(),
+        target=LocalTarget(working_directory=tmp_path.as_posix()),
+        outputs=[output],
+    )
+
+
+def _python_task(tmp_path: Path, code: str, output: JSONArtifact) -> HorusTask:
+    return HorusTask(
+        id="run",
+        name="my_task",
+        runtime=PythonCodeStringRuntime(code=code),
+        executor=PythonExecExecutor(),
+        target=LocalTarget(working_directory=tmp_path.as_posix()),
+        outputs=[output],
+    )
+
+
+def test_substitute_task_name(tmp_path: Path) -> None:
+    """${task.name} resolves to the task's name field."""
+    result = JSONArtifact(id="result", path=tmp_path / "result.json")
+    task = _shell_task(tmp_path, "unused", result)
+
+    assert substitute("${task.name}", task) == "my_task"
+
+
+def test_substitute_unknown_env_var_preserved(tmp_path: Path) -> None:
+    """Shell $VAR that doesn't match an artifact id is left untouched."""
+    result = JSONArtifact(id="result", path=tmp_path / "result.json")
+    task = _shell_task(tmp_path, "unused", result)
+
+    assert substitute("echo $HOME", task) == "echo $HOME"
+
+
+def test_substitute_double_dollar_escapes(tmp_path: Path) -> None:
+    """$$ emits a literal $."""
+    result = JSONArtifact(id="result", path=tmp_path / "result.json")
+    task = _shell_task(tmp_path, "unused", result)
+
+    assert substitute("echo $$", task) == "echo $"
+
+
+def test_substitute_curly_braces_preserved(tmp_path: Path) -> None:
+    """Plain {} (e.g. shell brace expansion) passes through unchanged."""
+    result = JSONArtifact(id="result", path=tmp_path / "result.json")
+    task = _shell_task(tmp_path, "unused", result)
+
+    assert substitute("echo {a,b}", task) == "echo {a,b}"
+
+
+def test_substitute_reserved_id_raises(tmp_path: Path) -> None:
+    """An artifact with id='task' raises ValueError."""
+    reserved = JSONArtifact(id="task", path=tmp_path / "task.json")
+    task = HorusTask(
+        id="run",
+        name="my_task",
+        runtime=CommandRuntime(command="x"),
+        executor=ShellExecutor(),
+        target=LocalTarget(working_directory=tmp_path.as_posix()),
+        outputs=[reserved],
+    )
+
+    with pytest.raises(ValueError, match="reserved"):
+        substitute("$task", task)
+
+
+@pytest.mark.usefixtures("horus_context")
+async def test_command_runtime_result_path_end_to_end(tmp_path: Path) -> None:
+    """${result.path} in a CommandRuntime resolves end-to-end."""
+    result = JSONArtifact(id="result", path=tmp_path / "result.json")
+    task = _shell_task(tmp_path, "cat ${result.path}", result)
+
+    formatted = await task.runtime.setup_runtime(task)
+
+    assert formatted == f"cat {result.path}"
+
+
+@pytest.mark.usefixtures("horus_context")
+async def test_python_code_string_result_path_end_to_end(
+    tmp_path: Path,
+) -> None:
+    """${result.path} in PythonCodeStringRuntime resolves end-to-end."""
+    result = JSONArtifact(id="result", path=tmp_path / "result.json")
+    task = _python_task(tmp_path, "open('${result.path}')", result)
+
+    code = await task.runtime.setup_runtime(task)
+
+    assert code == f"open('{result.path}')"


### PR DESCRIPTION
## Summary

Unifies all string-templating runtimes on `string.Template` `$`/`${}` syntax. This is a **breaking change** — `str.format` `{}` placeholders no longer substitute.

- New shared helper `horus_builtin.runtime.substitution` with `_DotTemplate`, `_Resolver`, `_ArtifactRef`, `_TaskNamespace`, and the `substitute()` entry point
- `CommandRuntime` and `PythonScriptRuntime`: drop `format_command`, wire `substitute()`
- `PythonCodeStringRuntime`: replace hand-rolled `Template` with `substitute()`
- All runtimes now support `$id`, `${id}`, `${id.path}`, `${id.attr}`, and `${task.name}`

## Breaking change

**`{}` no longer substitutes in `command` or `python_script`.** Migrate:

| Old | New |
|---|---|
| `{result}` | `$result` or `${result}` |
| `{result.path}` | `${result.path}` |
| `{task.name}` | `${task.name}` |

Additional notes:
- `$$` emits a literal `$`
- Shell `$VAR` is preserved unless an artifact id collides with the var name
- `{}` now passes through untouched (no longer raises on Python code with dict literals)
- Artifact id `"task"` is still reserved and raises `ValueError`

## python_function unchanged

`PythonFunctionRuntime` uses kwargs injection — unaffected by this change.


Docs change:
https://github.com/temple-compute/horus-docs/pull/26