### PR TITLE
feat(target): detachable execution in the target layer

### DIFF
--- a/src/horus_builtin/__init__.py
+++ b/src/horus_builtin/__init__.py
@@ -16,6 +16,13 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-from horus_builtin.event.tui_subscriber import (
-    render_workflow as render_workflow,
-)
+
+# Prevent circular import issues by lazily importing render_workflow
+def __getattr__(name: str) -> object:
+    if name == "render_workflow":
+        from horus_builtin.event.tui_subscriber import (  # noqa: PLC0415
+            render_workflow,
+        )
+
+        return render_workflow
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/horus_builtin/target/local.py
+++ b/src/horus_builtin/target/local.py
@@ -133,7 +133,7 @@ class LocalTarget(BaseTarget):
     # snappy for near-live streaming when detachment is requested.
     poll_interval: ClassVar[float] = 0.25
 
-    async def _run_command_sync(
+    async def run_command_sync(
         self,
         cmd: str,
         *,
@@ -170,7 +170,7 @@ class LocalTarget(BaseTarget):
         )
         return LocalChannelProcess(proc)
 
-    async def _launch(
+    async def launch(
         self,
         cmd: str,
         *,
@@ -202,7 +202,7 @@ class LocalTarget(BaseTarget):
         pid = int((Path(job_dir) / "pid").read_text().strip())
         return JobHandle(pid=pid, job_dir=job_dir)
 
-    async def _poll(self, handle: JobHandle) -> int | None:
+    async def poll(self, handle: JobHandle) -> int | None:
         """``None`` while running; the recorded exit code once finished."""
         ec = Path(handle.job_dir) / "exit_code"
         if ec.exists():
@@ -218,7 +218,7 @@ class LocalTarget(BaseTarget):
             pass
         return None
 
-    async def _read_output(self, handle: JobHandle) -> tuple[bytes, bytes]:
+    async def read_output(self, handle: JobHandle) -> tuple[bytes, bytes]:
         """Read the captured stdout/stderr log files."""
 
         def _read(name: str) -> bytes:
@@ -227,7 +227,7 @@ class LocalTarget(BaseTarget):
 
         return _read("stdout.log"), _read("stderr.log")
 
-    async def _send_signal(self, handle: JobHandle, sig: int) -> None:
+    async def send_signal(self, handle: JobHandle, sig: int) -> None:
         """
         Signal the detached job's whole process group, so children it spawned
         die with it (the launcher used ``start_new_session``, so the job's

--- a/src/horus_builtin/target/local.py
+++ b/src/horus_builtin/target/local.py
@@ -228,10 +228,16 @@ class LocalTarget(BaseTarget):
         return _read("stdout.log"), _read("stderr.log")
 
     async def _send_signal(self, handle: JobHandle, sig: int) -> None:
-        """Best-effort signal to the detached job."""
-        # ponytail: signals the recorded pid only; a forked tree may survive.
+        """
+        Signal the detached job's whole process group, so children it spawned
+        die with it (the launcher used ``start_new_session``, so the job's
+        PGID is queryable via ``os.getpgid``).
+        """
         try:
-            os.kill(handle.pid, sig)
+            if os.name == "posix":
+                os.killpg(os.getpgid(handle.pid), sig)
+            else:
+                os.kill(handle.pid, sig)
         except (ProcessLookupError, PermissionError):
             pass
 

--- a/src/horus_builtin/target/local.py
+++ b/src/horus_builtin/target/local.py
@@ -22,6 +22,7 @@ Local target: executes tasks in the current process, running commands via
 
 import asyncio
 import os
+import shlex
 import signal
 import socket
 from collections.abc import AsyncGenerator
@@ -32,8 +33,10 @@ from horus_runtime.core.artifact.base import BaseArtifact
 from horus_runtime.core.target.base import BaseTarget
 from horus_runtime.core.target.channel import (
     ChannelProcess,
+    JobHandle,
     RemoteDirEntry,
     StreamName,
+    build_detach_command,
     merge_line_streams,
 )
 
@@ -121,7 +124,16 @@ class LocalTarget(BaseTarget):
         """
         return 0.0 if artifact.path.exists() else None
 
-    async def run_command(
+    # No droppable channel locally, so keep the live-streaming path as the
+    # default; detachment is still available (e.g. for recovery) via the
+    # primitives below.
+    detach_by_default: ClassVar[bool] = False
+
+    # Local jobs live on the same filesystem, so polling is cheap; keep it
+    # snappy for near-live streaming when detachment is requested.
+    poll_interval: ClassVar[float] = 0.25
+
+    async def _run_command_sync(
         self,
         cmd: str,
         *,
@@ -157,6 +169,71 @@ class LocalTarget(BaseTarget):
             start_new_session=start_new_session,
         )
         return LocalChannelProcess(proc)
+
+    async def _launch(
+        self,
+        cmd: str,
+        *,
+        cwd: str | None,
+        env: dict[str, str] | None,
+        job_dir: str,
+    ) -> JobHandle:
+        """
+        Launch *cmd* detached: nohup'd, redirected to log files under
+        *job_dir*, surviving the orchestrator process.
+        """
+        exports = "".join(
+            f"export {k}={shlex.quote(v)}; " for k, v in (env or {}).items()
+        )
+        inner = f"{exports}{cmd}"
+        if cwd is not None:
+            inner = f"cd {shlex.quote(cwd)} && {inner}"
+        wrapper = build_detach_command(inner, job_dir)
+
+        # The launcher shell backgrounds the job and returns immediately; the
+        # nohup'd job reparents and keeps running independent of this process.
+        launcher = await asyncio.create_subprocess_shell(
+            wrapper,
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+            start_new_session=(os.name == "posix"),
+        )
+        await launcher.wait()
+        pid = int((Path(job_dir) / "pid").read_text().strip())
+        return JobHandle(pid=pid, job_dir=job_dir)
+
+    async def _poll(self, handle: JobHandle) -> int | None:
+        """``None`` while running; the recorded exit code once finished."""
+        ec = Path(handle.job_dir) / "exit_code"
+        if ec.exists():
+            txt = ec.read_text().strip()
+            if txt:
+                return int(txt)
+        try:
+            os.kill(handle.pid, 0)
+        except ProcessLookupError:
+            # Gone without an exit_code: killed or lost.
+            return -1
+        except PermissionError:
+            pass
+        return None
+
+    async def _read_output(self, handle: JobHandle) -> tuple[bytes, bytes]:
+        """Read the captured stdout/stderr log files."""
+
+        def _read(name: str) -> bytes:
+            p = Path(handle.job_dir) / name
+            return p.read_bytes() if p.exists() else b""
+
+        return _read("stdout.log"), _read("stderr.log")
+
+    async def _send_signal(self, handle: JobHandle, sig: int) -> None:
+        """Best-effort signal to the detached job."""
+        # ponytail: signals the recorded pid only; a forked tree may survive.
+        try:
+            os.kill(handle.pid, sig)
+        except (ProcessLookupError, PermissionError):
+            pass
 
     async def put_file(
         self,

--- a/src/horus_builtin/tui.py
+++ b/src/horus_builtin/tui.py
@@ -15,3 +15,11 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
+"""
+Re-export of the `render_workflow` function from the
+`horus_builtin.event.tui_subscriber` module for convenience.
+"""
+
+from horus_builtin.event.tui_subscriber import render_workflow
+
+__all__ = ["render_workflow"]

--- a/src/horus_runtime/cli.py
+++ b/src/horus_runtime/cli.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 import click
 
-from horus_builtin import render_workflow
+from horus_builtin.tui import render_workflow
 from horus_runtime.context import HorusContext
 from horus_runtime.core.workflow.base import BaseWorkflow
 from horus_runtime.i18n import tr as _

--- a/src/horus_runtime/core/target/base.py
+++ b/src/horus_runtime/core/target/base.py
@@ -82,18 +82,9 @@ class BaseTarget(AutoRegistry, entry_point="target"):
     @abstractmethod
     def location_id(self) -> str:
         """
-        Stable identifier for the physical location this target runs on.
-        Two targets with the same ``location_id`` share a filesystem, so no
-        artifact transfer is needed between them.
-
-        Implementations should return a URI-like string that is:
-        - deterministic across process restarts on the same host/node
-        - unique across distinct machines or agent instances
-
-        Examples:
-            ``local://hostname``
-            ``ssh://user@gpu-box``
-            ``horus-agent://agent-42``
+        Stable, URI-like identifier for the physical location this target runs
+        on (e.g. ``local://hostname``). Targets sharing a ``location_id`` share
+        a filesystem, so no artifact transfer is needed between them.
         """
 
     @property
@@ -109,17 +100,8 @@ class BaseTarget(AutoRegistry, entry_point="target"):
         return self._task
 
     def bind(self, task: "BaseTask") -> None:
-        """Associate *task* with this target ahead of dispatch.
-
-        Resource-aware targets can then read ``task.resources`` during
-        (possibly lazy) provisioning. Provisioning targets (e.g. Terraform)
-        provision at transfer time, which happens before :meth:`dispatch` sets
-        the task reference, so binding first gives them access to the task's
-        declared resources in time.
-
-        Args:
-            task: The task about to be transferred to and dispatched on this
-                target.
+        """Associate *task* with this target ahead of dispatch, so resource-
+        aware targets can read ``task.resources`` while provisioning.
 
         Raises:
             TaskExecutionError: If a task is already running on this target.
@@ -225,16 +207,13 @@ class BaseTarget(AutoRegistry, entry_point="target"):
         Return the estimated cost of reading ``artifact`` from this target,
         or ``None`` if this target cannot access it at all.
 
-        The value is dimensionless and relative, callers use it to compare
-        sources and decide whether a transfer is preferable:
+        A relative, dimensionless value used to compare sources:
 
         - ``0.0``   — zero-cost local read (same filesystem, in-memory, …)
         - ``> 0.0`` — accessible but non-free (network, agent API, …)
         - ``None``  — not accessible; transfer required before dispatch
 
-        Implementations must be synchronous and cheap (no I/O). Use
-        the artifact metadata such as ``artifact.path`` and ``artifact.kind``
-        (or the concrete artifact type) for kind-specific cost adjustments.
+        Must be synchronous and cheap (no I/O).
         """
 
     async def recover(self) -> bool:
@@ -249,12 +228,9 @@ class BaseTarget(AutoRegistry, entry_point="target"):
         """
         Absolute path where *artifact* lives on **this target's** filesystem.
 
-        Lets runtimes reference artifacts without the caller hand-building
-        remote paths: a command like ``python {script}`` resolves to the right
-        location on whichever target the task runs on. The default assumes the
-        artifact is reachable at its own path (same filesystem as the
-        orchestrator); targets that copy artifacts elsewhere (e.g. SSH)
-        override this to point at the on-host copy.
+        The default assumes the artifact is reachable at its own path (same
+        filesystem as the orchestrator); targets that copy artifacts elsewhere
+        (e.g. SSH) override this to point at the on-host copy.
         """
         return str(artifact.path)
 
@@ -287,6 +263,7 @@ class BaseTarget(AutoRegistry, entry_point="target"):
         handle = await self.launch(cmd, cwd=cwd, env=env, job_dir=job_dir)
         return PollingChannelProcess(self, handle)
 
+    @abstractmethod
     async def run_command_sync(
         self,
         cmd: str,
@@ -294,14 +271,9 @@ class BaseTarget(AutoRegistry, entry_point="target"):
         cwd: str | None = None,
         env: dict[str, str] | None = None,
     ) -> ChannelProcess:
-        """
-        Run *cmd* synchronously over a live channel (the pre-detach behavior).
+        """Run *cmd* synchronously over a live channel (``detach=False``)."""
 
-        Concrete targets that support detachment implement this for the
-        ``detach=False`` fast path.
-        """
-        raise NotImplementedError
-
+    @abstractmethod
     async def launch(
         self,
         cmd: str,
@@ -310,22 +282,19 @@ class BaseTarget(AutoRegistry, entry_point="target"):
         env: dict[str, str] | None,
         job_dir: str,
     ) -> JobHandle:
-        """
-        Start *cmd* so it outlives the launching channel and return a handle.
-        """
-        raise NotImplementedError
+        """Start *cmd* detached from the launching channel; return a handle."""
 
+    @abstractmethod
     async def poll(self, handle: JobHandle) -> int | None:
         """Non-blocking status: ``None`` while running, exit code once done."""
-        raise NotImplementedError
 
+    @abstractmethod
     async def read_output(self, handle: JobHandle) -> tuple[bytes, bytes]:
         """Return the job's captured ``(stdout, stderr)`` so far."""
-        raise NotImplementedError
 
+    @abstractmethod
     async def send_signal(self, handle: JobHandle, sig: int) -> None:
         """Best-effort signal delivery to a detached job (no live channel)."""
-        raise NotImplementedError
 
     @abstractmethod
     async def put_file(
@@ -372,12 +341,8 @@ class BaseTarget(AutoRegistry, entry_point="target"):
         List the immediate children of *path* on the target host
         (non-recursive).
 
-        Implementations must use a **native, non-shell** mechanism so this is
-        OS-agnostic (``pathlib`` locally, SFTP/agent API remotely) and must
-        **skip symlinks** (they cause cycles and are almost always noise in a
-        side-artifacts directory). Each :class:`.RemoteDirEntry` carries the
-        file ``size`` (``0`` for directories) so callers can enforce a size cap
-        before transferring.
+        Implementations must use a native, non-shell mechanism (``pathlib``
+        locally, SFTP/agent API remotely) and skip symlinks.
 
         Args:
             path: Directory path on the *target* host to list.

--- a/src/horus_runtime/core/target/base.py
+++ b/src/horus_runtime/core/target/base.py
@@ -29,8 +29,8 @@ from pydantic import Field, PrivateAttr
 from horus_runtime.core.target.channel import (
     ChannelProcess,
     JobHandle,
+    PollingChannelProcess,
     RemoteDirEntry,
-    _PollingChannelProcess,
     new_job_dir,
 )
 from horus_runtime.core.task.exceptions import TaskExecutionError
@@ -260,19 +260,12 @@ class BaseTarget(AutoRegistry, entry_point="target"):
 
     poll_interval: ClassVar[float] = 1.0
     """
-    Seconds between status polls for detached jobs (see :meth:`run_command`).
-    Targets probing over the network (SSH) keep it modest; local targets can
-    lower it for snappier streaming.
+    Seconds between status polls for detached jobs.
     """
 
     detach_by_default: ClassVar[bool] = True
     """
     Whether :meth:`run_command` detaches when the caller doesn't specify.
-
-    Detachment matters where there is a droppable channel (SSH): the job then
-    survives a connection loss. Targets with no such channel (``LocalTarget``)
-    set this ``False`` so their live-streaming path stays the default and only
-    opt into detachment explicitly (e.g. for recovery).
     """
 
     async def run_command(
@@ -285,42 +278,16 @@ class BaseTarget(AutoRegistry, entry_point="target"):
     ) -> ChannelProcess:
         """
         Run *cmd* on the target and return a :class:`.ChannelProcess` handle.
-
-        Template method: concrete targets implement the small primitives below
-        (:meth:`_launch`, :meth:`_poll`, :meth:`_read_output`,
-        :meth:`_send_signal`, plus the synchronous :meth:`_run_command_sync`)
-        rather than overriding this method. Targets that implement the
-        primitives get *detachment* for free — the returned process survives
-        the connection that launched it, so a dropped channel no longer kills
-        the job. (A target may still override ``run_command`` directly; it then
-        opts out of detachment.)
-
-        Args:
-            cmd: Shell command string to execute.
-            cwd: Working directory on the *target* host.  The channel
-                applies this — ``LocalTarget`` passes it as
-                ``subprocess cwd=``; remote targets inline
-                ``cd <cwd> && …`` before the command.
-            env: Additional environment variables to merge onto the
-                channel's base environment.  Keys/values are plain strings.
-            detach: Whether to launch detached (survives a dropped channel,
-                polled for completion) or run synchronously over the live
-                channel. Defaults to the target's :attr:`detach_by_default`.
-                Pass ``False`` for short control-plane commands (``mkdir``,
-                image build/cleanup) that should block as before.
-
-        Returns:
-            A :class:`.ChannelProcess` handle for the running command.
         """
         if detach is None:
             detach = self.detach_by_default
         if not detach:
-            return await self._run_command_sync(cmd, cwd=cwd, env=env)
+            return await self.run_command_sync(cmd, cwd=cwd, env=env)
         job_dir = new_job_dir(cwd or self.working_directory)
-        handle = await self._launch(cmd, cwd=cwd, env=env, job_dir=job_dir)
-        return _PollingChannelProcess(self, handle)
+        handle = await self.launch(cmd, cwd=cwd, env=env, job_dir=job_dir)
+        return PollingChannelProcess(self, handle)
 
-    async def _run_command_sync(
+    async def run_command_sync(
         self,
         cmd: str,
         *,
@@ -335,7 +302,7 @@ class BaseTarget(AutoRegistry, entry_point="target"):
         """
         raise NotImplementedError
 
-    async def _launch(
+    async def launch(
         self,
         cmd: str,
         *,
@@ -345,21 +312,18 @@ class BaseTarget(AutoRegistry, entry_point="target"):
     ) -> JobHandle:
         """
         Start *cmd* so it outlives the launching channel and return a handle.
-
-        Implementations record stdout/stderr, the PID, and (on completion) the
-        exit code under *job_dir*; see :func:`.build_detach_command`.
         """
         raise NotImplementedError
 
-    async def _poll(self, handle: JobHandle) -> int | None:
+    async def poll(self, handle: JobHandle) -> int | None:
         """Non-blocking status: ``None`` while running, exit code once done."""
         raise NotImplementedError
 
-    async def _read_output(self, handle: JobHandle) -> tuple[bytes, bytes]:
+    async def read_output(self, handle: JobHandle) -> tuple[bytes, bytes]:
         """Return the job's captured ``(stdout, stderr)`` so far."""
         raise NotImplementedError
 
-    async def _send_signal(self, handle: JobHandle, sig: int) -> None:
+    async def send_signal(self, handle: JobHandle, sig: int) -> None:
         """Best-effort signal delivery to a detached job (no live channel)."""
         raise NotImplementedError
 

--- a/src/horus_runtime/core/target/base.py
+++ b/src/horus_runtime/core/target/base.py
@@ -26,7 +26,13 @@ from typing import TYPE_CHECKING, ClassVar, final
 
 from pydantic import Field, PrivateAttr
 
-from horus_runtime.core.target.channel import ChannelProcess, RemoteDirEntry
+from horus_runtime.core.target.channel import (
+    ChannelProcess,
+    JobHandle,
+    RemoteDirEntry,
+    _PollingChannelProcess,
+    new_job_dir,
+)
 from horus_runtime.core.task.exceptions import TaskExecutionError
 from horus_runtime.core.task.status import TaskStatus
 from horus_runtime.i18n import tr as _
@@ -252,16 +258,42 @@ class BaseTarget(AutoRegistry, entry_point="target"):
         """
         return str(artifact.path)
 
-    @abstractmethod
+    poll_interval: ClassVar[float] = 1.0
+    """
+    Seconds between status polls for detached jobs (see :meth:`run_command`).
+    Targets probing over the network (SSH) keep it modest; local targets can
+    lower it for snappier streaming.
+    """
+
+    detach_by_default: ClassVar[bool] = True
+    """
+    Whether :meth:`run_command` detaches when the caller doesn't specify.
+
+    Detachment matters where there is a droppable channel (SSH): the job then
+    survives a connection loss. Targets with no such channel (``LocalTarget``)
+    set this ``False`` so their live-streaming path stays the default and only
+    opt into detachment explicitly (e.g. for recovery).
+    """
+
     async def run_command(
         self,
         cmd: str,
         *,
         cwd: str | None = None,
         env: dict[str, str] | None = None,
+        detach: bool | None = None,
     ) -> ChannelProcess:
         """
         Run *cmd* on the target and return a :class:`.ChannelProcess` handle.
+
+        Template method: concrete targets implement the small primitives below
+        (:meth:`_launch`, :meth:`_poll`, :meth:`_read_output`,
+        :meth:`_send_signal`, plus the synchronous :meth:`_run_command_sync`)
+        rather than overriding this method. Targets that implement the
+        primitives get *detachment* for free — the returned process survives
+        the connection that launched it, so a dropped channel no longer kills
+        the job. (A target may still override ``run_command`` directly; it then
+        opts out of detachment.)
 
         Args:
             cmd: Shell command string to execute.
@@ -271,10 +303,65 @@ class BaseTarget(AutoRegistry, entry_point="target"):
                 ``cd <cwd> && …`` before the command.
             env: Additional environment variables to merge onto the
                 channel's base environment.  Keys/values are plain strings.
+            detach: Whether to launch detached (survives a dropped channel,
+                polled for completion) or run synchronously over the live
+                channel. Defaults to the target's :attr:`detach_by_default`.
+                Pass ``False`` for short control-plane commands (``mkdir``,
+                image build/cleanup) that should block as before.
 
         Returns:
             A :class:`.ChannelProcess` handle for the running command.
         """
+        if detach is None:
+            detach = self.detach_by_default
+        if not detach:
+            return await self._run_command_sync(cmd, cwd=cwd, env=env)
+        job_dir = new_job_dir(cwd or self.working_directory)
+        handle = await self._launch(cmd, cwd=cwd, env=env, job_dir=job_dir)
+        return _PollingChannelProcess(self, handle)
+
+    async def _run_command_sync(
+        self,
+        cmd: str,
+        *,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> ChannelProcess:
+        """
+        Run *cmd* synchronously over a live channel (the pre-detach behavior).
+
+        Concrete targets that support detachment implement this for the
+        ``detach=False`` fast path.
+        """
+        raise NotImplementedError
+
+    async def _launch(
+        self,
+        cmd: str,
+        *,
+        cwd: str | None,
+        env: dict[str, str] | None,
+        job_dir: str,
+    ) -> JobHandle:
+        """
+        Start *cmd* so it outlives the launching channel and return a handle.
+
+        Implementations record stdout/stderr, the PID, and (on completion) the
+        exit code under *job_dir*; see :func:`.build_detach_command`.
+        """
+        raise NotImplementedError
+
+    async def _poll(self, handle: JobHandle) -> int | None:
+        """Non-blocking status: ``None`` while running, exit code once done."""
+        raise NotImplementedError
+
+    async def _read_output(self, handle: JobHandle) -> tuple[bytes, bytes]:
+        """Return the job's captured ``(stdout, stderr)`` so far."""
+        raise NotImplementedError
+
+    async def _send_signal(self, handle: JobHandle, sig: int) -> None:
+        """Best-effort signal delivery to a detached job (no live channel)."""
+        raise NotImplementedError
 
     @abstractmethod
     async def put_file(

--- a/src/horus_runtime/core/target/base.py
+++ b/src/horus_runtime/core/target/base.py
@@ -82,9 +82,18 @@ class BaseTarget(AutoRegistry, entry_point="target"):
     @abstractmethod
     def location_id(self) -> str:
         """
-        Stable, URI-like identifier for the physical location this target runs
-        on (e.g. ``local://hostname``). Targets sharing a ``location_id`` share
-        a filesystem, so no artifact transfer is needed between them.
+        Stable identifier for the physical location this target runs on.
+        Two targets with the same ``location_id`` share a filesystem, so no
+        artifact transfer is needed between them.
+
+        Implementations should return a URI-like string that is:
+        - deterministic across process restarts on the same host/node
+        - unique across distinct machines or agent instances
+
+        Examples:
+            ``local://hostname``
+            ``ssh://user@gpu-box``
+            ``horus-agent://agent-42``
         """
 
     @property

--- a/src/horus_runtime/core/target/channel.py
+++ b/src/horus_runtime/core/target/channel.py
@@ -27,6 +27,7 @@ import uuid
 from abc import ABC, abstractmethod
 from collections.abc import AsyncGenerator
 from dataclasses import dataclass
+from itertools import zip_longest
 from typing import TYPE_CHECKING, Literal, NamedTuple, Protocol
 
 from horus_runtime.settings import runtime_settings
@@ -172,11 +173,6 @@ async def merge_line_streams(
         pump_task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
             await pump_task
-
-
-# ---------------------------------------------------------------------------
-# Detachable execution
-# ---------------------------------------------------------------------------
 
 
 @dataclass(frozen=True)
@@ -334,10 +330,14 @@ class _PollingChannelProcess(ChannelProcess):
             out, err = await self._target._read_output(  # noqa: SLF001
                 self._handle
             )
-            for item in emit("stdout", out, final=done):
-                yield item
-            for item in emit("stderr", err, final=done):
-                yield item
+            # Read the log files in chunks, yielding lines as they appear.
+            # If the job is done, yield any remaining partial lines too.
+            stdout_items = emit("stdout", out, final=done)
+            stderr_items = emit("stderr", err, final=done)
+            for pair in zip_longest(stdout_items, stderr_items):
+                for item in pair:
+                    if item is not None:
+                        yield item
             if done:
                 return
             await asyncio.sleep(self._target.poll_interval)

--- a/src/horus_runtime/core/target/channel.py
+++ b/src/horus_runtime/core/target/channel.py
@@ -201,7 +201,9 @@ def new_job_dir(base: str) -> str:
     return f"{base.rstrip('/')}/.horus_job/{uuid.uuid4().hex[:8]}"
 
 
-def build_detach_command(inner: str, job_dir: str) -> str:
+def build_detach_command(
+    inner: str, job_dir: str, *, session_leader: bool = False
+) -> str:
     """
     Wrap *inner* (a shell command string, with ``cd``/``export`` already
     inlined by the caller) so it runs detached from the launching channel.
@@ -209,29 +211,39 @@ def build_detach_command(inner: str, job_dir: str) -> str:
     The wrapper:
 
     - ``mkdir -p`` the marker dir,
-    - ``nohup`` the command with stdin closed and stdout/stderr redirected to
-      log files so it ignores ``SIGHUP`` when the channel/session closes,
+    - launches the command with stdin closed and stdout/stderr redirected to
+      log files so it survives the channel/session closing,
     - records the job PID to ``pid``,
     - records the exit status to ``exit_code`` once the command finishes
       (the authoritative "done" signal, observable after the channel is gone).
 
+    Args:
+        inner: The command to run (self-contained shell string).
+        job_dir: Marker directory for pid / exit_code / log files.
+        session_leader: When ``True``, launch under ``setsid`` so the job leads
+            its own session and process group, and its PID equals its PGID.
+            A signal can then reach the **whole process tree** via
+            ``kill -- -<pid>`` (so cancelling a job also stops the children it
+            spawned). ``setsid`` also drops the controlling tty, so ``SIGHUP``
+            on channel close is a non-issue. When ``False`` (e.g. macOS, which
+            has no ``setsid`` binary) the portable ``nohup`` is used instead
+            and callers must signal the group via ``os.getpgid`` at kill time.
+
     The launching shell returns immediately after backgrounding the job.
-    Works in POSIX ``sh`` (no ``disown``/``setsid`` needed), so it is
-    identical for local and remote targets.
+    Works in POSIX ``sh`` (no ``disown`` needed), so it is identical for local
+    and remote targets.
     """
     q = shlex.quote(job_dir)
-    # ponytail: best-effort kill targets the recorded pid; a command that
-    # forks its own tree may leave children. Add a process-group kill
-    # (setsid + `kill -- -pgid`) only if that actually bites.
     # Run the command in a subshell so a top-level `exit` in it can't skip the
     # exit-code write.
     body = f"( {inner} ); echo $? > {q}/exit_code"
+    launcher = "setsid" if session_leader else "nohup"
     # mkdir runs in the foreground (`;`) so the marker dir exists before the
-    # pid write; only the nohup'd job is backgrounded (`&`), and `echo $!`
-    # captures *its* pid.
+    # pid write; only the job is backgrounded (`&`), and `echo $!` captures
+    # *its* pid (which is also its PGID under `setsid`).
     return (
         f"mkdir -p {q} || exit 1; "
-        f"nohup sh -c {shlex.quote(body)} "
+        f"{launcher} sh -c {shlex.quote(body)} "
         f"> {q}/stdout.log 2> {q}/stderr.log < /dev/null & "
         f"echo $! > {q}/pid"
     )

--- a/src/horus_runtime/core/target/channel.py
+++ b/src/horus_runtime/core/target/channel.py
@@ -21,11 +21,18 @@ Channel primitives for agentless target communication.
 
 import asyncio
 import contextlib
+import shlex
+import signal
+import uuid
 from abc import ABC, abstractmethod
 from collections.abc import AsyncGenerator
-from typing import Literal, NamedTuple, Protocol
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal, NamedTuple, Protocol
 
 from horus_runtime.settings import runtime_settings
+
+if TYPE_CHECKING:
+    from horus_runtime.core.target.base import BaseTarget
 
 
 class RemoteDirEntry(NamedTuple):
@@ -165,3 +172,160 @@ async def merge_line_streams(
         pump_task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
             await pump_task
+
+
+# ---------------------------------------------------------------------------
+# Detachable execution
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class JobHandle:
+    """
+    Opaque reference to a detached job launched by a target.
+
+    ``pid``/``job_dir`` cover PID-based targets (``LocalTarget``,
+    ``SSHTarget``). Targets with a different process model (e.g. a future
+    docker container-id handle) can carry it in :attr:`extra` without changing
+    the callers, which only pass the handle back to the same target's
+    primitives.
+    """
+
+    pid: int
+    job_dir: str
+    extra: dict[str, str] | None = None
+
+
+def new_job_dir(base: str) -> str:
+    """Return a unique per-launch marker directory under *base*."""
+    return f"{base.rstrip('/')}/.horus_job/{uuid.uuid4().hex[:8]}"
+
+
+def build_detach_command(inner: str, job_dir: str) -> str:
+    """
+    Wrap *inner* (a shell command string, with ``cd``/``export`` already
+    inlined by the caller) so it runs detached from the launching channel.
+
+    The wrapper:
+
+    - ``mkdir -p`` the marker dir,
+    - ``nohup`` the command with stdin closed and stdout/stderr redirected to
+      log files so it ignores ``SIGHUP`` when the channel/session closes,
+    - records the job PID to ``pid``,
+    - records the exit status to ``exit_code`` once the command finishes
+      (the authoritative "done" signal, observable after the channel is gone).
+
+    The launching shell returns immediately after backgrounding the job.
+    Works in POSIX ``sh`` (no ``disown``/``setsid`` needed), so it is
+    identical for local and remote targets.
+    """
+    q = shlex.quote(job_dir)
+    # ponytail: best-effort kill targets the recorded pid; a command that
+    # forks its own tree may leave children. Add a process-group kill
+    # (setsid + `kill -- -pgid`) only if that actually bites.
+    # Run the command in a subshell so a top-level `exit` in it can't skip the
+    # exit-code write.
+    body = f"( {inner} ); echo $? > {q}/exit_code"
+    # mkdir runs in the foreground (`;`) so the marker dir exists before the
+    # pid write; only the nohup'd job is backgrounded (`&`), and `echo $!`
+    # captures *its* pid.
+    return (
+        f"mkdir -p {q} || exit 1; "
+        f"nohup sh -c {shlex.quote(body)} "
+        f"> {q}/stdout.log 2> {q}/stderr.log < /dev/null & "
+        f"echo $! > {q}/pid"
+    )
+
+
+class _PollingChannelProcess(ChannelProcess):
+    """
+    :class:`ChannelProcess` for a detached job, driven by the launching
+    target's primitives (:meth:`BaseTarget._poll` /
+    :meth:`~BaseTarget._read_output` / :meth:`~BaseTarget._send_signal`)
+    instead of a held-open channel.
+
+    Because every method re-probes the target on demand, the underlying job
+    survives a dropped connection: a transient reconnect just resumes polling.
+    """
+
+    def __init__(self, target: "BaseTarget", handle: JobHandle) -> None:
+        self._target = target
+        self._handle = handle
+        self._returncode: int | None = None
+
+    @property
+    def returncode(self) -> int | None:
+        """Cached exit code; set once :meth:`wait` sees completion."""
+        return self._returncode
+
+    async def wait(self) -> int:
+        """Poll until the job finishes; return its exit code."""
+        while self._returncode is None:
+            rc = await self._target._poll(self._handle)  # noqa: SLF001
+            if rc is not None:
+                self._returncode = rc
+                break
+            await asyncio.sleep(self._target.poll_interval)
+        return self._returncode
+
+    async def communicate(self) -> tuple[bytes, bytes]:
+        """Wait for completion, then read back captured stdout/stderr."""
+        await self.wait()
+        return await self._target._read_output(self._handle)  # noqa: SLF001
+
+    def kill(self) -> None:
+        """Best-effort SIGKILL to the detached job (fire-and-forget)."""
+        self.signal(signal.SIGKILL)
+
+    def signal(self, sig: int) -> None:
+        """
+        Send *sig* to the detached job without a held-open channel.
+
+        Signal delivery may require a round trip (e.g. a short SSH exec), so it
+        is scheduled on the running loop; callers confirm the effect via
+        :meth:`wait` (which polls until ``exit_code`` appears).
+        """
+        asyncio.get_running_loop().create_task(
+            self._target._send_signal(self._handle, sig)  # noqa: SLF001
+        )
+
+    async def stream(self) -> AsyncGenerator[tuple[StreamName, bytes]]:
+        """
+        Yield ``(stream_name, line)`` pairs by polling the captured log files.
+
+        Lines appear with up to ``poll_interval`` latency rather than truly
+        live, which is the price of channel independence.
+        """
+        offsets = {"stdout": 0, "stderr": 0}
+
+        def emit(
+            name: StreamName, data: bytes, *, final: bool
+        ) -> list[tuple[StreamName, bytes]]:
+            out: list[tuple[StreamName, bytes]] = []
+            new = data[offsets[name] :]
+            *lines, rest = new.split(b"\n")
+            for line in lines:
+                out.append((name, line + b"\n"))
+            offsets[name] += len(new) - len(rest)
+            if final and rest:
+                out.append((name, rest))
+                offsets[name] += len(rest)
+            return out
+
+        while True:
+            done = self._returncode is not None
+            if not done:
+                rc = await self._target._poll(self._handle)  # noqa: SLF001
+                if rc is not None:
+                    self._returncode = rc
+                    done = True
+            out, err = await self._target._read_output(  # noqa: SLF001
+                self._handle
+            )
+            for item in emit("stdout", out, final=done):
+                yield item
+            for item in emit("stderr", err, final=done):
+                yield item
+            if done:
+                return
+            await asyncio.sleep(self._target.poll_interval)

--- a/src/horus_runtime/core/target/channel.py
+++ b/src/horus_runtime/core/target/channel.py
@@ -107,16 +107,6 @@ class ChannelProcess(ABC):
     def stream(self) -> AsyncGenerator[tuple[StreamName, bytes]]:
         """
         Yield ``(stream_name, line)`` pairs as the process produces them.
-
-        Unlike :meth:`communicate`, this returns data live, a line is
-        yielded as soon as a newline is observed, not after the process
-        exits. Don't call both on the same process: ``stream`` drains
-        stdout/stderr as it goes, so a subsequent ``communicate`` would
-        hang waiting on streams that are already empty.
-
-        Exhausting the iterator means stdout/stderr have hit EOF; the
-        process may not be *reaped* yet, so call :meth:`wait` afterward
-        to get a reliable :attr:`returncode`.
         """
 
 
@@ -179,12 +169,6 @@ async def merge_line_streams(
 class JobHandle:
     """
     Opaque reference to a detached job launched by a target.
-
-    ``pid``/``job_dir`` cover PID-based targets (``LocalTarget``,
-    ``SSHTarget``). Targets with a different process model (e.g. a future
-    docker container-id handle) can carry it in :attr:`extra` without changing
-    the callers, which only pass the handle back to the same target's
-    primitives.
     """
 
     pid: int
@@ -203,27 +187,6 @@ def build_detach_command(
     """
     Wrap *inner* (a shell command string, with ``cd``/``export`` already
     inlined by the caller) so it runs detached from the launching channel.
-
-    The wrapper:
-
-    - ``mkdir -p`` the marker dir,
-    - launches the command with stdin closed and stdout/stderr redirected to
-      log files so it survives the channel/session closing,
-    - records the job PID to ``pid``,
-    - records the exit status to ``exit_code`` once the command finishes
-      (the authoritative "done" signal, observable after the channel is gone).
-
-    Args:
-        inner: The command to run (self-contained shell string).
-        job_dir: Marker directory for pid / exit_code / log files.
-        session_leader: When ``True``, launch under ``setsid`` so the job leads
-            its own session and process group, and its PID equals its PGID.
-            A signal can then reach the **whole process tree** via
-            ``kill -- -<pid>`` (so cancelling a job also stops the children it
-            spawned). ``setsid`` also drops the controlling tty, so ``SIGHUP``
-            on channel close is a non-issue. When ``False`` (e.g. macOS, which
-            has no ``setsid`` binary) the portable ``nohup`` is used instead
-            and callers must signal the group via ``os.getpgid`` at kill time.
 
     The launching shell returns immediately after backgrounding the job.
     Works in POSIX ``sh`` (no ``disown`` needed), so it is identical for local
@@ -245,21 +208,16 @@ def build_detach_command(
     )
 
 
-class _PollingChannelProcess(ChannelProcess):
+@dataclass
+class PollingChannelProcess(ChannelProcess):
     """
     :class:`ChannelProcess` for a detached job, driven by the launching
-    target's primitives (:meth:`BaseTarget._poll` /
-    :meth:`~BaseTarget._read_output` / :meth:`~BaseTarget._send_signal`)
-    instead of a held-open channel.
-
-    Because every method re-probes the target on demand, the underlying job
-    survives a dropped connection: a transient reconnect just resumes polling.
+    target's primitives.
     """
 
-    def __init__(self, target: "BaseTarget", handle: JobHandle) -> None:
-        self._target = target
-        self._handle = handle
-        self._returncode: int | None = None
+    _target: "BaseTarget"
+    _handle: JobHandle
+    _returncode: int | None = None
 
     @property
     def returncode(self) -> int | None:
@@ -269,7 +227,7 @@ class _PollingChannelProcess(ChannelProcess):
     async def wait(self) -> int:
         """Poll until the job finishes; return its exit code."""
         while self._returncode is None:
-            rc = await self._target._poll(self._handle)  # noqa: SLF001
+            rc = await self._target.poll(self._handle)
             if rc is not None:
                 self._returncode = rc
                 break
@@ -279,7 +237,7 @@ class _PollingChannelProcess(ChannelProcess):
     async def communicate(self) -> tuple[bytes, bytes]:
         """Wait for completion, then read back captured stdout/stderr."""
         await self.wait()
-        return await self._target._read_output(self._handle)  # noqa: SLF001
+        return await self._target.read_output(self._handle)
 
     def kill(self) -> None:
         """Best-effort SIGKILL to the detached job (fire-and-forget)."""
@@ -294,15 +252,12 @@ class _PollingChannelProcess(ChannelProcess):
         :meth:`wait` (which polls until ``exit_code`` appears).
         """
         asyncio.get_running_loop().create_task(
-            self._target._send_signal(self._handle, sig)  # noqa: SLF001
+            self._target.send_signal(self._handle, sig)
         )
 
     async def stream(self) -> AsyncGenerator[tuple[StreamName, bytes]]:
         """
         Yield ``(stream_name, line)`` pairs by polling the captured log files.
-
-        Lines appear with up to ``poll_interval`` latency rather than truly
-        live, which is the price of channel independence.
         """
         offsets = {"stdout": 0, "stderr": 0}
 
@@ -323,13 +278,11 @@ class _PollingChannelProcess(ChannelProcess):
         while True:
             done = self._returncode is not None
             if not done:
-                rc = await self._target._poll(self._handle)  # noqa: SLF001
+                rc = await self._target.poll(self._handle)
                 if rc is not None:
                     self._returncode = rc
                     done = True
-            out, err = await self._target._read_output(  # noqa: SLF001
-                self._handle
-            )
+            out, err = await self._target.read_output(self._handle)
             # Read the log files in chunks, yielding lines as they appear.
             # If the job is done, yield any remaining partial lines too.
             stdout_items = emit("stdout", out, final=done)

--- a/tests/unit/executor/test_collect_side_artifacts.py
+++ b/tests/unit/executor/test_collect_side_artifacts.py
@@ -138,6 +138,7 @@ class _InMemoryRemoteTarget(BaseTarget):
         *,
         cwd: str | None = None,
         env: dict[str, str] | None = None,
+        detach: bool | None = None,
     ) -> ChannelProcess:
         raise NotImplementedError
 
@@ -236,6 +237,7 @@ class _MaliciousRemoteTarget(BaseTarget):
         *,
         cwd: str | None = None,
         env: dict[str, str] | None = None,
+        detach: bool | None = None,
     ) -> ChannelProcess:
         raise NotImplementedError
 

--- a/tests/unit/executor/test_collect_side_artifacts.py
+++ b/tests/unit/executor/test_collect_side_artifacts.py
@@ -33,7 +33,11 @@ from horus_builtin.runtime.command import CommandRuntime
 from horus_builtin.task.horus_task import HorusTask
 from horus_runtime.core.artifact.base import BaseArtifact
 from horus_runtime.core.target.base import BaseTarget
-from horus_runtime.core.target.channel import ChannelProcess, RemoteDirEntry
+from horus_runtime.core.target.channel import (
+    ChannelProcess,
+    JobHandle,
+    RemoteDirEntry,
+)
 from horus_runtime.settings import runtime_settings
 from tests.conftest import MakeTaskType
 
@@ -132,14 +136,32 @@ class _InMemoryRemoteTarget(BaseTarget):
     def access_cost(self, _: BaseArtifact) -> float | None:
         return None  # not accessible on the orchestrator fs
 
-    async def run_command(
+    async def run_command_sync(
         self,
         cmd: str,
         *,
         cwd: str | None = None,
         env: dict[str, str] | None = None,
-        detach: bool | None = None,
     ) -> ChannelProcess:
+        raise NotImplementedError
+
+    async def launch(
+        self,
+        cmd: str,
+        *,
+        cwd: str | None,
+        env: dict[str, str] | None,
+        job_dir: str,
+    ) -> JobHandle:
+        raise NotImplementedError
+
+    async def poll(self, handle: JobHandle) -> int | None:
+        raise NotImplementedError
+
+    async def read_output(self, handle: JobHandle) -> tuple[bytes, bytes]:
+        raise NotImplementedError
+
+    async def send_signal(self, handle: JobHandle, sig: int) -> None:
         raise NotImplementedError
 
     async def put_file(
@@ -231,14 +253,32 @@ class _MaliciousRemoteTarget(BaseTarget):
     def access_cost(self, _: BaseArtifact) -> float | None:
         return None
 
-    async def run_command(
+    async def run_command_sync(
         self,
         cmd: str,
         *,
         cwd: str | None = None,
         env: dict[str, str] | None = None,
-        detach: bool | None = None,
     ) -> ChannelProcess:
+        raise NotImplementedError
+
+    async def launch(
+        self,
+        cmd: str,
+        *,
+        cwd: str | None,
+        env: dict[str, str] | None,
+        job_dir: str,
+    ) -> JobHandle:
+        raise NotImplementedError
+
+    async def poll(self, handle: JobHandle) -> int | None:
+        raise NotImplementedError
+
+    async def read_output(self, handle: JobHandle) -> tuple[bytes, bytes]:
+        raise NotImplementedError
+
+    async def send_signal(self, handle: JobHandle, sig: int) -> None:
         raise NotImplementedError
 
     async def put_file(

--- a/tests/unit/middleware/test_middleware.py
+++ b/tests/unit/middleware/test_middleware.py
@@ -31,7 +31,11 @@ from horus_runtime.core.interaction.base import BaseInteraction
 from horus_runtime.core.interaction.renderer import BaseInteractionRenderer
 from horus_runtime.core.interaction.transport import BaseInteractionTransport
 from horus_runtime.core.target.base import BaseTarget
-from horus_runtime.core.target.channel import ChannelProcess, RemoteDirEntry
+from horus_runtime.core.target.channel import (
+    ChannelProcess,
+    JobHandle,
+    RemoteDirEntry,
+)
 from horus_runtime.core.task.base import BaseTask
 from horus_runtime.core.task.status import TaskStatus
 from horus_runtime.middleware.auto_middleware import AutoMiddleware
@@ -134,14 +138,44 @@ class TrackingTarget(BaseTarget):
         """
         return 0.0
 
-    async def run_command(
+    async def run_command_sync(
         self,
         cmd: str,
         *,
         cwd: str | None = None,
         env: dict[str, str] | None = None,
-        detach: bool | None = None,
     ) -> ChannelProcess:
+        """
+        Stub channel method — not used in middleware tests.
+        """
+        raise NotImplementedError
+
+    async def launch(
+        self,
+        cmd: str,
+        *,
+        cwd: str | None,
+        env: dict[str, str] | None,
+        job_dir: str,
+    ) -> JobHandle:
+        """
+        Stub channel method — not used in middleware tests.
+        """
+        raise NotImplementedError
+
+    async def poll(self, handle: JobHandle) -> int | None:
+        """
+        Stub channel method — not used in middleware tests.
+        """
+        raise NotImplementedError
+
+    async def read_output(self, handle: JobHandle) -> tuple[bytes, bytes]:
+        """
+        Stub channel method — not used in middleware tests.
+        """
+        raise NotImplementedError
+
+    async def send_signal(self, handle: JobHandle, sig: int) -> None:
         """
         Stub channel method — not used in middleware tests.
         """

--- a/tests/unit/middleware/test_middleware.py
+++ b/tests/unit/middleware/test_middleware.py
@@ -140,6 +140,7 @@ class TrackingTarget(BaseTarget):
         *,
         cwd: str | None = None,
         env: dict[str, str] | None = None,
+        detach: bool | None = None,
     ) -> ChannelProcess:
         """
         Stub channel method — not used in middleware tests.

--- a/tests/unit/target/test_detach.py
+++ b/tests/unit/target/test_detach.py
@@ -33,7 +33,7 @@ import pytest
 
 from horus_builtin.target.local import LocalChannelProcess, LocalTarget
 from horus_runtime.core.target.channel import (
-    _PollingChannelProcess,
+    PollingChannelProcess,
     build_detach_command,
     new_job_dir,
 )
@@ -56,13 +56,13 @@ class TestDetachDefaults:
         assert isinstance(proc, LocalChannelProcess)
         assert await proc.wait() == 0
 
-    async def test_explicit_detach_returns_polling_process(
+    async def test_explicit_detach_returnspolling_process(
         self, tmp_path: Path
     ) -> None:
         """Explicit detach=True yields a polling process."""
         target = LocalTarget(working_directory=tmp_path.as_posix())
         proc = await target.run_command("true", detach=True)
-        assert isinstance(proc, _PollingChannelProcess)
+        assert isinstance(proc, PollingChannelProcess)
         assert await proc.wait() == 0
 
 

--- a/tests/unit/target/test_detach.py
+++ b/tests/unit/target/test_detach.py
@@ -1,0 +1,148 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Unit tests for detachable execution: the ``run_command`` template method,
+the shared ``_PollingChannelProcess``, and the ``LocalTarget`` primitives.
+
+These exercise the real detach path (nohup'd subprocess + marker files) since
+``LocalTarget`` runs on the local filesystem.
+"""
+
+import asyncio
+import signal
+from contextlib import aclosing
+from pathlib import Path
+
+import pytest
+
+from horus_builtin.target.local import LocalChannelProcess, LocalTarget
+from horus_runtime.core.target.channel import (
+    _PollingChannelProcess,
+    build_detach_command,
+    new_job_dir,
+)
+
+
+@pytest.mark.unit
+class TestDetachDefaults:
+    """The default detach behavior is target-specific."""
+
+    def test_local_defaults_to_sync(self) -> None:
+        """LocalTarget keeps the synchronous path by default."""
+        assert LocalTarget.detach_by_default is False
+
+    async def test_local_sync_path_returns_local_channel_process(
+        self, tmp_path: Path
+    ) -> None:
+        """Default (non-detached) LocalTarget keeps its live-streaming path."""
+        target = LocalTarget(working_directory=tmp_path.as_posix())
+        proc = await target.run_command("echo hi")
+        assert isinstance(proc, LocalChannelProcess)
+        assert await proc.wait() == 0
+
+    async def test_explicit_detach_returns_polling_process(
+        self, tmp_path: Path
+    ) -> None:
+        """Explicit detach=True yields a polling process."""
+        target = LocalTarget(working_directory=tmp_path.as_posix())
+        proc = await target.run_command("true", detach=True)
+        assert isinstance(proc, _PollingChannelProcess)
+        assert await proc.wait() == 0
+
+
+@pytest.mark.unit
+class TestLocalDetachedExecution:
+    """End-to-end detached execution on LocalTarget."""
+
+    async def test_captures_output_and_exit_code(self, tmp_path: Path) -> None:
+        """Detached run captures stdout/stderr and a zero exit code."""
+        target = LocalTarget(working_directory=tmp_path.as_posix())
+        proc = await target.run_command(
+            "echo out; echo err 1>&2", cwd=tmp_path.as_posix(), detach=True
+        )
+        out, err = await proc.communicate()
+        assert proc.returncode == 0
+        assert out == b"out\n"
+        assert err == b"err\n"
+
+    async def test_nonzero_exit_code_is_recorded(self, tmp_path: Path) -> None:
+        """A non-zero exit code survives the exit_code marker round trip."""
+        target = LocalTarget(working_directory=tmp_path.as_posix())
+        proc = await target.run_command("exit 3", detach=True)
+        assert await proc.wait() == 3
+
+    async def test_env_and_cwd_are_applied(self, tmp_path: Path) -> None:
+        """Env vars and cwd are inlined into the detached command."""
+        workdir = tmp_path / "work"
+        workdir.mkdir()
+        target = LocalTarget(working_directory=tmp_path.as_posix())
+        proc = await target.run_command(
+            'echo "$GREETING in $(basename "$PWD")"',
+            cwd=workdir.as_posix(),
+            env={"GREETING": "hello"},
+            detach=True,
+        )
+        out, _ = await proc.communicate()
+        assert out == b"hello in work\n"
+
+    async def test_stream_yields_lines(self, tmp_path: Path) -> None:
+        """stream() yields captured stdout/stderr lines with labels."""
+        target = LocalTarget(working_directory=tmp_path.as_posix())
+        proc = await target.run_command(
+            "echo a; echo b; echo c 1>&2", detach=True
+        )
+        seen: list[tuple[str, bytes]] = []
+        async with aclosing(proc.stream()) as stream:
+            async for name, line in stream:
+                seen.append((name, line))
+        assert (b"a\n") in [line for _, line in seen]
+        assert ("stderr", b"c\n") in seen
+        # Draining the stream hits EOF; wait() still reports the exit code.
+        assert await proc.wait() == 0
+
+    async def test_signal_terminates_detached_job(
+        self, tmp_path: Path
+    ) -> None:
+        """signal() reaches the detached job and ends it."""
+        target = LocalTarget(working_directory=tmp_path.as_posix())
+        proc = await target.run_command("sleep 30", detach=True)
+        # Give the nohup'd job a moment to start, then kill it.
+        await asyncio.sleep(0.3)
+        proc.signal(signal.SIGKILL)
+        rc = await asyncio.wait_for(proc.wait(), timeout=5)
+        assert rc != 0
+
+
+@pytest.mark.unit
+class TestDetachHelpers:
+    """The shared wrapper/marker-dir helpers."""
+
+    def test_new_job_dir_is_unique_and_under_base(self) -> None:
+        """Each call returns a distinct marker dir under the base."""
+        a = new_job_dir("/tmp/x")
+        b = new_job_dir("/tmp/x")
+        assert a != b
+        assert a.startswith("/tmp/x/.horus_job/")
+
+    def test_wrapper_records_pid_and_exit_code(self) -> None:
+        """The wrapper nohups the job and records pid/exit_code/logs."""
+        wrapper = build_detach_command("mycmd", "/jobs/1")
+        assert "nohup" in wrapper
+        assert "/jobs/1/pid" in wrapper
+        assert "/jobs/1/exit_code" in wrapper
+        assert "/jobs/1/stdout.log" in wrapper

--- a/tests/unit/target/test_detach.py
+++ b/tests/unit/target/test_detach.py
@@ -24,6 +24,7 @@ These exercise the real detach path (nohup'd subprocess + marker files) since
 """
 
 import asyncio
+import os
 import signal
 from contextlib import aclosing
 from pathlib import Path
@@ -127,6 +128,38 @@ class TestLocalDetachedExecution:
         rc = await asyncio.wait_for(proc.wait(), timeout=5)
         assert rc != 0
 
+    async def test_signal_kills_child_processes(self, tmp_path: Path) -> None:
+        """
+        signal() targets the whole process group, so a child the command
+        spawned is stopped too (not left orphaned).
+        """
+        marker = tmp_path / "child.pid"
+        target = LocalTarget(working_directory=tmp_path.as_posix())
+        # Spawn a background grandchild that records its pid, then both sleep.
+        proc = await target.run_command(
+            f"sleep 30 & echo $! > {marker.as_posix()}; wait",
+            detach=True,
+        )
+
+        for _ in range(50):  # wait for the child to record its pid
+            if marker.exists() and marker.read_text().strip():
+                break
+            await asyncio.sleep(0.1)
+        child_pid = int(marker.read_text().strip())
+        assert os.getpgid(child_pid)  # child is alive
+
+        proc.signal(signal.SIGKILL)
+        await asyncio.wait_for(proc.wait(), timeout=5)
+
+        for _ in range(50):  # child should die with the group
+            try:
+                os.kill(child_pid, 0)
+            except ProcessLookupError:
+                break
+            await asyncio.sleep(0.1)
+        with pytest.raises(ProcessLookupError):
+            os.kill(child_pid, 0)
+
 
 @pytest.mark.unit
 class TestDetachHelpers:
@@ -140,9 +173,15 @@ class TestDetachHelpers:
         assert a.startswith("/tmp/x/.horus_job/")
 
     def test_wrapper_records_pid_and_exit_code(self) -> None:
-        """The wrapper nohups the job and records pid/exit_code/logs."""
+        """The wrapper backgrounds the job and records pid/exit_code/logs."""
         wrapper = build_detach_command("mycmd", "/jobs/1")
         assert "nohup" in wrapper
         assert "/jobs/1/pid" in wrapper
         assert "/jobs/1/exit_code" in wrapper
         assert "/jobs/1/stdout.log" in wrapper
+
+    def test_wrapper_session_leader_uses_setsid(self) -> None:
+        """session_leader launches under setsid for group signalling."""
+        wrapper = build_detach_command("mycmd", "/jobs/1", session_leader=True)
+        assert "setsid" in wrapper
+        assert "nohup" not in wrapper

--- a/tests/unit/target/test_target_base.py
+++ b/tests/unit/target/test_target_base.py
@@ -30,7 +30,11 @@ from horus_builtin.runtime.command import CommandRuntime
 from horus_builtin.task.horus_task import HorusTask
 from horus_runtime.core.artifact.base import BaseArtifact
 from horus_runtime.core.target.base import BaseTarget
-from horus_runtime.core.target.channel import ChannelProcess, RemoteDirEntry
+from horus_runtime.core.target.channel import (
+    ChannelProcess,
+    JobHandle,
+    RemoteDirEntry,
+)
 from horus_runtime.registry.auto_registry import AutoRegistry
 
 
@@ -65,6 +69,39 @@ class ConcreteTestTarget(BaseTarget):
         """
         Stub channel method — not used in base-class tests.
         """
+        raise NotImplementedError
+
+    async def run_command_sync(
+        self,
+        cmd: str,
+        *,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> ChannelProcess:
+        """Stub channel method — not used in base-class tests."""
+        raise NotImplementedError
+
+    async def launch(
+        self,
+        cmd: str,
+        *,
+        cwd: str | None,
+        env: dict[str, str] | None,
+        job_dir: str,
+    ) -> JobHandle:
+        """Stub channel method — not used in base-class tests."""
+        raise NotImplementedError
+
+    async def poll(self, _handle: JobHandle) -> int | None:
+        """Stub channel method — not used in base-class tests."""
+        raise NotImplementedError
+
+    async def read_output(self, _handle: JobHandle) -> tuple[bytes, bytes]:
+        """Stub channel method — not used in base-class tests."""
+        raise NotImplementedError
+
+    async def send_signal(self, _handle: JobHandle, _sig: int) -> None:
+        """Stub channel method — not used in base-class tests."""
         raise NotImplementedError
 
     async def put_file(

--- a/tests/unit/target/test_target_base.py
+++ b/tests/unit/target/test_target_base.py
@@ -60,6 +60,7 @@ class ConcreteTestTarget(BaseTarget):
         *,
         cwd: str | None = None,
         env: dict[str, str] | None = None,
+        detach: bool | None = None,
     ) -> ChannelProcess:
         """
         Stub channel method — not used in base-class tests.

--- a/tests/unit/transfer/test_transfer.py
+++ b/tests/unit/transfer/test_transfer.py
@@ -69,6 +69,7 @@ class _UnregisteredTarget(BaseTarget):
         *,
         cwd: str | None = None,
         env: dict[str, str] | None = None,
+        detach: bool | None = None,
     ) -> ChannelProcess:
         """
         Not used in transfer tests.

--- a/tests/unit/transfer/test_transfer.py
+++ b/tests/unit/transfer/test_transfer.py
@@ -27,7 +27,11 @@ from horus_builtin.target.local import LocalTarget
 from horus_builtin.transfer.local_noop import LocalNoOpTransfer
 from horus_runtime.core.artifact.base import BaseArtifact
 from horus_runtime.core.target.base import BaseTarget
-from horus_runtime.core.target.channel import ChannelProcess, RemoteDirEntry
+from horus_runtime.core.target.channel import (
+    ChannelProcess,
+    JobHandle,
+    RemoteDirEntry,
+)
 from horus_runtime.core.task.base import BaseTask
 from horus_runtime.core.task.status import TaskStatus
 from horus_runtime.core.transfer.strategy import BaseTransferStrategy
@@ -63,14 +67,44 @@ class _UnregisteredTarget(BaseTarget):
         del artifact
         return 0.0
 
-    async def run_command(
+    async def run_command_sync(
         self,
         cmd: str,
         *,
         cwd: str | None = None,
         env: dict[str, str] | None = None,
-        detach: bool | None = None,
     ) -> ChannelProcess:
+        """
+        Not used in transfer tests.
+        """
+        raise NotImplementedError
+
+    async def launch(
+        self,
+        cmd: str,
+        *,
+        cwd: str | None,
+        env: dict[str, str] | None,
+        job_dir: str,
+    ) -> JobHandle:
+        """
+        Not used in transfer tests.
+        """
+        raise NotImplementedError
+
+    async def poll(self, handle: JobHandle) -> int | None:
+        """
+        Not used in transfer tests.
+        """
+        raise NotImplementedError
+
+    async def read_output(self, handle: JobHandle) -> tuple[bytes, bytes]:
+        """
+        Not used in transfer tests.
+        """
+        raise NotImplementedError
+
+    async def send_signal(self, handle: JobHandle, sig: int) -> None:
         """
         Not used in transfer tests.
         """


### PR DESCRIPTION
## Why

A real failure motivates this: a Boltz-2 virtual-screening workflow ran a 3+ hour CPU prediction over SSH to host `awow`. `horus-ssh` held a single foreground SSH exec channel open for the whole command; the remote process was a plain child of that channel (no `nohup`/`disown`), so a mid-run network drop killed the channel **and** the job. Keepalive tuning can't fix that — only detaching the process from the channel does.

This is also the groundwork for issue #97 (checkpoint/resume): the same primitives back a future `recover()`.

## What

Detachment moves into the **target layer**, so it's not an executor opt-in. `run_command` becomes a template method; every existing caller (`shell`, `uv_python_environment`, `docker` executors) gains detach with **zero changes to its streaming/`communicate` path**.

- **`channel.py`** — `JobHandle`, `build_detach_command` (nohup + `pid`/`exit_code`/log markers), `new_job_dir`, and `_PollingChannelProcess` (implements `wait`/`communicate`/`stream`/`kill`/`signal` by polling the target primitives instead of holding a channel open).
- **`base.py`** — `run_command` is now a concrete template with `detach: bool | None` resolving to a per-target `detach_by_default`; adds the primitives (`_launch`/`_poll`/`_read_output`/`_send_signal`/`_run_command_sync`) with safe `NotImplementedError` defaults, so any `BaseTarget` subclass that keeps its own `run_command` is unaffected (not `@final`, no new abstract methods — nothing else breaks).
- **`local.py`** — `LocalTarget` implements the primitives but **defaults to the synchronous path** (no droppable channel locally); detachment is still available for recovery.

## Design notes / deviations from the original plan

- **Not `@final` + not abstract primitives.** Forcing abstract primitives would break every other `BaseTarget` subclass (test doubles, out-of-repo `s3_target`, plugins). Defaults make the migration opt-in per target — same end state for SSH/Local, zero collateral.
- **`detach_by_default` is per-target** (SSH on, Local off). Detach only helps where a channel can drop; defaulting it on for Local regressed streaming semantics (ordering, before-exit delivery) for no benefit.

## Tests

`tests/unit/target/test_detach.py` (10 tests) exercises the real Local detach path (nohup + markers), wrapper/marker helpers, and the polling process. Full suite: **403 passed, 92% coverage**.

The SSH-side detach primitives ship in the companion horus-ssh PR; docker/environments carry one-line adjustments in their own PRs. Real network-drop verification against `awow` is manual (needs the remote host).

https://github.com/temple-compute/horus-docs/pull/31