### PR TITLE
feat(cli): 'horus run' workflow runner + live Rich TUI (#89)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
   "pydantic~=2.0",
   "pydantic_settings~=2.0",
   "pyyaml~=6.0",
+  "rich>=13.7",
 ]
 
 [project.scripts]

--- a/src/horus_builtin/event/tui_subscriber.py
+++ b/src/horus_builtin/event/tui_subscriber.py
@@ -16,30 +16,54 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 """
-Live terminal UI for a running workflow.
+Live terminal dashboard for a running workflow.
 
-``WorkflowTUISubscriber`` subscribes to the event bus and repaints a Rich table
-of the workflow's tasks and their statuses as events arrive. It is **opt-in**:
-the CLI constructs it and attaches it with ``bus.subscribe(...)``. It sets
-``add_to_registry = False`` so the bus does not auto-instantiate it on startup
-(registry subscribers are created with no arguments).
+``WorkflowTUISubscriber`` is an **opt-in** event-bus subscriber that renders a
+live Rich dashboard while a workflow runs: a header (workflow status + wall
+clock), a task progress bar, a per-task table beside the dependency DAG, a
+scrolling log/event pane, and a failure panel.
 """
 
+import asyncio
+import sys
+import time
+from collections import deque
 from collections.abc import Iterator
 from contextlib import contextmanager
-from typing import ClassVar
+from typing import TYPE_CHECKING, ClassVar, NamedTuple
 
 from pydantic import PrivateAttr
-from rich.console import Console
+from rich.columns import Columns
+from rich.console import Console, Group, RenderableType
 from rich.live import Live
+from rich.panel import Panel
+from rich.progress_bar import ProgressBar
 from rich.table import Table
 from rich.text import Text
+from rich.tree import Tree
 
+from horus_builtin.event.artifact_event import ArtifactEvent
+from horus_builtin.event.task_event import HorusTaskEvent
+from horus_builtin.event.workflow_event import HorusWorkflowEvent
+from horus_builtin.workflow.dag import build_dependencies, execution_plan
 from horus_runtime.context import HorusContext
+from horus_runtime.core.interaction.transport import (
+    InteractionAnsweredEvent,
+    InteractionAskedEvent,
+    InteractionFailedEvent,
+)
+from horus_runtime.core.task.base import BaseTask
 from horus_runtime.core.task.status import TaskStatus
 from horus_runtime.core.workflow.base import BaseWorkflow
+from horus_runtime.core.workflow.status import WorkflowStatus
 from horus_runtime.event.base import BaseEvent
 from horus_runtime.event.subscriber import BaseEventSubscriber, EventFilterType
