### PR TITLE
feat(core): task-level ResourceRequest model (#90)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ RUFF_FORMAT_CHECK_CMD = ruff format --check --diff .
 RUFF_FIX_CMD = ruff check --fix src/ tests/
 RUFF_FORMAT_CMD = ruff format .
 MYPY_CMD = mypy src/ tests/
-ADD_LICENSE_HEADERS_CMD = licenseheaders -t .agpl3.tmpl -cy -o 'Temple Compute' -n horus-runtime -u https://horus.bsc.es
+ADD_LICENSE_HEADERS_CMD = licenseheaders -t .agpl3.tmpl -cy -o 'Temple Compute' -n horus-runtime -u https://templecompute.com
 
 # i18n settings (babel)
 BABEL_CFG = babel.cfg

--- a/src/horus_builtin/workflow/horus_workflow.py
+++ b/src/horus_builtin/workflow/horus_workflow.py
@@ -95,6 +95,11 @@ class HorusWorkflow(BaseWorkflow):
         for task_id in plan:
             task = tasks[task_id]
 
+            # Associate the task with its target before any transfer so
+            # resource-aware targets (which may provision lazily at transfer
+            # time, before dispatch) can read task.resources.
+            task.target.bind(task)
+
             # Transfer input artifacts to the task's target as needed.
             await self.transfer_artifacts(task, source_map)
 

--- a/src/horus_runtime/core/resources.py
+++ b/src/horus_runtime/core/resources.py
@@ -24,7 +24,7 @@ into their own provisioning primitives. Targets that ignore resources are
 unaffected, which keeps the field fully backwards compatible.
 """
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class ResourceRequest(BaseModel):
@@ -49,8 +49,8 @@ class ResourceRequest(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    cpus: int | None = None
-    gpus: int = 0
-    memory_gb: int | None = None
-    vram_gb: int | None = None
+    cpus: int | None = Field(default=None, ge=1)
+    gpus: int = Field(default=0, ge=0)
+    memory_gb: int | None = Field(default=None, ge=1)
+    vram_gb: int | None = Field(default=None, ge=1)
     walltime: str | None = None

--- a/src/horus_runtime/core/resources.py
+++ b/src/horus_runtime/core/resources.py
@@ -1,0 +1,56 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Portable, target-agnostic compute resource requests for tasks.
+
+The model defined here is advisory: a task may declare the resources it would
+like, and resource-aware targets (Slurm, Terraform, etc.) translate those hints
+into their own provisioning primitives. Targets that ignore resources are
+unaffected, which keeps the field fully backwards compatible.
+"""
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ResourceRequest(BaseModel):
+    """Advisory compute requirements for a task. Optional; consumed by
+    resource-aware targets (e.g. Slurm, Terraform) when present.
+
+    All fields are hints. Targets are free to round up, ignore unsupported
+    fields, or reject a request they cannot satisfy. Unknown fields are
+    rejected so typos in a workflow YAML surface as validation errors rather
+    than being silently dropped.
+
+    Attributes:
+        cpus: Number of CPU cores to request. ``None`` lets the target choose.
+        gpus: Number of GPUs to request. Defaults to ``0`` (no GPU).
+        memory_gb: System RAM to request, in gibibytes. ``None`` lets the
+            target choose.
+        vram_gb: GPU memory to request per GPU, in gibibytes. ``None`` lets the
+            target choose.
+        walltime: Maximum wall-clock runtime, as a target-interpreted string
+            (e.g. ``"01:30:00"``). ``None`` means no explicit limit.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    cpus: int | None = None
+    gpus: int = 0
+    memory_gb: int | None = None
+    vram_gb: int | None = None
+    walltime: str | None = None

--- a/src/horus_runtime/core/target/base.py
+++ b/src/horus_runtime/core/target/base.py
@@ -90,6 +90,18 @@ class BaseTarget(AutoRegistry, entry_point="target"):
             ``horus-agent://agent-42``
         """
 
+    @property
+    def task_or_raise(self) -> "BaseTask":
+        """
+        Return the task currently running on this target, or raise an error if
+        no task is running.
+        """
+        if self._task is None:
+            raise TaskExecutionError(
+                _("No task is currently running on this target.")
+            )
+        return self._task
+
     def bind(self, task: "BaseTask") -> None:
         """Associate *task* with this target ahead of dispatch.
 
@@ -102,7 +114,15 @@ class BaseTarget(AutoRegistry, entry_point="target"):
         Args:
             task: The task about to be transferred to and dispatched on this
                 target.
+
+        Raises:
+            TaskExecutionError: If a task is already running on this target.
         """
+        if self._task_future is not None and not self._task_future.done():
+            raise TaskExecutionError(
+                _("Task '%(task_name)s' is already running on this target.")
+                % {"task_name": self._task.name if self._task else "unknown"}
+            )
         self._task = task
 
     @final
@@ -131,14 +151,10 @@ class BaseTarget(AutoRegistry, entry_point="target"):
         Raises:
             TaskExecutionError: If the task is already running on this target.
         """
-        if self._task_future is not None and not self._task_future.done():
-            raise TaskExecutionError(
-                _("Task '%(task_name)s' is already running on this target.")
-                % {"task_name": task.name}
-            )
+        self.bind(task)
 
-        self._task = task
-        self._task_future = asyncio.create_task(self._task.run())
+        # Here _task is always set, so we can cast it
+        self._task_future = asyncio.create_task(self.task_or_raise.run())
         horus_logger.log.debug(
             _("Dispatched task '%(task_name)s' to %(kind)s target")
             % {"task_name": task.name, "kind": self.kind}
@@ -193,9 +209,9 @@ class BaseTarget(AutoRegistry, entry_point="target"):
         Raises:
             TaskExecutionError: If no task has been dispatched yet.
         """
-        if self._task is None:
+        if self._task_future is None:
             raise TaskExecutionError(_("Task has not been dispatched yet."))
-        return self._task.status
+        return self.task_or_raise.status
 
     @abstractmethod
     def access_cost(self, artifact: "BaseArtifact") -> float | None:

--- a/src/horus_runtime/core/target/base.py
+++ b/src/horus_runtime/core/target/base.py
@@ -90,6 +90,21 @@ class BaseTarget(AutoRegistry, entry_point="target"):
             ``horus-agent://agent-42``
         """
 
+    def bind(self, task: "BaseTask") -> None:
+        """Associate *task* with this target ahead of dispatch.
+
+        Resource-aware targets can then read ``task.resources`` during
+        (possibly lazy) provisioning. Provisioning targets (e.g. Terraform)
+        provision at transfer time, which happens before :meth:`dispatch` sets
+        the task reference, so binding first gives them access to the task's
+        declared resources in time.
+
+        Args:
+            task: The task about to be transferred to and dispatched on this
+                target.
+        """
+        self._task = task
+
     @final
     async def dispatch(self, task: "BaseTask") -> None:
         """

--- a/src/horus_runtime/core/task/base.py
+++ b/src/horus_runtime/core/task/base.py
@@ -34,6 +34,7 @@ from horus_runtime.core.artifact.base import BaseArtifact
 from horus_runtime.core.executor.base import BaseExecutor
 from horus_runtime.core.executor.exceptions import IncompatibleRuntimeError
 from horus_runtime.core.interaction.transport import BaseInteractionTransport
+from horus_runtime.core.resources import ResourceRequest
 from horus_runtime.core.runtime.base import BaseRuntime
 from horus_runtime.core.target.base import BaseTarget
 from horus_runtime.core.task.status import TaskStatus
@@ -130,6 +131,14 @@ class BaseTask(AutoRegistry, entry_point="task"):
     target: BaseTarget
     """
     The target that indicates where this task should be dispatched.
+    """
+
+    resources: ResourceRequest | None = None
+    """
+    Advisory compute requirements for this task (CPUs, GPUs, memory, …). Read
+    by resource-aware targets (e.g. Slurm, Terraform) when provisioning;
+    targets that do not understand resources ignore it. Defaults to ``None`` so
+    existing workflows and YAML stay valid.
     """
 
     status: TaskStatus = TaskStatus.IDLE

--- a/tests/unit/core/test_resources.py
+++ b/tests/unit/core/test_resources.py
@@ -1,0 +1,103 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Unit tests for the portable ResourceRequest model and its use on BaseTask.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from horus_builtin.executor.shell import ShellExecutor
+from horus_builtin.runtime.command import CommandRuntime
+from horus_builtin.target.local import LocalTarget
+from horus_builtin.task.horus_task import HorusTask
+from horus_runtime.core.resources import ResourceRequest
+
+
+def _make_task(resources: ResourceRequest | None = None) -> HorusTask:
+    """Build a minimal concrete ``HorusTask`` for round-trip checks."""
+    return HorusTask(
+        id="task_id",
+        name="task",
+        runtime=CommandRuntime(command="echo hi"),
+        executor=ShellExecutor(),
+        target=LocalTarget(),
+        resources=resources,
+    )
+
+
+@pytest.mark.unit
+class TestResourceRequest:
+    """Tests for the ResourceRequest pydantic model."""
+
+    def test_defaults(self) -> None:
+        """All fields default to None except gpus, which defaults to 0."""
+        req = ResourceRequest()
+        assert req.cpus is None
+        assert req.gpus == 0
+        assert req.memory_gb is None
+        assert req.vram_gb is None
+        assert req.walltime is None
+
+    def test_explicit_values_are_preserved(self) -> None:
+        """Provided values are stored verbatim."""
+        req = ResourceRequest(
+            cpus=8,
+            gpus=2,
+            memory_gb=64,
+            vram_gb=24,
+            walltime="01:30:00",
+        )
+        assert req.cpus == 8
+        assert req.gpus == 2
+        assert req.memory_gb == 64
+        assert req.vram_gb == 24
+        assert req.walltime == "01:30:00"
+
+    def test_extra_fields_are_forbidden(self) -> None:
+        """Unknown fields raise rather than being silently dropped."""
+        with pytest.raises(ValidationError):
+            ResourceRequest(bogus=1)  # type: ignore[call-arg]
+
+    def test_json_round_trip(self) -> None:
+        """A ResourceRequest survives model_dump(json) -> model_validate."""
+        req = ResourceRequest(cpus=4, gpus=1, memory_gb=16)
+        restored = ResourceRequest.model_validate(req.model_dump(mode="json"))
+        assert restored == req
+
+
+@pytest.mark.unit
+class TestTaskResources:
+    """Tests for the advisory ``resources`` field on BaseTask."""
+
+    def test_resources_default_is_none(self) -> None:
+        """Existing tasks/YAML stay valid: resources defaults to None."""
+        assert _make_task().resources is None
+
+    def test_round_trip_without_resources(self) -> None:
+        """A task with no resources round-trips with resources still None."""
+        task = _make_task()
+        restored = HorusTask.model_validate(task.model_dump(mode="json"))
+        assert restored.resources is None
+
+    def test_round_trip_with_resources(self) -> None:
+        """A task's resources survive model_dump(json) -> model_validate."""
+        resources = ResourceRequest(cpus=4, gpus=1, memory_gb=32)
+        task = _make_task(resources=resources)
+        restored = HorusTask.model_validate(task.model_dump(mode="json"))
+        assert restored.resources == resources

--- a/tests/unit/target/test_target_base.py
+++ b/tests/unit/target/test_target_base.py
@@ -25,6 +25,9 @@ from pathlib import Path
 import pytest
 from pydantic import BaseModel
 
+from horus_builtin.executor.shell import ShellExecutor
+from horus_builtin.runtime.command import CommandRuntime
+from horus_builtin.task.horus_task import HorusTask
 from horus_runtime.core.artifact.base import BaseArtifact
 from horus_runtime.core.target.base import BaseTarget
 from horus_runtime.core.target.channel import ChannelProcess, RemoteDirEntry
@@ -139,3 +142,22 @@ class TestBaseTarget:
         target = ConcreteTestTarget()
         assert isinstance(target.location_id, str)
         assert target.location_id
+
+    def test_bind_sets_task_reference(self) -> None:
+        """
+        bind() associates the task with the target before dispatch so
+        resource-aware targets can read task.resources during provisioning.
+        """
+        target = ConcreteTestTarget()
+        assert target._task is None
+
+        task = HorusTask(
+            id="bind_task",
+            name="bind_task",
+            runtime=CommandRuntime(command="echo hi"),
+            executor=ShellExecutor(),
+            target=target,
+        )
+        target.bind(task)
+
+        assert target._task is task

--- a/tests/unit/workflow/test_builtin_workflow.py
+++ b/tests/unit/workflow/test_builtin_workflow.py
@@ -334,6 +334,52 @@ class TestWorkflowRun:
         assert task_a.runs == 1
         assert task_b.runs == 0
 
+    async def test_run_binds_task_to_target_before_transfer(
+        self,
+        tmp_path: Path,
+        horus_context: HorusContext,
+    ) -> None:
+        """
+        _run must call ``task.target.bind(task)`` before transferring
+        artifacts so resource-aware targets that provision lazily at transfer
+        time can read ``task.resources``. ``_task`` is otherwise only set by
+        dispatch, which runs *after* transfer, so observing it during transfer
+        proves bind ran first.
+        """
+        del horus_context
+        task = HorusTask(
+            id="bind_task",
+            name="bind_task",
+            runtime=CommandRuntime(command="echo hi"),
+            executor=ShellExecutor(),
+            target=LocalTarget(working_directory=tmp_path.as_posix()),
+        )
+        wf = HorusWorkflow(name="bind_order", tasks=[task])
+
+        recorded: dict[str, bool] = {}
+
+        async def _recording_transfer(
+            self: HorusWorkflow,
+            target_task: HorusTask,
+            source_map: object = None,
+        ) -> None:
+            del self, source_map
+            recorded["bound_before_transfer"] = (
+                target_task.target._task is target_task
+            )
+
+        # Patch on the class: pydantic models forbid setattr of non-field
+        # attributes on instances, so an instance-level patch.object fails.
+        with (
+            patch.object(
+                HorusWorkflow, "transfer_artifacts", _recording_transfer
+            ),
+            patch.object(HorusTask, "run", new=AsyncMock()),
+        ):
+            await wf.run(trigger_id="bind_task")
+
+        assert recorded["bound_before_transfer"] is True
+
     async def test_run_empty_workflow_raises_for_missing_trigger(
         self, horus_context: HorusContext
     ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -2,13 +2,6 @@ version = 1
 revision = 3
 requires-python = ">=3.13"
 
-[options]
-exclude-newer = "2026-06-22T10:33:42.434861Z"
-exclude-newer-span = "P2D"
-
-[options.exclude-newer-package]
-horus-runtime = false
-
 [[package]]
 name = "annotated-types"
 version = "0.7.0"


### PR DESCRIPTION
## What
Adds an optional, target-agnostic `ResourceRequest` model (`cpus`, `gpus`, `memory_gb`, `vram_gb`, `walltime`) in `horus_runtime.core.resources` and a `resources: ResourceRequest | None = None` field on `BaseTask`.

Also adds `BaseTarget.bind(task)`, invoked by `HorusWorkflow._run` **before** artifact transfer, so targets that provision lazily at transfer time (e.g. Terraform) can read `task.resources` before `dispatch` sets the task reference.

## Why
A portable way for a task to declare compute needs. Resource-aware targets (Slurm, Terraform) translate the hints into their own provisioning; targets that ignore them are unaffected. The field defaults to `None`, so existing workflows and YAML are unchanged.

## Notes
- Fully additive / backward compatible.
- Foundation for the Slurm target (#2) and consumed by a follow-up horus-terraform PR.

Closes #90

https://github.com/temple-compute/horus-docs/pull/28