### PR TITLE
Added working dir propagation of the orchestrator to local

### DIFF
--- a/src/horus_builtin/target/local.py
+++ b/src/horus_builtin/target/local.py
@@ -117,6 +117,15 @@ class LocalTarget(BaseTarget):
         """
         return f"local://{socket.gethostname()}"
 
+    @property
+    def resolved_working_directory(self) -> str:
+        """
+        Fall back to the current working directory when none was set, so a
+        plain ``LocalTarget()`` runs tasks under the process CWD without
+        requiring an explicit path.
+        """
+        return self.working_directory or Path.cwd().as_posix()
+
     def access_cost(self, artifact: BaseArtifact) -> float | None:
         """
         Return ``0.0`` for artifacts that already exist on this machine and

--- a/src/horus_runtime/core/target/base.py
+++ b/src/horus_runtime/core/target/base.py
@@ -24,7 +24,7 @@ from abc import abstractmethod
 from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar, final
 
-from pydantic import Field, PrivateAttr
+from pydantic import PrivateAttr
 
 from horus_runtime.core.target.channel import (
     ChannelProcess,
@@ -33,6 +33,7 @@ from horus_runtime.core.target.channel import (
     RemoteDirEntry,
     new_job_dir,
 )
+from horus_runtime.core.target.exceptions import WorkingDirectoryNotSetError
 from horus_runtime.core.task.exceptions import TaskExecutionError
 from horus_runtime.core.task.status import TaskStatus
 from horus_runtime.i18n import tr as _
@@ -67,16 +68,36 @@ class BaseTarget(AutoRegistry, entry_point="target"):
     Human-friendly description of this kind of target.
     """
 
-    working_directory: str = Field(
-        default_factory=lambda: Path.cwd().as_posix()
-    )
+    working_directory: str | None = None
     """
     Base directory on the target host where per-task working directories are
-    created.
+    created. Left ``None`` until resolved: the workflow fills it in for targets
+    co-located with the orchestrator (see
+    :meth:`BaseWorkflow._propagate_orchestrator_working_directory`); every
+    other target decides for itself what an unset value means via
+    :attr:`resolved_working_directory`.
     """
 
     _task: "BaseTask | None" = PrivateAttr(default=None)
     _task_future: "asyncio.Task[None] | None" = PrivateAttr(default=None)
+
+    @property
+    def resolved_working_directory(self) -> str:
+        """
+        The base working directory as a concrete path, resolved at use time.
+
+        ``working_directory`` may be ``None``. The base contract requires it to
+        have been set (explicitly or by orchestrator propagation) and raises
+        otherwise; targets that can derive a sensible default when it is unset
+        (e.g. the local machine's current directory) override this property.
+
+        Raises:
+            WorkingDirectoryNotSetError: When ``working_directory`` is ``None``
+                and the target does not derive one.
+        """
+        if self.working_directory is None:
+            raise WorkingDirectoryNotSetError(self.kind)
+        return self.working_directory
 
     @property
     @abstractmethod
@@ -268,7 +289,7 @@ class BaseTarget(AutoRegistry, entry_point="target"):
             detach = self.detach_by_default
         if not detach:
             return await self.run_command_sync(cmd, cwd=cwd, env=env)
-        job_dir = new_job_dir(cwd or self.working_directory)
+        job_dir = new_job_dir(cwd or self.resolved_working_directory)
         handle = await self.launch(cmd, cwd=cwd, env=env, job_dir=job_dir)
         return PollingChannelProcess(self, handle)
 

--- a/src/horus_runtime/core/target/exceptions.py
+++ b/src/horus_runtime/core/target/exceptions.py
@@ -1,0 +1,49 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Exceptions related to task targets in the Horus runtime.
+"""
+
+from horus_runtime.i18n import tr as _
+
+
+class BaseTargetError(Exception):
+    """
+    Base exception for target-related errors in the Horus runtime.
+    """
+
+
+class WorkingDirectoryNotSetError(BaseTargetError):
+    """
+    Raised when a target's working directory is required but was never set.
+
+    ``BaseTarget.working_directory`` defaults to ``None``. The workflow fills
+    it in for targets co-located with the orchestrator; every other target
+    must either be given an explicit ``working_directory`` or override
+    :attr:`BaseTarget.resolved_working_directory` to derive one.
+    """
+
+    def __init__(self, kind: str) -> None:
+        super().__init__(
+            _(
+                "Target '%(kind)s' has no working_directory set. Provide one "
+                "explicitly or use a target that derives it automatically."
+            )
+            % {"kind": kind}
+        )
+        self.kind = kind

--- a/src/horus_runtime/core/task/base.py
+++ b/src/horus_runtime/core/task/base.py
@@ -169,7 +169,9 @@ class BaseTask(AutoRegistry, entry_point="task"):
         working directory. Inputs are materialized here and outputs and
         side-products are written relative to it.
         """
-        return (Path(self.target.working_directory) / self.id).as_posix()
+        return (
+            Path(self.target.resolved_working_directory) / self.id
+        ).as_posix()
 
     @property
     def side_artifacts_dir(self) -> str:

--- a/src/horus_runtime/core/workflow/base.py
+++ b/src/horus_runtime/core/workflow/base.py
@@ -391,6 +391,31 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
             artifact.path = transfer_art.path
 
     @final
+    def _propagate_orchestrator_working_directory(self) -> None:
+        """
+        Give every co-located task target the orchestrator target's working
+        directory as its base, so local tasks run inside the orchestrator's
+        folder (each still nested under its own ``working_dir / task.id``).
+
+        A target is co-located with the orchestrator when it shares its
+        ``location_id`` (same filesystem). A task target that already has a
+        ``working_directory`` set (not ``None``) is left untouched.
+        """
+        if self.orchestrator_target is None:
+            return
+
+        base = self.orchestrator_target.working_directory
+        if base is None:
+            return
+
+        orchestrator_loc = self.orchestrator_target.location_id
+        for task in self.tasks:
+            target = task.target
+            if target.working_directory is not None:
+                continue
+            if target.location_id == orchestrator_loc:
+                target.working_directory = base
+
     async def run(self, trigger_id: str) -> None:
         """
         Execute the workflow, managing status transitions automatically.
@@ -418,6 +443,11 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
             _("Workflow %(workflow_name)s status → RUNNING")
             % {"workflow_name": self.name}
         )
+
+        # Co-located task targets inherit the orchestrator's working
+        # directory so all such tasks run under that common folder.
+        self._propagate_orchestrator_working_directory()
+
         try:
             # Wrap the function to pass the trigger.
             def call_run() -> Awaitable[None]:

--- a/tests/unit/target/test_local_target.py
+++ b/tests/unit/target/test_local_target.py
@@ -77,6 +77,23 @@ class TestLocalTargetProperties:
         artifact = Mock(path=Path("/definitely/nonexistent/file.txt"))
         assert target.access_cost(artifact) is None
 
+    def test_resolved_working_directory_falls_back_to_cwd(self) -> None:
+        """
+        With no working_directory set, LocalTarget resolves to the process
+        CWD (the historical default) instead of raising.
+        """
+        target = LocalTarget()
+        assert target.working_directory is None
+        assert target.resolved_working_directory == Path.cwd().as_posix()
+
+    def test_resolved_working_directory_uses_explicit_value(self) -> None:
+        """
+        An explicit working_directory is returned as-is, not overridden by the
+        CWD fallback.
+        """
+        target = LocalTarget(working_directory="/explicit/dir")
+        assert target.resolved_working_directory == "/explicit/dir"
+
 
 @pytest.mark.unit
 class TestLocalTargetDispatch:

--- a/tests/unit/target/test_target_base.py
+++ b/tests/unit/target/test_target_base.py
@@ -35,6 +35,7 @@ from horus_runtime.core.target.channel import (
     JobHandle,
     RemoteDirEntry,
 )
+from horus_runtime.core.target.exceptions import WorkingDirectoryNotSetError
 from horus_runtime.registry.auto_registry import AutoRegistry
 
 
@@ -199,3 +200,26 @@ class TestBaseTarget:
         target.bind(task)
 
         assert target._task is task
+
+    def test_working_directory_defaults_to_none(self) -> None:
+        """
+        working_directory is left unset (None) until resolved, so the
+        workflow can distinguish "not set" from an explicit value.
+        """
+        assert ConcreteTestTarget().working_directory is None
+
+    def test_resolved_working_directory_returns_set_value(self) -> None:
+        """
+        When working_directory is set, the base resolver returns it verbatim.
+        """
+        target = ConcreteTestTarget(working_directory="/some/dir")
+        assert target.resolved_working_directory == "/some/dir"
+
+    def test_resolved_working_directory_raises_when_unset(self) -> None:
+        """
+        The base contract requires working_directory to have been resolved; a
+        target that neither sets it nor overrides the resolver raises.
+        """
+        target = ConcreteTestTarget()
+        with pytest.raises(WorkingDirectoryNotSetError):
+            _ = target.resolved_working_directory

--- a/tests/unit/workflow/test_builtin_workflow.py
+++ b/tests/unit/workflow/test_builtin_workflow.py
@@ -132,6 +132,90 @@ class TestWorkflowConstruction:
 
 
 @pytest.mark.unit
+class TestOrchestratorWorkingDirectoryPropagation:
+    """
+    Tests that local (co-located) task targets inherit the orchestrator
+    target's working directory.
+    """
+
+    def _make_task(self, task_id: str, target: LocalTarget) -> HorusTask:
+        return HorusTask(
+            id=task_id,
+            name=task_id,
+            runtime=CommandRuntime(command="echo hi"),
+            executor=ShellExecutor(),
+            target=target,
+        )
+
+    def test_local_task_inherits_orchestrator_working_directory(
+        self, tmp_path: Path
+    ) -> None:
+        """
+        A task whose local target left ``working_directory`` at its default
+        runs under the orchestrator target's folder (nested by task id).
+        """
+        folder = tmp_path / "orchestrator_folder"
+        task = self._make_task("worker", LocalTarget())
+        wf = HorusWorkflow(
+            name="propagation",
+            tasks=[task],
+            orchestrator_target=LocalTarget(
+                working_directory=folder.as_posix()
+            ),
+        )
+
+        wf._propagate_orchestrator_working_directory()
+
+        assert task.target.working_directory == folder.as_posix()
+        assert task.working_dir == (folder / "worker").as_posix()
+
+    def test_explicit_task_working_directory_is_preserved(
+        self, tmp_path: Path
+    ) -> None:
+        """
+        A task target that set its own ``working_directory`` keeps it and is
+        not overridden by the orchestrator folder.
+        """
+        orchestrator_folder = tmp_path / "orchestrator_folder"
+        task_folder = tmp_path / "task_folder"
+        task = self._make_task(
+            "worker", LocalTarget(working_directory=task_folder.as_posix())
+        )
+        wf = HorusWorkflow(
+            name="propagation_override",
+            tasks=[task],
+            orchestrator_target=LocalTarget(
+                working_directory=orchestrator_folder.as_posix()
+            ),
+        )
+
+        wf._propagate_orchestrator_working_directory()
+
+        assert task.target.working_directory == task_folder.as_posix()
+        assert task.working_dir == (task_folder / "worker").as_posix()
+
+    def test_unset_orchestrator_folder_leaves_task_to_resolve_cwd(
+        self,
+    ) -> None:
+        """
+        When the orchestrator target has no working_directory, there is nothing
+        to propagate: the local task stays unset and resolves to the CWD via
+        ``LocalTarget.resolved_working_directory``.
+        """
+        task = self._make_task("worker", LocalTarget())
+        wf = HorusWorkflow(
+            name="propagation_noop",
+            tasks=[task],
+            orchestrator_target=LocalTarget(),
+        )
+
+        wf._propagate_orchestrator_working_directory()
+
+        assert task.target.working_directory is None
+        assert task.working_dir == (Path.cwd() / "worker").as_posix()
+
+
+@pytest.mark.unit
 class TestWorkflowRun:
     """
     Tests for the run method of the Workflow class.


### PR DESCRIPTION
## Summary

Working directory now propagates to task targets with the same location. For example, local tasks will use the orchestrator's working directory.

## Documentation impact

If a user, plugin, or GUI can observe the difference, it requires documentation.

- [x] No documentation update required
- [ ] Documentation updated / will be updated