+from horus_runtime.i18n import tr as _
+from horus_runtime.logging import horus_logger
+
+if TYPE_CHECKING:
+    from loguru import Message
+
 
 #: Rich style per task status.
 _STATUS_STYLE: dict[TaskStatus, str] = {
@@ -51,64 +75,504 @@ _STATUS_STYLE: dict[TaskStatus, str] = {
     TaskStatus.CANCELED: "magenta",
 }
 
+# Glyph per task status (RUNNING uses an animated spinner instead).
+_STATUS_GLYPH: dict[TaskStatus, str] = {
+    TaskStatus.IDLE: "◌",
+    TaskStatus.PENDING: "◔",
+    TaskStatus.RUNNING: "●",
+    TaskStatus.COMPLETED: "✓",
+    TaskStatus.FAILED: "✗",
+    TaskStatus.CANCELED: "⊘",
+}
+
+# Rich style per workflow status.
+_WF_STATUS_STYLE: dict[WorkflowStatus, str] = {
+    WorkflowStatus.IDLE: "dim",
+    WorkflowStatus.QUEUED: "cyan",
+    WorkflowStatus.RUNNING: "bold yellow",
+    WorkflowStatus.COMPLETED: "bold green",
+    WorkflowStatus.FAILED: "bold red",
+    WorkflowStatus.CANCELED: "magenta",
+    WorkflowStatus.PARTIAL: "yellow",
+}
+
+# Verify all statuses are covered.
+assert _STATUS_STYLE.keys() == set(TaskStatus), (
+    f"TUI - missing styles for: {set(TaskStatus) - _STATUS_STYLE.keys()}"
+)
+assert _STATUS_GLYPH.keys() == set(TaskStatus), (
+    f"TUI - missing glyphs for: {set(TaskStatus) - _STATUS_GLYPH.keys()}"
+)
+assert _WF_STATUS_STYLE.keys() == set(WorkflowStatus), (
+    "TUI - missing styles for: "
+    f"{set(WorkflowStatus) - _WF_STATUS_STYLE.keys()}"
+)
+
+
+# Rich style per loguru/event level, for the log pane.
+_LEVEL_STYLE: dict[str, str] = {
+    "CRITICAL": "bold red",
+    "ERROR": "red",
+    "WARNING": "yellow",
+    "INFO": "white",
+    "DEBUG": "dim",
+    "TRACE": "dim",
+}
+
+# Tasks in a terminal state count as "executed" for the progress bar.
+_TERMINAL: frozenset[TaskStatus] = frozenset(
+    {TaskStatus.COMPLETED, TaskStatus.FAILED, TaskStatus.CANCELED}
+)
+
+_SPINNER_FRAMES = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
+_SECONDS_PER_MINUTE = 60
+
+# How many log lines to show in the pane, and how long (seconds) the transient
+# "transferring artifact" indicator stays visible after the last event.
+_LOG_LINES = 8
+_TRANSFER_LINGER_S = 2.0
+
+
+class _LogLine(NamedTuple):
+    """One rendered entry in the log/event pane."""
+
+    when: float  # epoch seconds, for HH:MM:SS formatting
+    style: str
+    icon: str
+    text: str
+
+
+def _make_console() -> Console:
+    """
+    Console bound to the *real* stdout.
+
+    Binding to ``sys.__stdout__`` keeps ``is_terminal`` stable and writes
+    frames to the real terminal.
+    """
+    return Console(file=sys.__stdout__ or sys.stdout)
+
+
+def _spinner_frame() -> str:
+    """Pick a spinner glyph from the wall clock (animates via Live refresh)."""
+    return _SPINNER_FRAMES[int(time.monotonic() * 10) % len(_SPINNER_FRAMES)]
+
+
+def _fmt_duration(seconds: float | None) -> str:
+    """Human-readable elapsed time, e.g. ``1.2s`` or ``3m04s``."""
+    if seconds is None:
+        return "—"
+    if seconds < _SECONDS_PER_MINUTE:
+        return f"{seconds:.1f}s"
+    minutes, secs = divmod(int(seconds), _SECONDS_PER_MINUTE)
+    return f"{minutes}m{secs:02d}s"
+
+
+def _fmt_resources(task: BaseTask) -> str:
+    """Compact ``cpus/gpus/mem/walltime`` summary, blank if unspecified."""
+    res = task.resources
+    if res is None:
+        return ""
+
+    parts: list[str] = []
+    if res.cpus is not None:
+        parts.append(f"{res.cpus}cpu")
+    if res.gpus is not None:
+        parts.append(f"{res.gpus}gpu")
+    if res.memory_gb is not None:
+        parts.append(f"{res.memory_gb}G")
+    if res.walltime is not None:
+        parts.append(str(res.walltime))
+
+    return " ".join(parts)
+
+
+def _fmt_target(task: BaseTask) -> str:
+    """``kind`` of the task's target (plus location when cheaply available)."""
+    target = task.target
+    if target is None:
+        return ""
+
+    kind = target.kind
+    try:
+        location = target.location_id
+    except Exception:
+        return kind
+
+    if location and location not in (kind, ""):
+        return f"{kind}·{location}"
+
+    return kind
+
+
+class _DashboardView:
+    """
+    Thin renderable so Rich ``Live`` recomputes the dashboard every frame.
+    """
+
+    def __init__(self, subscriber: "WorkflowTUISubscriber") -> None:
+        self._subscriber = subscriber
+
+    def __rich__(self) -> RenderableType:
+        return self._subscriber.render()
+
 
 class WorkflowTUISubscriber(BaseEventSubscriber):
     """
-    Render a live table of workflow task statuses from the event bus.
+    Render a live dashboard of a running workflow from the event bus.
     """
 
     # Opt-in only: never auto-registered, so bus.start() won't construct it.
     add_to_registry: ClassVar[bool] = False
     subscriber_type: str = "workflow_tui"
-    # Subscribe to every event; any event may change a task's status.
+    # Subscribe to every event.
     events: ClassVar[EventFilterType] = (BaseEvent,)
 
-    _console: Console = PrivateAttr(default_factory=Console)
+    _console: Console = PrivateAttr(default_factory=_make_console)
     _live: Live | None = PrivateAttr(default=None)
     _workflow: BaseWorkflow | None = PrivateAttr(default=None)
+
+    # Execution scope (planned task ids) for an honest progress total.
+    _scope: set[str] = PrivateAttr(default_factory=set)
+    _started_at: float | None = PrivateAttr(default=None)
+
+    # Per-task timing, derived from status transitions / completion events.
+    _start: dict[str, float] = PrivateAttr(default_factory=dict)
+    _elapsed: dict[str, float] = PrivateAttr(default_factory=dict)
+
+    _log: deque[_LogLine] = PrivateAttr(
+        default_factory=lambda: deque(maxlen=500)
+    )
+    _last_transfer: tuple[str, float] | None = PrivateAttr(default=None)
+    _error: tuple[str, str] | None = PrivateAttr(default=None)
+    _paused: bool = PrivateAttr(default=False)
 
     def setup(self) -> None:
         """No startup work needed."""
 
-    def track(self, workflow: BaseWorkflow) -> None:
-        """Render *workflow*'s tasks (so all rows show before the run starts).
-
-        If never called, :meth:`render` falls back to the active workflow on
-        the context.
+    def track(
+        self, workflow: BaseWorkflow, trigger_id: str | None = None
+    ) -> None:
+        """
+        Render *workflow*'s tasks before the run starts.
         """
         self._workflow = workflow
+        try:
+            target = trigger_id or (
+                workflow.tasks[0].id if workflow.tasks else None
+            )
+            if target is not None:
+                self._scope = set(
+                    execution_plan(
+                        workflow.tasks, trigger_id=target, edges=workflow.edges
+                    )
+                )
+        except Exception:
+            self._scope = {t.id for t in workflow.tasks}
 
     @contextmanager
     def live(self) -> Iterator[None]:
-        """Drive a Rich ``Live`` display for the ``with`` body."""
-        with Live(
-            self.render(),
-            console=self._console,
-            refresh_per_second=8,
-            transient=False,
-        ) as live:
-            self._live = live
-            try:
-                yield
-            finally:
-                # Final repaint so the terminating statuses are shown.
-                live.update(self.render())
-                self._live = None
+        """Drive the Rich ``Live`` dashboard for the ``with`` body.
+
+        Redirects loguru's terminal sink into the log pane for the duration so
+        log lines never corrupt the display, restoring it on exit.
+        """
+        horus_logger.redirect_terminal(self._log_sink)
+        self._started_at = time.monotonic()
+        view = _DashboardView(self)
+        try:
+            with Live(
+                view,
+                console=self._console,
+                refresh_per_second=10,
+                transient=False,
+            ) as live:
+                self._live = live
+                try:
+                    yield
+                except BaseException as exc:
+                    self._capture_error(exc)
+                    raise
+                finally:
+                    self._live = None
+                    # Final repaint so terminating statuses (and any error
+                    # panel) are shown before Live tears down.
+                    live.update(view)
+        finally:
+            horus_logger.restore_terminal()
 
     def handle(self, event: BaseEvent) -> None:
-        """Repaint the table whenever an event arrives."""
-        del event
-        if self._live is not None:
-            self._live.update(self.render())
+        """React to bus events: pause for interactions, feed the log pane."""
+        # If the interaction is asked, pause the live dashboard so the
+        # prompt is clean.
+        if isinstance(event, InteractionAskedEvent):
+            self._pause()
+            return
 
-    def render(self) -> Table:
-        """Build the task-status table from the tracked/active workflow."""
-        workflow = self._workflow or HorusContext.get_context().workflow
-        table = Table(title=workflow.name if workflow else "Workflow")
-        table.add_column("Task", no_wrap=True)
-        table.add_column("Status")
-        if workflow is not None:
-            for task in workflow.tasks:
-                style = _STATUS_STYLE.get(task.status, "white")
-                table.add_row(task.name, Text(task.status.value, style=style))
+        # If the interaction is answered or failed, resume the live dashboard.
+        if isinstance(
+            event, (InteractionAnsweredEvent, InteractionFailedEvent)
+        ):
+            self._resume()
+
+        self._note_timings()
+        self._record_log(event)
+
+        if isinstance(event, ArtifactEvent):
+            self._last_transfer = (event.artifact_id, time.monotonic())
+
+    def _pause(self) -> None:
+        """Stop the Live so an interaction prompt has a clean terminal."""
+        if self._live is not None and not self._paused:
+            self._live.stop()
+            self._paused = True
+
+    def _resume(self) -> None:
+        """Restart the Live after an interaction completes."""
+        if self._live is not None and self._paused:
+            self._live.start(refresh=True)
+            self._paused = False
+
+    def _note_timings(self) -> None:
+        """Record per-task start/elapsed from the live workflow statuses."""
+        workflow = self._workflow
+        if workflow is None:
+            return
+        now = time.monotonic()
+        for task in workflow.tasks:
+            if task.status is TaskStatus.RUNNING:
+                self._start.setdefault(task.id, now)
+            elif (
+                task.status in _TERMINAL
+                and task.id in self._start
+                and task.id not in self._elapsed
+            ):
+                self._elapsed[task.id] = now - self._start[task.id]
+
+    def _task_elapsed(self, task: "BaseTask") -> float | None:
+        """Elapsed seconds for *task*: live for RUNNING, frozen once done."""
+        if task.id in self._elapsed:
+            return self._elapsed[task.id]
+        if task.status is TaskStatus.RUNNING:
+            start = self._start.get(task.id)
+            return None if start is None else time.monotonic() - start
+        return None
+
+    def _record_log(self, event: BaseEvent) -> None:
+        """Append a curated notification line for an event.
+
+        Events are the single source for these lines; the loguru sink skips the
+        ``LogsSubscriber`` echoes (see :meth:`_log_sink`) so each shows once.
+        """
+        if isinstance(event, HorusTaskEvent):
+            icon, style = "▶", "white"
+        elif isinstance(event, ArtifactEvent):
+            icon, style = "⇅", "cyan"
+        elif isinstance(event, HorusWorkflowEvent):
+            icon, style = "◆", "magenta"
+        else:
+            icon, style = "·", _LEVEL_STYLE.get(event.level, "white")
+        if not event.message:
+            return  # nothing useful to show for an empty-message event
+        self._log.append(
+            _LogLine(time.time(), style, icon, str(event.message))
+        )
+
+    def _log_sink(self, message: "Message") -> None:
+        """
+        Loguru sink: push genuine log records into the pane (not stdout).
+        """
+        record = message.record
+        name = record["name"] or ""
+        if name.endswith("event.log_subscriber"):
+            return
+        style = _LEVEL_STYLE.get(record["level"].name, "white")
+        self._log.append(
+            _LogLine(record["time"].timestamp(), style, "•", record["message"])
+        )
+
+    def _capture_error(self, exc: BaseException) -> None:
+        """Remember the failed task + error for the failure panel."""
+        name = exc.__class__.__name__
+        if self._workflow is not None:
+            for task in self._workflow.tasks:
+                if task.status is TaskStatus.FAILED:
+                    name = task.name
+                    break
+        self._error = (name, str(exc) or exc.__class__.__name__)
+
+    def render(self) -> RenderableType:
+        """Compose the full dashboard."""
+        workflow = self._workflow
+        if workflow is None:
+            try:
+                workflow = HorusContext.get_context().workflow
+            except Exception:  # no booted context → nothing to show
+                workflow = None
+
+        if workflow is None:
+            return Panel(Text(_("No active workflow."), style="dim"))
+
+        sections: list[RenderableType] = [
+            self._render_header(workflow),
+            self._render_progress(workflow),
+            Columns(
+                [self._render_table(workflow), self._render_tree(workflow)],
+                expand=True,
+            ),
+            self._render_log(),
+        ]
+        if self._error is not None:
+            sections.append(self._render_error())
+        return Group(*sections)
+
+    def _render_header(self, workflow: BaseWorkflow) -> RenderableType:
+        status = workflow.status
+        style = _WF_STATUS_STYLE.get(status, "white")
+        elapsed = (
+            None
+            if self._started_at is None
+            else time.monotonic() - self._started_at
+        )
+        line = Text.assemble(
+            (workflow.name, "bold"),
+            ("  ·  ", "dim"),
+            (status.value.upper(), style),
+            ("  ·  ", "dim"),
+            (_("elapsed ") + _fmt_duration(elapsed), "dim"),
+        )
+        if self._last_transfer is not None:
+            art_id, when = self._last_transfer
+            if time.monotonic() - when < _TRANSFER_LINGER_S:
+                line.append("\n")
+                line.append(
+                    _("⇅ transferring artifact %(id)s") % {"id": art_id},
+                    style="cyan",
+                )
+        return Panel(line, border_style=style, padding=(0, 1))
+
+    def _render_progress(self, workflow: BaseWorkflow) -> RenderableType:
+        scope = self._scope or {t.id for t in workflow.tasks}
+        total = len(scope)
+        tasks = [t for t in workflow.tasks if t.id in scope]
+        done = sum(1 for t in tasks if t.status in _TERMINAL)
+        failed = any(t.status is TaskStatus.FAILED for t in tasks)
+        bar = ProgressBar(
+            total=max(total, 1),
+            completed=done,
+            width=40,
+            complete_style="red" if failed else "green",
+            finished_style="red" if failed else "green",
+        )
+        label = Text(f"  {done}/{total} " + _("tasks"), style="bold")
+        grid = Table.grid(padding=(0, 1))
+        grid.add_row(bar, label)
+        return grid
+
+    def _render_table(self, workflow: BaseWorkflow) -> RenderableType:
+        table = Table(
+            title=_("Tasks"),
+            title_style="bold",
+            expand=True,
+            header_style="dim",
+        )
+        table.add_column("", no_wrap=True, width=2)
+        table.add_column(_("Task"), no_wrap=True)
+        table.add_column(_("Target"), style="dim")
+        table.add_column(_("Resources"), style="dim")
+        table.add_column(_("Elapsed"), justify="right")
+        table.add_column(_("Runs"), justify="right", style="dim")
+        for task in workflow.tasks:
+            style = _STATUS_STYLE.get(task.status, "white")
+            if task.status is TaskStatus.RUNNING:
+                glyph = Text(_spinner_frame(), style=style)
+            else:
+                glyph = Text(_STATUS_GLYPH.get(task.status, "?"), style=style)
+            table.add_row(
+                glyph,
+                Text(task.name, style=style),
+                _fmt_target(task),
+                _fmt_resources(task),
+                _fmt_duration(self._task_elapsed(task)),
+                str(getattr(task, "runs", "")),
+            )
         return table
+
+    def _render_tree(self, workflow: BaseWorkflow) -> RenderableType:
+        """Dependency DAG, nodes colored by current status."""
+        deps = build_dependencies(workflow.tasks, workflow.edges)
+        names = {t.id: t.name for t in workflow.tasks}
+        status = {t.id: t.status for t in workflow.tasks}
+        # Children of each task (inverse of dependencies) + the roots.
+        children: dict[str, list[str]] = {tid: [] for tid in deps}
+        for tid, upstream in deps.items():
+            for up in upstream:
+                children[up].append(tid)
+        roots = [tid for tid, up in deps.items() if not up]
+
+        tree = Tree(_("Dependencies"), style="bold")
+
+        def add(node: Tree, tid: str, seen: set[str]) -> None:
+            if tid in seen:  # guard against cycles in display
+                return
+            seen.add(tid)
+            style = _STATUS_STYLE.get(
+                status.get(tid, TaskStatus.IDLE), "white"
+            )
+            branch = node.add(Text(names.get(tid, tid), style=style))
+            for child in children.get(tid, []):
+                add(branch, child, seen)
+
+        for root in roots:
+            add(tree, root, set())
+        return (
+            Panel(tree, padding=(0, 1))
+            if roots
+            else Panel(Text(_("no dependencies"), style="dim"))
+        )
+
+    def _render_log(self) -> RenderableType:
+        lines = list(self._log)[-_LOG_LINES:]
+        if not lines:
+            body: RenderableType = Text(_("waiting for events…"), style="dim")
+        else:
+            text = Text()
+            for i, entry in enumerate(lines):
+                if i:
+                    text.append("\n")
+                stamp = time.strftime("%H:%M:%S", time.localtime(entry.when))
+                text.append(f"{stamp} ", style="dim")
+                text.append(f"{entry.icon} ", style=entry.style)
+                text.append(entry.text, style=entry.style)
+            body = text
+        return Panel(body, title=_("Log"), title_align="left", padding=(0, 1))
+
+    def _render_error(self) -> RenderableType:
+        assert self._error is not None
+        name, message = self._error
+        body = Text.assemble(
+            (name + "\n", "bold red"),
+            (message, "red"),
+        )
+        return Panel(
+            body, title=_("Failed"), border_style="red", padding=(0, 1)
+        )
+
+
+def render_workflow(workflow: BaseWorkflow, trigger_id: str) -> None:
+    """
+    Run the body under the live dashboard, the same one ``horus run`` uses.
+
+    Use this to drive a Python-defined workflow (one that can't be expressed in
+    YAML, e.g. ``FunctionTask`` interactions) with the TUI. The runtime must
+    already be booted::
+
+        ctx = HorusContext.boot()
+        render_workflow(wf, trigger_id="first")
+    """
+    ctx = HorusContext.get_context()
+    tui = WorkflowTUISubscriber()
+    tui.setup()
+    tui.track(workflow, trigger_id=trigger_id)
+    ctx.bus.subscribe(tui)
+    with tui.live():
+        asyncio.run(workflow.run(trigger_id=trigger_id))

--- a/src/horus_builtin/event/tui_subscriber.py
+++ b/src/horus_builtin/event/tui_subscriber.py
@@ -1,0 +1,114 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Live terminal UI for a running workflow.
+
+``WorkflowTUISubscriber`` subscribes to the event bus and repaints a Rich table
+of the workflow's tasks and their statuses as events arrive. It is **opt-in**:
+the CLI constructs it and attaches it with ``bus.subscribe(...)``. It sets
+``add_to_registry = False`` so the bus does not auto-instantiate it on startup
+(registry subscribers are created with no arguments).
+"""
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import ClassVar
+
+from pydantic import PrivateAttr
+from rich.console import Console
+from rich.live import Live
+from rich.table import Table
+from rich.text import Text
+
+from horus_runtime.context import HorusContext
+from horus_runtime.core.task.status import TaskStatus
+from horus_runtime.core.workflow.base import BaseWorkflow
+from horus_runtime.event.base import BaseEvent
+from horus_runtime.event.subscriber import BaseEventSubscriber, EventFilterType
+
+#: Rich style per task status.
+_STATUS_STYLE: dict[TaskStatus, str] = {
+    TaskStatus.IDLE: "dim",
+    TaskStatus.PENDING: "cyan",
+    TaskStatus.RUNNING: "bold yellow",
+    TaskStatus.COMPLETED: "bold green",
+    TaskStatus.FAILED: "bold red",
+    TaskStatus.CANCELED: "magenta",
+}
+
+
+class WorkflowTUISubscriber(BaseEventSubscriber):
+    """
+    Render a live table of workflow task statuses from the event bus.
+    """
+
+    # Opt-in only: never auto-registered, so bus.start() won't construct it.
+    add_to_registry: ClassVar[bool] = False
+    subscriber_type: str = "workflow_tui"
+    # Subscribe to every event; any event may change a task's status.
+    events: ClassVar[EventFilterType] = (BaseEvent,)
+
+    _console: Console = PrivateAttr(default_factory=Console)
+    _live: Live | None = PrivateAttr(default=None)
+    _workflow: BaseWorkflow | None = PrivateAttr(default=None)
+
+    def setup(self) -> None:
+        """No startup work needed."""
+
+    def track(self, workflow: BaseWorkflow) -> None:
+        """Render *workflow*'s tasks (so all rows show before the run starts).
+
+        If never called, :meth:`render` falls back to the active workflow on
+        the context.
+        """
+        self._workflow = workflow
+
+    @contextmanager
+    def live(self) -> Iterator[None]:
+        """Drive a Rich ``Live`` display for the ``with`` body."""
+        with Live(
+            self.render(),
+            console=self._console,
+            refresh_per_second=8,
+            transient=False,
+        ) as live:
+            self._live = live
+            try:
+                yield
+            finally:
+                # Final repaint so the terminating statuses are shown.
+                live.update(self.render())
+                self._live = None
+
+    def handle(self, event: BaseEvent) -> None:
+        """Repaint the table whenever an event arrives."""
+        del event
+        if self._live is not None:
+            self._live.update(self.render())
+
+    def render(self) -> Table:
+        """Build the task-status table from the tracked/active workflow."""
+        workflow = self._workflow or HorusContext.get_context().workflow
+        table = Table(title=workflow.name if workflow else "Workflow")
+        table.add_column("Task", no_wrap=True)
+        table.add_column("Status")
+        if workflow is not None:
+            for task in workflow.tasks:
+                style = _STATUS_STYLE.get(task.status, "white")
+                table.add_row(task.name, Text(task.status.value, style=style))
+        return table

--- a/src/horus_builtin/interaction/cli.py
+++ b/src/horus_builtin/interaction/cli.py
@@ -21,6 +21,10 @@ CLI interaction transport and renderers for common interactions.
 
 from typing import ClassVar
 
+from rich.console import Console
+from rich.prompt import Prompt
+from rich.text import Text
+
 from horus_builtin.interaction.common.confirm import ConfirmInteraction
 from horus_builtin.interaction.common.dropdown import DropdownInteraction
 from horus_builtin.interaction.common.file import FileInteraction
@@ -30,6 +34,10 @@ from horus_runtime.core.interaction.renderer import (
 )
 from horus_runtime.core.interaction.transport import BaseInteractionTransport
 from horus_runtime.i18n import tr as _
+
+#: Shared console for prompts. The live TUI pauses its display (via the
+#: interaction events) before a prompt runs, so writing here is safe.
+_console = Console()
 
 
 class CLIInteractionTransport(BaseInteractionTransport):
@@ -49,23 +57,18 @@ class CLIInteractionTransport(BaseInteractionTransport):
         placeholder: str | None = None,
     ) -> str:
         """
-        Ask for free-form text input.
+        Ask for free-form text input, returning the raw string answer.
         """
