### PR TITLE
Render flow now importable from horus_builtin

### DIFF
--- a/src/horus_builtin/__init__.py
+++ b/src/horus_builtin/__init__.py
@@ -15,3 +15,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
+
+from horus_builtin.event.tui_subscriber import (
+    render_workflow as render_workflow,
+)

--- a/src/horus_builtin/event/tui_subscriber.py
+++ b/src/horus_builtin/event/tui_subscriber.py
@@ -573,6 +573,8 @@ def render_workflow(workflow: BaseWorkflow, trigger_id: str) -> None:
     YAML, e.g. ``FunctionTask`` interactions) with the TUI. The runtime must
     already be booted::
 
+        from horus_builtin import render_workflow
+
         ctx = HorusContext.boot()
         render_workflow(wf, trigger_id="first")
     """

--- a/src/horus_runtime/cli.py
+++ b/src/horus_runtime/cli.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 import click
 
-from horus_builtin.event.tui_subscriber import render_workflow
+from horus_builtin import render_workflow
 from horus_runtime.context import HorusContext
 from horus_runtime.core.workflow.base import BaseWorkflow
 from horus_runtime.i18n import tr as _


### PR DESCRIPTION
## Summary

The render_workflow function is now importable directly from horus_builtin.

## Documentation impact

If a user, plugin, or GUI can observe the difference, it requires documentation.

- [ ] No documentation update required
- [X] Documentation updated / will be updated

If documentation was updated, link the docs PR here:

https://github.com/temple-compute/horus-docs/pull/30