-        lines = []
         if title is not None:
-            lines.append(title)
-        if prompt is not None:
-            lines.append(prompt)
-        if default is not None:
-            lines.append(_("(default: %(default)s)") % {"default": default})
+            _console.print(Text(title, style="bold"))
+        question = prompt or _("Input")
         if placeholder is not None:
-            lines.append(
-                _("(placeholder: %(placeholder)s)")
-                % {"placeholder": placeholder}
-            )
-        lines.append("> ")
-        data = "\n".join(lines)
-        return input(data)
+            question += _(" (e.g. %(placeholder)s)") % {
+                "placeholder": placeholder
+            }
+        if default is None:
+            return Prompt.ask(question, console=_console)
+        return Prompt.ask(question, console=_console, default=default)
 
 
 class CLIStringRenderer(

--- a/src/horus_runtime/cli.py
+++ b/src/horus_runtime/cli.py
@@ -25,19 +25,23 @@ from pathlib import Path
 
 import click
 
-from horus_builtin.event.tui_subscriber import WorkflowTUISubscriber
+from horus_builtin.event.tui_subscriber import render_workflow
 from horus_builtin.workflow.horus_workflow import HorusWorkflow
 from horus_runtime.context import HorusContext
 from horus_runtime.i18n import tr as _
 from horus_runtime.version import __version__ as horus_version
 
 
-@click.group()
+@click.group(invoke_without_command=True)
 @click.version_option(version=horus_version, prog_name="Horus Runtime")
-def main() -> None:
+@click.pass_context
+def main(ctx: click.Context) -> None:
     """
     Run workflows and tasks using the Horus Runtime.
     """
+    # Bare `horus` (no subcommand) shows help rather than doing nothing.
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
 
 
 @main.command()
@@ -73,11 +77,8 @@ def run(workflow_yaml: Path, trigger_id: str | None, no_tui: bool) -> None:
         if no_tui:
             asyncio.run(workflow.run(trigger_id=trigger))
         else:
-            tui = WorkflowTUISubscriber()
-            tui.track(workflow)
-            ctx.bus.subscribe(tui)
-            with tui.live():
-                asyncio.run(workflow.run(trigger_id=trigger))
+            render_workflow(workflow, trigger_id=trigger)
+
     except click.ClickException:
         raise
     except Exception as exc:

--- a/src/horus_runtime/cli.py
+++ b/src/horus_runtime/cli.py
@@ -20,24 +20,71 @@
 Entrypoint for horus-runtime.
 """
 
+import asyncio
+from pathlib import Path
+
 import click
 
+from horus_builtin.event.tui_subscriber import WorkflowTUISubscriber
+from horus_builtin.workflow.horus_workflow import HorusWorkflow
 from horus_runtime.context import HorusContext
+from horus_runtime.i18n import tr as _
 from horus_runtime.version import __version__ as horus_version
 
 
-@click.command()
+@click.group()
 @click.version_option(version=horus_version, prog_name="Horus Runtime")
 def main() -> None:
     """
     Run workflows and tasks using the Horus Runtime.
     """
-    # Boot the runtime to initialize logging, load plugins,
-    # and set up global context
-    ctx = HorusContext.boot()
 
-    # Finish the application lifecycle.
-    ctx.shutdown()
+
+@main.command()
+@click.argument(
+    "workflow_yaml",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+)
+@click.option(
+    "--trigger",
+    "trigger_id",
+    default=None,
+    help="Task id to trigger. Defaults to the first task in the workflow.",
+)
+@click.option(
+    "--no-tui",
+    is_flag=True,
+    help="Disable the live TUI; stream log output only.",
+)
+def run(workflow_yaml: Path, trigger_id: str | None, no_tui: bool) -> None:
+    """
+    Run the workflow defined in WORKFLOW_YAML.
+
+    Boots the runtime, loads the workflow, and executes it from the trigger
+    task downstream. Exits non-zero if the workflow fails.
+    """
+    ctx = HorusContext.boot()
+    try:
+        workflow = HorusWorkflow.from_yaml(workflow_yaml)
+        if not workflow.tasks:
+            raise click.ClickException(_("Workflow has no tasks to run."))
+        trigger = trigger_id or workflow.tasks[0].id
+
+        if no_tui:
+            asyncio.run(workflow.run(trigger_id=trigger))
+        else:
+            tui = WorkflowTUISubscriber()
+            tui.track(workflow)
+            ctx.bus.subscribe(tui)
+            with tui.live():
+                asyncio.run(workflow.run(trigger_id=trigger))
+    except click.ClickException:
+        raise
+    except Exception as exc:
+        # Surface any workflow/loading failure as a non-zero CLI exit.
+        raise click.ClickException(str(exc)) from exc
+    finally:
+        ctx.shutdown()
 
 
 if __name__ == "__main__":

--- a/src/horus_runtime/logging.py
+++ b/src/horus_runtime/logging.py
@@ -20,15 +20,16 @@ Loguru setup for horus-runtime.
 """
 
 import sys
+from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Literal
 
 from loguru import logger
 
 if TYPE_CHECKING:
-    from loguru import Logger
+    from loguru import Logger, Message
 
-from pydantic import BeforeValidator
+from pydantic import BeforeValidator, PrivateAttr
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 HORUS_LOG_ENV_PREFIX = "HORUS_LOG_"
@@ -62,6 +63,11 @@ class HorusLogger(BaseSettings):
     compression: str | None = None
     filename_template: str = "log_{time:YYYY-MM-DD}.log"
 
+    #: Loguru handler id of the terminal sink, tracked so it can be swapped
+    #: (e.g. the live TUI redirects it to a panel) without touching the file
+    #: sink. ``None`` until :meth:`setup` runs.
+    _terminal_sink_id: int | None = PrivateAttr(default=None)
+
     @property
     def log(self) -> "Logger":
         """
@@ -91,8 +97,31 @@ class HorusLogger(BaseSettings):
             enqueue=True,
         )
 
-        # Add terminal logging as well
-        logger.add(
+        # Add terminal logging as well, tracking its id so it can be swapped.
+        self._terminal_sink_id = logger.add(
+            sink=sys.stdout,
+            format=self.format,
+            level=self.level,
+        )
+
+    def redirect_terminal(self, sink: "Callable[[Message], None]") -> None:
+        """
+        Replace the terminal (stdout) sink with *sink*, leaving the file sink
+        intact. Used by the live TUI to capture log records into a panel
+        instead of corrupting the Rich display. ``sink`` receives loguru
+        ``Message`` objects (``message.record`` holds the structured fields).
+        """
+        if self._terminal_sink_id is not None:
+            logger.remove(self._terminal_sink_id)
+        self._terminal_sink_id = logger.add(sink=sink, level=self.level)
+
+    def restore_terminal(self) -> None:
+        """
+        Restore stdout terminal logging after :meth:`redirect_terminal`.
+        """
+        if self._terminal_sink_id is not None:
+            logger.remove(self._terminal_sink_id)
+        self._terminal_sink_id = logger.add(
             sink=sys.stdout,
             format=self.format,
             level=self.level,

--- a/src/horus_runtime/logging.py
+++ b/src/horus_runtime/logging.py
@@ -107,9 +107,7 @@ class HorusLogger(BaseSettings):
     def redirect_terminal(self, sink: "Callable[[Message], None]") -> None:
         """
         Replace the terminal (stdout) sink with *sink*, leaving the file sink
-        intact. Used by the live TUI to capture log records into a panel
-        instead of corrupting the Rich display. ``sink`` receives loguru
-        ``Message`` objects (``message.record`` holds the structured fields).
+        intact. Used by the live TUI to capture log records into a panel.
         """
         if self._terminal_sink_id is not None:
             logger.remove(self._terminal_sink_id)

--- a/tests/integration/test_runtime_integration.py
+++ b/tests/integration/test_runtime_integration.py
@@ -32,16 +32,17 @@ class TestHorusRuntimeIntegration:
 
     def test_main_script_execution(self) -> None:
         """
-        Test that main script can be executed.
+        Test that the main script runs and exposes the run command.
         """
         result = subprocess.run(
-            ["horus"],
+            ["horus", "--help"],
             capture_output=True,
             text=True,
             check=False,
         )
 
         assert result.returncode == 0
+        assert "run" in result.stdout
 
     @pytest.mark.slow
     def test_system_integration(self) -> None:

--- a/tests/unit/cli/test_run.py
+++ b/tests/unit/cli/test_run.py
@@ -1,0 +1,98 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Unit tests for the ``horus run`` CLI command.
+"""
+
+import textwrap
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from horus_runtime.cli import main
+
+
+def _write_workflow(
+    tmp_path: Path, *, command: str = "true", with_task: bool = True
+) -> Path:
+    """Write a minimal one-task workflow YAML and return its path."""
+    if with_task:
+        body = textwrap.dedent(f"""\
+            name: cli_test_wf
+            kind: horus_workflow
+            tasks:
+              - id: t1
+                name: Task One
+                kind: horus_task
+                runtime:
+                  kind: command
+                  command: "{command}"
+                executor:
+                  kind: shell
+            """)
+    else:
+        body = "name: empty_wf\nkind: horus_workflow\ntasks: []\n"
+    wf = tmp_path / "workflow.yaml"
+    wf.write_text(body)
+    return wf
+
+
+@pytest.mark.unit
+class TestRunCommand:
+    """Tests for ``horus run``."""
+
+    def test_run_no_tui_succeeds(self, tmp_path: Path) -> None:
+        """A valid workflow runs to completion and exits 0."""
+        wf = _write_workflow(tmp_path)
+        result = CliRunner().invoke(main, ["run", str(wf), "--no-tui"])
+        assert result.exit_code == 0, result.output
+
+    def test_run_with_tui_succeeds(self, tmp_path: Path) -> None:
+        """The default (TUI) path also runs to completion."""
+        wf = _write_workflow(tmp_path)
+        result = CliRunner().invoke(main, ["run", str(wf)])
+        assert result.exit_code == 0, result.output
+
+    def test_run_explicit_trigger(self, tmp_path: Path) -> None:
+        """An explicit --trigger is honored."""
+        wf = _write_workflow(tmp_path)
+        result = CliRunner().invoke(
+            main, ["run", str(wf), "--trigger", "t1", "--no-tui"]
+        )
+        assert result.exit_code == 0, result.output
+
+    def test_run_empty_workflow_errors(self, tmp_path: Path) -> None:
+        """A workflow with no tasks exits non-zero with a clear message."""
+        wf = _write_workflow(tmp_path, with_task=False)
+        result = CliRunner().invoke(main, ["run", str(wf), "--no-tui"])
+        assert result.exit_code != 0
+        assert "no tasks" in result.output.lower()
+
+    def test_run_failing_task_errors(self, tmp_path: Path) -> None:
+        """A failing task surfaces as a non-zero CLI exit."""
+        wf = _write_workflow(tmp_path, command="false")
+        result = CliRunner().invoke(main, ["run", str(wf), "--no-tui"])
+        assert result.exit_code != 0
+
+    def test_run_missing_file_errors(self, tmp_path: Path) -> None:
+        """A non-existent workflow path is rejected by click."""
+        result = CliRunner().invoke(
+            main, ["run", str(tmp_path / "nope.yaml"), "--no-tui"]
+        )
+        assert result.exit_code != 0

--- a/tests/unit/event/test_tui_subscriber.py
+++ b/tests/unit/event/test_tui_subscriber.py
@@ -28,6 +28,10 @@ from horus_builtin.executor.shell import ShellExecutor
 from horus_builtin.runtime.command import CommandRuntime
 from horus_builtin.task.horus_task import HorusTask
 from horus_builtin.workflow.horus_workflow import HorusWorkflow
+from horus_runtime.core.interaction.transport import (
+    InteractionAnsweredEvent,
+    InteractionAskedEvent,
+)
 from horus_runtime.core.task.base import BaseTask
 from horus_runtime.core.task.status import TaskStatus
 from horus_runtime.event.subscriber import BaseEventSubscriber
@@ -56,8 +60,8 @@ class TestWorkflowTUISubscriber:
         registered = BaseEventSubscriber.registry.values()
         assert WorkflowTUISubscriber not in registered
 
-    def test_render_shows_tasks_and_statuses(self) -> None:
-        """The table lists each task name and its colored status."""
+    def test_render_shows_tasks_and_workflow(self) -> None:
+        """Dashboard names each task, the workflow, and a progress total."""
         wf = _workflow()
         wf.tasks[0].status = TaskStatus.RUNNING
         wf.tasks[1].status = TaskStatus.COMPLETED
@@ -65,15 +69,19 @@ class TestWorkflowTUISubscriber:
         tui = WorkflowTUISubscriber()
         tui.track(wf)
 
-        console = Console(record=True, width=80)
+        console = Console(record=True, width=120)
         console.print(tui.render())
         out = console.export_text()
 
         assert "Alpha" in out
         assert "Beta" in out
-        assert "running" in out
-        assert "completed" in out
-        assert "demo_wf" in out  # table title is the workflow name
+        assert "demo_wf" in out  # header shows the workflow name
+        assert "tasks" in out  # progress label
+        assert "✓" in out  # completed glyph
+
+    def test_render_without_workflow_is_safe(self) -> None:
+        """render() must not raise when nothing is tracked or active."""
+        Console(record=True).print(WorkflowTUISubscriber().render())
 
     def test_handle_without_live_is_noop(self) -> None:
         """handle() must not raise when no Live display is active."""
@@ -87,6 +95,26 @@ class TestWorkflowTUISubscriber:
         tui.track(_workflow())
         with tui.live():
             tui.handle(HorusTaskEvent(task_name="Alpha"))
+
+    def test_interaction_pauses_and_resumes_live(self) -> None:
+        """An asked interaction stops the Live; the answer restarts it."""
+        tui = WorkflowTUISubscriber()
+        tui.track(_workflow())
+        asked = InteractionAskedEvent(
+            interaction_kind="string",
+            transport_kind="cli",
+            renderer_key="cli.string",
+            value_key="v",
+        )
+        answered = InteractionAnsweredEvent(
+            interaction_kind="string", transport_kind="cli", value_key="v"
+        )
+        with tui.live():
+            assert tui._paused is False
+            tui.handle(asked)
+            assert tui._paused is True
+            tui.handle(answered)
+            assert tui._paused is False
 
     def test_setup_is_noop(self) -> None:
         """setup() is a no-op and must not raise."""

--- a/tests/unit/event/test_tui_subscriber.py
+++ b/tests/unit/event/test_tui_subscriber.py
@@ -1,0 +1,93 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Unit tests for the live workflow TUI subscriber.
+"""
+
+import pytest
+from rich.console import Console
+
+from horus_builtin.event.task_event import HorusTaskEvent
+from horus_builtin.event.tui_subscriber import WorkflowTUISubscriber
+from horus_builtin.executor.shell import ShellExecutor
+from horus_builtin.runtime.command import CommandRuntime
+from horus_builtin.task.horus_task import HorusTask
+from horus_builtin.workflow.horus_workflow import HorusWorkflow
+from horus_runtime.core.task.base import BaseTask
+from horus_runtime.core.task.status import TaskStatus
+from horus_runtime.event.subscriber import BaseEventSubscriber
+
+
+def _workflow() -> HorusWorkflow:
+    """A tiny two-task workflow for rendering."""
+    tasks: list[BaseTask] = [
+        HorusTask(
+            id=tid,
+            name=name,
+            runtime=CommandRuntime(command="true"),
+            executor=ShellExecutor(),
+        )
+        for tid, name in (("a", "Alpha"), ("b", "Beta"))
+    ]
+    return HorusWorkflow(name="demo_wf", tasks=tasks)
+
+
+@pytest.mark.unit
+class TestWorkflowTUISubscriber:
+    """Tests for ``WorkflowTUISubscriber``."""
+
+    def test_not_auto_registered(self) -> None:
+        """It must stay out of the auto-instantiated registry."""
+        registered = BaseEventSubscriber.registry.values()
+        assert WorkflowTUISubscriber not in registered
+
+    def test_render_shows_tasks_and_statuses(self) -> None:
+        """The table lists each task name and its colored status."""
+        wf = _workflow()
+        wf.tasks[0].status = TaskStatus.RUNNING
+        wf.tasks[1].status = TaskStatus.COMPLETED
+
+        tui = WorkflowTUISubscriber()
+        tui.track(wf)
+
+        console = Console(record=True, width=80)
+        console.print(tui.render())
+        out = console.export_text()
+
+        assert "Alpha" in out
+        assert "Beta" in out
+        assert "running" in out
+        assert "completed" in out
+        assert "demo_wf" in out  # table title is the workflow name
+
+    def test_handle_without_live_is_noop(self) -> None:
+        """handle() must not raise when no Live display is active."""
+        tui = WorkflowTUISubscriber()
+        tui.track(_workflow())
+        tui.handle(HorusTaskEvent(task_name="Alpha"))
+
+    def test_handle_within_live_repaints(self) -> None:
+        """Inside the Live context, handle() repaints without error."""
+        tui = WorkflowTUISubscriber()
+        tui.track(_workflow())
+        with tui.live():
+            tui.handle(HorusTaskEvent(task_name="Alpha"))
+
+    def test_setup_is_noop(self) -> None:
+        """setup() is a no-op and must not raise."""
+        WorkflowTUISubscriber().setup()

--- a/tests/unit/interaction/test_builtin_interactions.py
+++ b/tests/unit/interaction/test_builtin_interactions.py
@@ -274,25 +274,28 @@ class TestCLIInteractionTransport:
     Test cases for CLIInteractionTransport.
     """
 
-    def test_ask_text_formats_prompt_for_input(
+    def test_ask_text_uses_rich_prompt(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """
-        Test that ask_text() composes the CLI prompt before calling input().
+        Test that ask_text() prompts via Rich, folding in the prompt text,
+        placeholder hint, and default, and returns the raw string answer.
         """
-        prompts: list[str] = []
+        captured: dict[str, object] = {}
+
+        class _FakePrompt:
+            @staticmethod
+            def ask(question: str, **kwargs: object) -> str:
+                captured["question"] = question
+                captured["default"] = kwargs.get("default")
+                return "typed value"
+
+        monkeypatch.setattr(
+            "horus_builtin.interaction.cli.Prompt", _FakePrompt
+        )
+
         transport = CLIInteractionTransport()
-
-        def fake_input(prompt: str) -> str:
-            """
-            Record the prompt and return a fixed answer.
-            """
-            prompts.append(prompt)
-            return "typed value"
-
-        monkeypatch.setattr("builtins.input", fake_input)
-
         result = transport.ask_text(
             title="Title",
             prompt="Prompt",
@@ -301,9 +304,9 @@ class TestCLIInteractionTransport:
         )
 
         assert result == "typed value"
-        assert prompts == [
-            "Title\nPrompt\n(default: fallback)\n(placeholder: Type here)\n> "
-        ]
+        assert "Prompt" in str(captured["question"])
+        assert "Type here" in str(captured["question"])
+        assert captured["default"] == "fallback"
 
 
 @pytest.mark.unit

--- a/uv.lock
+++ b/uv.lock
@@ -173,6 +173,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pyyaml" },
+    { name = "rich" },
 ]
 
 [package.dev-dependencies]
@@ -196,6 +197,7 @@ requires-dist = [
     { name = "pydantic", specifier = "~=2.0" },
     { name = "pydantic-settings", specifier = "~=2.0" },
     { name = "pyyaml", specifier = "~=6.0" },
+    { name = "rich", specifier = ">=13.7" },
 ]
 
 [package.metadata.requires-dev]
@@ -315,6 +317,18 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -364,6 +378,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -736,6 +759,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/19/eb/ef32dcd2cb69b69bc0c3e55205bce94a7def48d495358946bc42186dcccc/regex-2026.4.4-cp314-cp314t-win32.whl", hash = "sha256:385edaebde5db5be103577afc8699fea73a0e36a734ba24870be7ffa61119d74", size = 275709, upload-time = "2026-04-03T20:56:20.996Z" },
     { url = "https://files.pythonhosted.org/packages/a0/86/c291bf740945acbf35ed7dbebf8e2eea2f3f78041f6bd7cdab80cb274dc0/regex-2026.4.4-cp314-cp314t-win_amd64.whl", hash = "sha256:5d354b18839328927832e2fa5f7c95b7a3ccc39e7a681529e1685898e6436d45", size = 285622, upload-time = "2026-04-03T20:56:23.641Z" },
     { url = "https://files.pythonhosted.org/packages/d5/e7/ec846d560ae6a597115153c02ca6138a7877a1748b2072d9521c10a93e58/regex-2026.4.4-cp314-cp314t-win_arm64.whl", hash = "sha256:af0384cb01a33600c49505c27c6c57ab0b27bf84a74e28524c92ca897ebdac9d", size = 275773, upload-time = "2026-04-03T20:56:26.07Z" },
+]
+
+[[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What
`horus` becomes a command group with a new subcommand:

```
horus run WORKFLOW_YAML [--trigger TASK_ID] [--no-tui]
```

It boots the runtime, loads the workflow with `HorusWorkflow.from_yaml`, runs it from the trigger task (default: the first task), and exits non-zero on failure.

## Live TUI
`WorkflowTUISubscriber` is an **opt-in** event-bus subscriber that renders a live Rich table of each task's status (IDLE→PENDING→RUNNING→COMPLETED/FAILED). The CLI constructs it and attaches it via `bus.subscribe()`; `add_to_registry = False` keeps `bus.start()` from auto-instantiating it (registry subscribers are built with no args). `--no-tui` streams logs only.

## Why
Previously `main()` only booted and shut down — workflows could only be run from bespoke Python drivers. This is the missing runner.

## Notes
- Adds `rich` as a dependency.
- Bare `horus` now shows help (it's a group); the integration smoke was updated to `horus --help`.

Closes #89

Docs PR:
https://github.com/temple-compute/horus-docs/pull/29