### PR TITLE
fix(target/workflow): anchor local tasks and artifacts to run directory

### DIFF
--- a/src/horus_builtin/runtime/python_script.py
+++ b/src/horus_builtin/runtime/python_script.py
@@ -66,6 +66,11 @@ class PythonScriptRuntime(CommandRuntime):
 
     command: str = ""
 
+    def anchor_local_paths(self, base: Path) -> None:
+        """Resolve ``script`` against ``base`` if it is a relative path."""
+        if not self.script.is_absolute():
+            self.script = (base / self.script).resolve()
+
     async def _setup_runtime(self, task: "BaseTask") -> str:
         remote_path = f"{task.working_dir}/{self.script.name}"
 

--- a/src/horus_builtin/target/local.py
+++ b/src/horus_builtin/target/local.py
@@ -123,8 +123,15 @@ class LocalTarget(BaseTarget):
         Fall back to the current working directory when none was set, so a
         plain ``LocalTarget()`` runs tasks under the process CWD without
         requiring an explicit path.
+
+        The result is always absolute. ``working_dir`` is used both as the
+        subprocess ``cwd`` and as an in-command path prefix; a relative value
+        (e.g. propagated from a relative orchestrator target) would be applied
+        twice and double the path. Resolving here against the process launch
+        directory keeps the prefix harmless when chdir'd into the same folder.
         """
-        return self.working_directory or Path.cwd().as_posix()
+        wd = self.working_directory or Path.cwd().as_posix()
+        return Path(wd).resolve().as_posix()
 
     def access_cost(self, artifact: BaseArtifact) -> float | None:
         """

--- a/src/horus_runtime/core/artifact/base.py
+++ b/src/horus_runtime/core/artifact/base.py
@@ -26,7 +26,7 @@ from abc import abstractmethod
 from pathlib import Path
 from typing import Annotated, Any, ClassVar, Self
 
-from pydantic import BeforeValidator, PrivateAttr, model_validator
+from pydantic import BeforeValidator, Field, model_validator
 
 from horus_builtin.event.artifact_event import (
     ArtifactEvent,
@@ -100,7 +100,7 @@ class BaseArtifact[T: Any = Any](AutoRegistry, entry_point="artifact"):
     Absolute local filesystem path where the artifact materializes.
     """
 
-    _declared_path: Path | None = PrivateAttr(default=None)
+    declared_path: Path | None = Field(default=None, init=False, exclude=True)
     """
     The path exactly as declared (before resolution), preserved so a workflow
     can re-anchor relative artifact paths to its run directory. ``None`` until
@@ -145,11 +145,11 @@ class BaseArtifact[T: Any = Any](AutoRegistry, entry_point="artifact"):
         """
         Normalize artifact paths to absolute resolved paths.
 
-        The declared (pre-resolution) path is preserved on ``_declared_path``
+        The declared (pre-resolution) path is preserved on ``declared_path``
         so a workflow can re-anchor a relative path to its run directory; the
         eager CWD resolution here remains the default for standalone use.
         """
-        self._declared_path = self.path
+        self.declared_path = self.path
         self.path = self.path.resolve()
         return self
 

--- a/src/horus_runtime/core/artifact/base.py
+++ b/src/horus_runtime/core/artifact/base.py
@@ -26,7 +26,7 @@ from abc import abstractmethod
 from pathlib import Path
 from typing import Annotated, Any, ClassVar, Self
 
-from pydantic import BeforeValidator, model_validator
+from pydantic import BeforeValidator, PrivateAttr, model_validator
 
 from horus_builtin.event.artifact_event import (
     ArtifactEvent,
@@ -100,6 +100,13 @@ class BaseArtifact[T: Any = Any](AutoRegistry, entry_point="artifact"):
     Absolute local filesystem path where the artifact materializes.
     """
 
+    _declared_path: Path | None = PrivateAttr(default=None)
+    """
+    The path exactly as declared (before resolution), preserved so a workflow
+    can re-anchor relative artifact paths to its run directory. ``None`` until
+    :meth:`resolve_path` runs. See ``BaseWorkflow._resolve_run_paths``.
+    """
+
     kind: str
     """
     Type of the artifact, such as 'file', 'folder', 'dataset', 'model', etc.
@@ -137,7 +144,12 @@ class BaseArtifact[T: Any = Any](AutoRegistry, entry_point="artifact"):
     def resolve_path(self) -> Self:
         """
         Normalize artifact paths to absolute resolved paths.
+
+        The declared (pre-resolution) path is preserved on ``_declared_path``
+        so a workflow can re-anchor a relative path to its run directory; the
+        eager CWD resolution here remains the default for standalone use.
         """
+        self._declared_path = self.path
         self.path = self.path.resolve()
         return self
 

--- a/src/horus_runtime/core/runtime/base.py
+++ b/src/horus_runtime/core/runtime/base.py
@@ -22,6 +22,7 @@ functionality for executing tasks, and should be ingested by the executor.
 """
 
 from abc import abstractmethod
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, final
 
 from horus_runtime.i18n import tr as _
@@ -57,6 +58,12 @@ class BaseRuntime[T: Any = Any](AutoRegistry, entry_point="runtime"):
     """
     Description of this runtime type, used in the UI.
     """
+
+    def anchor_local_paths(self, base: Path) -> None:
+        """
+        Resolve any relative local file paths this runtime owns against `base`.
+        Called by the workflow before execution. No-op by default.
+        """
 
     @abstractmethod
     async def _setup_runtime(self, task: "BaseTask") -> T:

--- a/src/horus_runtime/core/workflow/base.py
+++ b/src/horus_runtime/core/workflow/base.py
@@ -270,7 +270,7 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
         # Anchor the run (working dirs, outputs, logs) to the workflow file's
         # own directory, so a run is self-contained regardless of the launch
         # directory.
-        workflow._base_directory = Path(path).resolve().parent
+        workflow._base_directory = Path(path).resolve().parent  # noqa: SLF001
         return workflow
 
     def to_yaml(self, path: str | Path) -> None:
@@ -453,14 +453,14 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
             self.orchestrator_target.working_directory = run_root.as_posix()
 
         produced = {
-            artifact._declared_path
+            artifact.declared_path
             for task in self.tasks
             for artifact in task.outputs
-            if artifact._declared_path is not None
+            if artifact.declared_path is not None
         }
 
         def anchor(artifact: BaseArtifact) -> None:
-            declared = artifact._declared_path
+            declared = artifact.declared_path
             if declared is None or declared.is_absolute():
                 return
             root = run_root if declared in produced else base
@@ -469,12 +469,7 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
         for task in self.tasks:
             for artifact in (*task.inputs, *task.outputs):
                 anchor(artifact)
-            # A runtime's local source file (e.g. a python_script's ``script``)
-            # is provided relative to the workflow file, so anchor it to the
-            # base dir too. Accessed by name to avoid a core->builtin import.
-            script = getattr(task.runtime, "script", None)
-            if isinstance(script, Path) and not script.is_absolute():
-                task.runtime.script = (base / script).resolve()
+            task.runtime.anchor_local_paths(base)
         for artifact in self.artifacts:
             anchor(artifact)
 

--- a/src/horus_runtime/core/workflow/base.py
+++ b/src/horus_runtime/core/workflow/base.py
@@ -404,6 +404,10 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
             artifact.path = transfer_art.path
 
     @property
+    def _effective_base(self) -> Path:
+        return self._base_directory or Path.cwd()
+
+    @property
     def run_directory(self) -> Path:
         """
         The single root directory for this run's generated files: per-task
@@ -416,7 +420,7 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
         :meth:`from_yaml`, otherwise the process CWD. An absolute orchestrator
         working directory is used as-is.
         """
-        base = self._base_directory or Path.cwd()
+        base = self._effective_base
         wd = (
             self.orchestrator_target.working_directory
             if self.orchestrator_target is not None
@@ -426,7 +430,7 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
         return (base / root).resolve()
 
     @final
-    def _resolve_run_paths(self) -> None:
+    def _resolve_run_paths(self) -> Path:
         """
         Anchor this run's relative paths to the single :attr:`run_directory`.
 
@@ -440,16 +444,16 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
           untouched.
 
         Only relative declared paths are rewritten, so calling this twice is
-        safe.
+        safe. Returns the resolved run root so callers can use it directly.
         """
-        base = self._base_directory or Path.cwd()
+        base = self._effective_base
         run_root = self.run_directory
 
         if self.orchestrator_target is not None:
             self.orchestrator_target.working_directory = run_root.as_posix()
 
         produced = {
-            artifact._declared_path.as_posix()
+            artifact._declared_path
             for task in self.tasks
             for artifact in task.outputs
             if artifact._declared_path is not None
@@ -459,7 +463,7 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
             declared = artifact._declared_path
             if declared is None or declared.is_absolute():
                 return
-            root = run_root if declared.as_posix() in produced else base
+            root = run_root if declared in produced else base
             artifact.path = (root / declared).resolve()
 
         for task in self.tasks:
@@ -473,6 +477,8 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
                 task.runtime.script = (base / script).resolve()
         for artifact in self.artifacts:
             anchor(artifact)
+
+        return run_root
 
     @final
     def _propagate_orchestrator_working_directory(self) -> None:
@@ -522,16 +528,17 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
 
         ctx.workflow = self
 
+        # Anchor working dirs, artifact paths, and logs to a single
+        # self-contained run directory before anything reads them, including
+        # the RUNNING log below (so it lands in the file sink too).
+        run_root = self._resolve_run_paths()
+        horus_logger.set_log_directory(run_root / "logs")
+
         self.status = WorkflowStatus.RUNNING
         horus_logger.log.debug(
             _("Workflow %(workflow_name)s status → RUNNING")
             % {"workflow_name": self.name}
         )
-
-        # Anchor working dirs, artifact paths, and logs to a single
-        # self-contained run directory before anything reads them.
-        self._resolve_run_paths()
-        horus_logger.set_log_directory(self.run_directory / "logs")
 
         # Co-located task targets inherit the orchestrator's working
         # directory so all such tasks run under that common folder.

--- a/src/horus_runtime/core/workflow/base.py
+++ b/src/horus_runtime/core/workflow/base.py
@@ -38,7 +38,7 @@ from typing import ClassVar, NamedTuple, Self, final
 from uuid import UUID, uuid4
 
 import yaml
-from pydantic import Field, model_validator
+from pydantic import Field, PrivateAttr, model_validator
 
 from horus_runtime.context import HorusContext
 from horus_runtime.core.artifact.base import BaseArtifact
@@ -152,6 +152,14 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
     ``run()``; do not set manually.
     """
 
+    _base_directory: Path | None = PrivateAttr(default=None)
+    """
+    Directory relative paths are anchored to (the run directory and, through
+    it, artifact paths and logs). Set to the workflow YAML's folder by
+    :meth:`from_yaml`; ``None`` for programmatically-built workflows, which
+    fall back to the process CWD. Runtime-only state, not serialized.
+    """
+
     @model_validator(mode="after")
     def check_unique_task_ids(self) -> Self:
         """
@@ -258,7 +266,12 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
             A fully constructed :class:`BaseWorkflow` instance.
         """
         with Path(path).open("r", encoding="utf-8") as fh:
-            return cls.model_validate(yaml.safe_load(fh))
+            workflow = cls.model_validate(yaml.safe_load(fh))
+        # Anchor the run (working dirs, outputs, logs) to the workflow file's
+        # own directory, so a run is self-contained regardless of the launch
+        # directory.
+        workflow._base_directory = Path(path).resolve().parent
+        return workflow
 
     def to_yaml(self, path: str | Path) -> None:
         """
@@ -390,6 +403,77 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
             )
             artifact.path = transfer_art.path
 
+    @property
+    def run_directory(self) -> Path:
+        """
+        The single root directory for this run's generated files: per-task
+        working directories, declared output artifacts, and logs all live
+        under it, so a run is self-contained.
+
+        Resolved as ``base_directory / orchestrator working_directory`` (the
+        base directory alone when no orchestrator working directory is set).
+        The base directory is the workflow YAML's folder when loaded via
+        :meth:`from_yaml`, otherwise the process CWD. An absolute orchestrator
+        working directory is used as-is.
+        """
+        base = self._base_directory or Path.cwd()
+        wd = (
+            self.orchestrator_target.working_directory
+            if self.orchestrator_target is not None
+            else None
+        )
+        root = Path(wd) if wd else Path(".")
+        return (base / root).resolve()
+
+    @final
+    def _resolve_run_paths(self) -> None:
+        """
+        Anchor this run's relative paths to the single :attr:`run_directory`.
+
+        - Point the orchestrator target (and, by propagation, co-located task
+          targets) at the absolute run directory, so per-task working dirs
+          nest under it.
+        - Make declared artifact paths absolute: a path produced by some task
+          (a task output, or an input fed by an upstream output) resolves
+          under the run directory; a path never produced (an external input)
+          resolves under the base directory. Paths declared absolute are left
+          untouched.
+
+        Only relative declared paths are rewritten, so calling this twice is
+        safe.
+        """
+        base = self._base_directory or Path.cwd()
+        run_root = self.run_directory
+
+        if self.orchestrator_target is not None:
+            self.orchestrator_target.working_directory = run_root.as_posix()
+
+        produced = {
+            artifact._declared_path.as_posix()
+            for task in self.tasks
+            for artifact in task.outputs
+            if artifact._declared_path is not None
+        }
+
+        def anchor(artifact: BaseArtifact) -> None:
+            declared = artifact._declared_path
+            if declared is None or declared.is_absolute():
+                return
+            root = run_root if declared.as_posix() in produced else base
+            artifact.path = (root / declared).resolve()
+
+        for task in self.tasks:
+            for artifact in (*task.inputs, *task.outputs):
+                anchor(artifact)
+            # A runtime's local source file (e.g. a python_script's ``script``)
+            # is provided relative to the workflow file, so anchor it to the
+            # base dir too. Accessed by name to avoid a core->builtin import.
+            script = getattr(task.runtime, "script", None)
+            if isinstance(script, Path) and not script.is_absolute():
+                task.runtime.script = (base / script).resolve()
+        for artifact in self.artifacts:
+            anchor(artifact)
+
     @final
     def _propagate_orchestrator_working_directory(self) -> None:
         """
@@ -443,6 +527,11 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
             _("Workflow %(workflow_name)s status → RUNNING")
             % {"workflow_name": self.name}
         )
+
+        # Anchor working dirs, artifact paths, and logs to a single
+        # self-contained run directory before anything reads them.
+        self._resolve_run_paths()
+        horus_logger.set_log_directory(self.run_directory / "logs")
 
         # Co-located task targets inherit the orchestrator's working
         # directory so all such tasks run under that common folder.

--- a/src/horus_runtime/logging.py
+++ b/src/horus_runtime/logging.py
@@ -68,6 +68,11 @@ class HorusLogger(BaseSettings):
     #: sink. ``None`` until :meth:`setup` runs.
     _terminal_sink_id: int | None = PrivateAttr(default=None)
 
+    #: Loguru handler id of the file sink, tracked so its directory can be
+    #: re-pointed (see :meth:`set_log_directory`) without disturbing the
+    #: terminal sink. ``None`` until a file sink is installed.
+    _file_sink_id: int | None = PrivateAttr(default=None)
+
     @property
     def log(self) -> "Logger":
         """
@@ -77,17 +82,29 @@ class HorusLogger(BaseSettings):
 
     def setup(self, level: LoggerLevel | None = None) -> None:
         """
-        Set up the loguru logger with the current settings.
+        Set up the loguru logger with the current settings, replacing any
+        existing sinks with a fresh file sink and terminal sink.
         """
         # Load the configuration from environment variables or defaults
         self.level = level or self.level
 
-        # Ensure the log directory exists
-        self.log_directory.mkdir(parents=True, exist_ok=True)
-
-        # Remove the default logger and add a new one with our configuration
+        # Remove every existing handler, then re-add ours. The ids are stale
+        # after a full remove(), so clear them before reinstalling.
         logger.remove()
-        logger.add(
+        self._file_sink_id = None
+        self._terminal_sink_id = None
+        self._install_file_sink()
+        self._install_terminal_sink()
+
+    def _install_file_sink(self) -> None:
+        """
+        (Re)install the file sink at :attr:`log_directory`, replacing a
+        previously installed one without touching the terminal sink.
+        """
+        self.log_directory.mkdir(parents=True, exist_ok=True)
+        if self._file_sink_id is not None:
+            logger.remove(self._file_sink_id)
+        self._file_sink_id = logger.add(
             sink=f"{self.log_directory}/{self.filename_template}",
             format=self.format,
             level=self.level,
@@ -97,12 +114,27 @@ class HorusLogger(BaseSettings):
             enqueue=True,
         )
 
-        # Add terminal logging as well, tracking its id so it can be swapped.
+    def _install_terminal_sink(self) -> None:
+        """
+        (Re)install the stdout terminal sink, replacing a previously installed
+        one. Tracked by id so the live TUI can swap it for a panel.
+        """
+        if self._terminal_sink_id is not None:
+            logger.remove(self._terminal_sink_id)
         self._terminal_sink_id = logger.add(
             sink=sys.stdout,
             format=self.format,
             level=self.level,
         )
+
+    def set_log_directory(self, path: "Path") -> None:
+        """
+        Point the file logs at *path* and re-register the file sink, leaving
+        the terminal sink intact. Used to move logs under a run's directory
+        once it is known (the import-time default installs no file sink).
+        """
+        self.log_directory = Path(path)
+        self._install_file_sink()
 
     def redirect_terminal(self, sink: "Callable[[Message], None]") -> None:
         """
@@ -132,6 +164,10 @@ class HorusLogger(BaseSettings):
         self.setup(level=level)  # Re-setup to apply the new level
 
 
-# Instantiate a global logger ready to be used.
+# Instantiate a global logger ready to be used. Only the terminal sink is
+# installed at import time; the file sink is created when a run points it at
+# its directory (see HorusLogger.set_log_directory), so importing the runtime
+# never creates a stray ``logs/`` folder in the launch directory.
 horus_logger: "HorusLogger" = HorusLogger()
-horus_logger.setup()
+logger.remove()
+horus_logger._install_terminal_sink()

--- a/src/horus_runtime/logging.py
+++ b/src/horus_runtime/logging.py
@@ -175,4 +175,4 @@ class HorusLogger(BaseSettings):
 # never creates a stray ``logs/`` folder in the launch directory.
 horus_logger: "HorusLogger" = HorusLogger()
 logger.remove()
-horus_logger._install_terminal_sink()
+horus_logger._install_terminal_sink()  # noqa: SLF001

--- a/src/horus_runtime/logging.py
+++ b/src/horus_runtime/logging.py
@@ -90,10 +90,15 @@ class HorusLogger(BaseSettings):
 
         # Remove every existing handler, then re-add ours. The ids are stale
         # after a full remove(), so clear them before reinstalling.
+        # Re-install the file sink only when one was already active; the file
+        # sink is deferred until set_log_directory() is called, so setup()
+        # must not spontaneously create it (e.g. via set_level()).
+        had_file_sink = self._file_sink_id is not None
         logger.remove()
         self._file_sink_id = None
         self._terminal_sink_id = None
-        self._install_file_sink()
+        if had_file_sink:
+            self._install_file_sink()
         self._install_terminal_sink()
 
     def _install_file_sink(self) -> None:

--- a/tests/unit/runtime/test_anchor_local_paths.py
+++ b/tests/unit/runtime/test_anchor_local_paths.py
@@ -1,0 +1,87 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Unit tests for the ``anchor_local_paths`` hook on BaseRuntime and its
+override in PythonScriptRuntime.
+"""
+
+from pathlib import Path
+from typing import ClassVar
+
+import pytest
+
+from horus_builtin.runtime.command import CommandRuntime
+from horus_builtin.runtime.python_script import PythonScriptRuntime
+from horus_runtime.core.runtime.base import BaseRuntime
+from horus_runtime.core.task.base import BaseTask
+
+
+class _MinimalRuntime(BaseRuntime):
+    """Concrete subclass with no local file fields."""
+
+    add_to_registry: ClassVar[bool] = False
+    kind: str = "minimal_test"
+
+    async def _setup_runtime(self, _: "BaseTask") -> None:
+        return None
+
+
+@pytest.mark.unit
+class TestBaseRuntimeAnchorLocalPaths:
+    """The base no-op implementation does not raise for runtimes
+    with no local files.
+    """
+
+    def test_base_noop_does_not_raise(self, tmp_path: Path) -> None:
+        """BaseRuntime subclass with no file fields survives the hook call."""
+        rt = _MinimalRuntime()
+        rt.anchor_local_paths(tmp_path)
+
+    def test_command_runtime_noop_does_not_raise(self, tmp_path: Path) -> None:
+        """CommandRuntime has no local file fields; anchor is a safe no-op."""
+        rt = CommandRuntime(command="echo hi")
+        rt.anchor_local_paths(tmp_path)
+
+
+@pytest.mark.unit
+class TestPythonScriptRuntimeAnchorLocalPaths:
+    """PythonScriptRuntime.anchor_local_paths resolves script against base."""
+
+    def test_relative_script_is_resolved_against_base(
+        self, tmp_path: Path
+    ) -> None:
+        """A relative script path is made absolute under the given base."""
+        rt = PythonScriptRuntime(script=Path("scripts/job.py"))
+        rt.anchor_local_paths(tmp_path)
+        assert rt.script == (tmp_path / "scripts/job.py").resolve()
+        assert rt.script.is_absolute()
+
+    def test_absolute_script_is_left_untouched(self, tmp_path: Path) -> None:
+        """An already-absolute script path is not modified."""
+        abs_script = (tmp_path / "scripts/job.py").resolve()
+        rt = PythonScriptRuntime(script=abs_script)
+        rt.anchor_local_paths(tmp_path / "some_other_base")
+        assert rt.script == abs_script
+
+    def test_anchor_is_idempotent(self, tmp_path: Path) -> None:
+        """Calling anchor_local_paths twice yields the same absolute path."""
+        rt = PythonScriptRuntime(script=Path("scripts/job.py"))
+        rt.anchor_local_paths(tmp_path)
+        first = rt.script
+        rt.anchor_local_paths(tmp_path)
+        assert rt.script == first

--- a/tests/unit/target/test_local_target.py
+++ b/tests/unit/target/test_local_target.py
@@ -94,6 +94,18 @@ class TestLocalTargetProperties:
         target = LocalTarget(working_directory="/explicit/dir")
         assert target.resolved_working_directory == "/explicit/dir"
 
+    def test_resolved_working_directory_absolutizes_relative_value(self) -> None:
+        """
+        A relative working_directory (e.g. propagated from a relative
+        orchestrator target) is resolved to an absolute path against the
+        process CWD. working_dir is used both as the subprocess cwd and as an
+        in-command path prefix, so a relative value would double the path.
+        """
+        target = LocalTarget(working_directory="horus_workflow_results")
+        resolved = target.resolved_working_directory
+        assert Path(resolved).is_absolute()
+        assert resolved == (Path.cwd() / "horus_workflow_results").as_posix()
+
 
 @pytest.mark.unit
 class TestLocalTargetDispatch:

--- a/tests/unit/target/test_local_target.py
+++ b/tests/unit/target/test_local_target.py
@@ -94,7 +94,9 @@ class TestLocalTargetProperties:
         target = LocalTarget(working_directory="/explicit/dir")
         assert target.resolved_working_directory == "/explicit/dir"
 
-    def test_resolved_working_directory_absolutizes_relative_value(self) -> None:
+    def test_resolved_working_directory_absolutizes_relative_value(
+        self,
+    ) -> None:
         """
         A relative working_directory (e.g. propagated from a relative
         orchestrator target) is resolved to an absolute path against the

--- a/tests/unit/workflow/test_run_layout.py
+++ b/tests/unit/workflow/test_run_layout.py
@@ -1,0 +1,201 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Unit tests for run-directory anchoring: per-task working dirs, declared output
+artifacts, and external inputs are resolved into a single self-contained run
+folder anchored at the workflow's base directory.
+"""
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from horus_builtin.artifact.file import FileArtifact
+from horus_builtin.executor.shell import ShellExecutor
+from horus_builtin.runtime.command import CommandRuntime
+from horus_builtin.runtime.python_script import PythonScriptRuntime
+from horus_builtin.target.local import LocalTarget
+from horus_builtin.task.horus_task import HorusTask
+from horus_builtin.workflow.horus_workflow import HorusWorkflow
+from tests.conftest import MakeWorkflowFileType
+
+
+def _task(
+    task_id: str,
+    *,
+    inputs: list[FileArtifact] | None = None,
+    outputs: list[FileArtifact] | None = None,
+) -> HorusTask:
+    return HorusTask(
+        id=task_id,
+        name=task_id,
+        inputs=inputs or [],
+        outputs=outputs or [],
+        runtime=CommandRuntime(command="echo hi"),
+        executor=ShellExecutor(),
+        target=LocalTarget(),
+    )
+
+
+@pytest.mark.unit
+class TestRunDirectory:
+    """The run root is base_directory / orchestrator working_directory."""
+
+    def test_run_directory_joins_base_and_working_directory(
+        self, tmp_path: Path
+    ) -> None:
+        wf = HorusWorkflow(
+            name="layout",
+            tasks=[_task("t1")],
+            orchestrator_target=LocalTarget(working_directory="workflow_results"),
+        )
+        wf._base_directory = tmp_path
+        assert wf.run_directory == (tmp_path / "workflow_results").resolve()
+
+    def test_absolute_working_directory_wins(self, tmp_path: Path) -> None:
+        abs_wd = (tmp_path / "elsewhere").resolve()
+        wf = HorusWorkflow(
+            name="layout",
+            tasks=[_task("t1")],
+            orchestrator_target=LocalTarget(working_directory=abs_wd.as_posix()),
+        )
+        wf._base_directory = tmp_path / "ignored"
+        assert wf.run_directory == abs_wd
+
+    def test_defaults_to_cwd_when_unanchored(self) -> None:
+        # No base directory (programmatic workflow) and no orchestrator
+        # working directory: fall back to the process CWD.
+        wf = HorusWorkflow(name="layout", tasks=[_task("t1")])
+        assert wf.run_directory == Path.cwd().resolve()
+
+
+@pytest.mark.unit
+class TestResolveRunPaths:
+    """Declared artifact paths anchor by whether some task produces them."""
+
+    def test_output_anchors_under_run_root_input_under_base(
+        self, tmp_path: Path
+    ) -> None:
+        external = FileArtifact(id="receptor", path="examples/receptor.pdb")
+        produced = FileArtifact(id="vina", path="results/vina.tar.gz")
+        wf = HorusWorkflow(
+            name="layout",
+            tasks=[_task("prep", inputs=[external], outputs=[produced])],
+            orchestrator_target=LocalTarget(working_directory="workflow_results"),
+        )
+        wf._base_directory = tmp_path
+
+        wf._resolve_run_paths()
+
+        run_root = (tmp_path / "workflow_results").resolve()
+        # Produced output nests under the run root...
+        assert produced.path == (run_root / "results/vina.tar.gz").resolve()
+        # ...while an external (never-produced) input stays at the base dir.
+        assert external.path == (tmp_path / "examples/receptor.pdb").resolve()
+
+    def test_intermediate_resolves_to_same_path_for_both_tasks(
+        self, tmp_path: Path
+    ) -> None:
+        # The same declared path is one task's output and the next task's
+        # input; both must land at one location (under the run root).
+        producer_out = FileArtifact(id="vina", path="results/vina.tar.gz")
+        consumer_in = FileArtifact(id="vina", path="results/vina.tar.gz")
+        wf = HorusWorkflow(
+            name="layout",
+            tasks=[
+                _task("prep", outputs=[producer_out]),
+                _task("dock", inputs=[consumer_in]),
+            ],
+            orchestrator_target=LocalTarget(working_directory="workflow_results"),
+        )
+        wf._base_directory = tmp_path
+
+        wf._resolve_run_paths()
+
+        expected = (tmp_path / "workflow_results/results/vina.tar.gz").resolve()
+        assert producer_out.path == expected
+        assert consumer_in.path == expected
+
+    def test_orchestrator_working_directory_becomes_absolute_run_root(
+        self, tmp_path: Path
+    ) -> None:
+        wf = HorusWorkflow(
+            name="layout",
+            tasks=[_task("t1")],
+            orchestrator_target=LocalTarget(working_directory="workflow_results"),
+        )
+        wf._base_directory = tmp_path
+
+        wf._resolve_run_paths()
+
+        assert wf.orchestrator_target is not None
+        assert (
+            wf.orchestrator_target.working_directory
+            == (tmp_path / "workflow_results").resolve().as_posix()
+        )
+
+    def test_absolute_declared_path_is_left_untouched(
+        self, tmp_path: Path
+    ) -> None:
+        abs_out = (tmp_path / "somewhere/out.txt").resolve()
+        artifact = FileArtifact(id="out", path=abs_out.as_posix())
+        wf = HorusWorkflow(
+            name="layout",
+            tasks=[_task("t1", outputs=[artifact])],
+            orchestrator_target=LocalTarget(working_directory="workflow_results"),
+        )
+        wf._base_directory = tmp_path
+
+        wf._resolve_run_paths()
+
+        assert artifact.path == abs_out
+
+
+@pytest.mark.unit
+class TestFromYamlBaseDirectory:
+    """from_yaml anchors the run at the workflow file's own directory."""
+
+    def test_from_yaml_sets_base_directory_to_yaml_parent(
+        self, tmp_path: Path, make_workflow_file: MakeWorkflowFileType
+    ) -> None:
+        wf_content = textwrap.dedent("""\
+            name: yaml_layout
+            kind: horus_workflow
+            tasks:
+                - id: t1
+                  name: Task 1
+                  kind: horus_task
+                  runtime:
+                      kind: command
+                      command: "echo hello"
+                  executor:
+                      kind: shell
+            orchestrator_target:
+                kind: local
+                working_directory: workflow_results
+        """)
+        workflow_file = make_workflow_file(tmp_path, wf_content)
+
+        wf = HorusWorkflow.from_yaml(workflow_file)
+
+        assert wf._base_directory == Path(workflow_file).resolve().parent
+        # And that base dir drives the run root, independent of the CWD.
+        assert wf.run_directory == (
+            Path(workflow_file).resolve().parent / "workflow_results"
+        ).resolve()

--- a/tests/unit/workflow/test_run_layout.py
+++ b/tests/unit/workflow/test_run_layout.py
@@ -23,6 +23,7 @@ folder anchored at the workflow's base directory.
 
 import textwrap
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -33,14 +34,16 @@ from horus_builtin.runtime.python_script import PythonScriptRuntime
 from horus_builtin.target.local import LocalTarget
 from horus_builtin.task.horus_task import HorusTask
 from horus_builtin.workflow.horus_workflow import HorusWorkflow
+from horus_runtime.core.artifact.base import BaseArtifact
+from horus_runtime.core.target.base import BaseTarget
 from tests.conftest import MakeWorkflowFileType
 
 
 def _task(
     task_id: str,
     *,
-    inputs: list[FileArtifact] | None = None,
-    outputs: list[FileArtifact] | None = None,
+    inputs: list[BaseArtifact] | None = None,
+    outputs: list[BaseArtifact] | None = None,
 ) -> HorusTask:
     return HorusTask(
         id=task_id,
@@ -60,27 +63,34 @@ class TestRunDirectory:
     def test_run_directory_joins_base_and_working_directory(
         self, tmp_path: Path
     ) -> None:
+        """run_directory = base_directory / orchestrator working_directory."""
         wf = HorusWorkflow(
             name="layout",
             tasks=[_task("t1")],
-            orchestrator_target=LocalTarget(working_directory="workflow_results"),
+            orchestrator_target=LocalTarget(
+                working_directory="workflow_results"
+            ),
         )
         wf._base_directory = tmp_path
         assert wf.run_directory == (tmp_path / "workflow_results").resolve()
 
     def test_absolute_working_directory_wins(self, tmp_path: Path) -> None:
+        """An absolute working_directory is used as-is, ignoring
+        base_directory.
+        """
         abs_wd = (tmp_path / "elsewhere").resolve()
         wf = HorusWorkflow(
             name="layout",
             tasks=[_task("t1")],
-            orchestrator_target=LocalTarget(working_directory=abs_wd.as_posix()),
+            orchestrator_target=LocalTarget(
+                working_directory=abs_wd.as_posix()
+            ),
         )
         wf._base_directory = tmp_path / "ignored"
         assert wf.run_directory == abs_wd
 
     def test_defaults_to_cwd_when_unanchored(self) -> None:
-        # No base directory (programmatic workflow) and no orchestrator
-        # working directory: fall back to the process CWD.
+        """Programmatic workflow with no orchestrator defaults to CWD."""
         wf = HorusWorkflow(name="layout", tasks=[_task("t1")])
         assert wf.run_directory == Path.cwd().resolve()
 
@@ -92,12 +102,17 @@ class TestResolveRunPaths:
     def test_output_anchors_under_run_root_input_under_base(
         self, tmp_path: Path
     ) -> None:
-        external = FileArtifact(id="receptor", path="examples/receptor.pdb")
-        produced = FileArtifact(id="vina", path="results/vina.tar.gz")
+        """Produced outputs go under run_root; external inputs stay at base."""
+        external = FileArtifact(
+            id="receptor", path=Path("examples/receptor.pdb")
+        )
+        produced = FileArtifact(id="vina", path=Path("results/vina.tar.gz"))
         wf = HorusWorkflow(
             name="layout",
             tasks=[_task("prep", inputs=[external], outputs=[produced])],
-            orchestrator_target=LocalTarget(working_directory="workflow_results"),
+            orchestrator_target=LocalTarget(
+                working_directory="workflow_results"
+            ),
         )
         wf._base_directory = tmp_path
 
@@ -112,33 +127,41 @@ class TestResolveRunPaths:
     def test_intermediate_resolves_to_same_path_for_both_tasks(
         self, tmp_path: Path
     ) -> None:
-        # The same declared path is one task's output and the next task's
-        # input; both must land at one location (under the run root).
-        producer_out = FileArtifact(id="vina", path="results/vina.tar.gz")
-        consumer_in = FileArtifact(id="vina", path="results/vina.tar.gz")
+        """Shared declared path lands at the same location for both tasks."""
+        producer_out = FileArtifact(
+            id="vina", path=Path("results/vina.tar.gz")
+        )
+        consumer_in = FileArtifact(id="vina", path=Path("results/vina.tar.gz"))
         wf = HorusWorkflow(
             name="layout",
             tasks=[
                 _task("prep", outputs=[producer_out]),
                 _task("dock", inputs=[consumer_in]),
             ],
-            orchestrator_target=LocalTarget(working_directory="workflow_results"),
+            orchestrator_target=LocalTarget(
+                working_directory="workflow_results"
+            ),
         )
         wf._base_directory = tmp_path
 
         wf._resolve_run_paths()
 
-        expected = (tmp_path / "workflow_results/results/vina.tar.gz").resolve()
+        expected = (
+            tmp_path / "workflow_results/results/vina.tar.gz"
+        ).resolve()
         assert producer_out.path == expected
         assert consumer_in.path == expected
 
     def test_orchestrator_working_directory_becomes_absolute_run_root(
         self, tmp_path: Path
     ) -> None:
+        """After _resolve_run_paths the orchestrator working_directory is absolute."""  # noqa: E501
         wf = HorusWorkflow(
             name="layout",
             tasks=[_task("t1")],
-            orchestrator_target=LocalTarget(working_directory="workflow_results"),
+            orchestrator_target=LocalTarget(
+                working_directory="workflow_results"
+            ),
         )
         wf._base_directory = tmp_path
 
@@ -153,12 +176,15 @@ class TestResolveRunPaths:
     def test_absolute_declared_path_is_left_untouched(
         self, tmp_path: Path
     ) -> None:
+        """An artifact with an absolute declared path is not re-anchored."""
         abs_out = (tmp_path / "somewhere/out.txt").resolve()
-        artifact = FileArtifact(id="out", path=abs_out.as_posix())
+        artifact = FileArtifact(id="out", path=abs_out)
         wf = HorusWorkflow(
             name="layout",
             tasks=[_task("t1", outputs=[artifact])],
-            orchestrator_target=LocalTarget(working_directory="workflow_results"),
+            orchestrator_target=LocalTarget(
+                working_directory="workflow_results"
+            ),
         )
         wf._base_directory = tmp_path
 
@@ -168,12 +194,96 @@ class TestResolveRunPaths:
 
 
 @pytest.mark.unit
+class TestRuntimeAnchorLocalPaths:
+    """_resolve_run_paths delegates path anchoring to the runtime hook."""
+
+    def _script_task(
+        self, script: Path, base_dir: Path, working_dir: str = "results"
+    ) -> tuple[HorusWorkflow, PythonScriptRuntime]:
+        runtime = PythonScriptRuntime(script=script)
+        task = HorusTask(
+            id="t1",
+            name="t1",
+            runtime=runtime,
+            executor=ShellExecutor(),
+            target=LocalTarget(),
+        )
+        wf = HorusWorkflow(
+            name="layout",
+            tasks=[task],
+            orchestrator_target=LocalTarget(working_directory=working_dir),
+        )
+        wf._base_directory = base_dir
+        return wf, runtime
+
+    def test_relative_script_is_anchored_to_base(self, tmp_path: Path) -> None:
+        """Relative script resolves against the workflow base directory."""
+        wf, runtime = self._script_task(Path("scripts/job.py"), tmp_path)
+        wf._resolve_run_paths()
+        assert runtime.script == (tmp_path / "scripts/job.py").resolve()
+
+    def test_absolute_script_is_left_untouched(self, tmp_path: Path) -> None:
+        """An already-absolute script path is not modified."""
+        abs_script = (tmp_path / "scripts/job.py").resolve()
+        wf, runtime = self._script_task(abs_script, tmp_path / "other_base")
+        wf._resolve_run_paths()
+        assert runtime.script == abs_script
+
+    def test_command_runtime_survives_anchor_call(
+        self, tmp_path: Path
+    ) -> None:
+        """CommandRuntime has no local files; anchor hook is a safe no-op."""
+        task = HorusTask(
+            id="t1",
+            name="t1",
+            runtime=CommandRuntime(command="echo hi"),
+            executor=ShellExecutor(),
+            target=LocalTarget(),
+        )
+        wf = HorusWorkflow(
+            name="layout",
+            tasks=[task],
+            orchestrator_target=LocalTarget(working_directory="results"),
+        )
+        wf._base_directory = tmp_path
+        wf._resolve_run_paths()  # must not raise
+
+    def test_anchoring_is_target_agnostic(self, tmp_path: Path) -> None:
+        """Swapping to an SSH-like target does not affect local path anchoring.
+
+        anchor_local_paths resolves paths on the orchestrator side only,
+        so the concrete target type is irrelevant.
+        """
+        ssh_target = MagicMock(spec=BaseTarget)
+        ssh_target.working_directory = None
+        ssh_target.location_id = "remote-host"
+
+        runtime = PythonScriptRuntime(script=Path("scripts/job.py"))
+        task = HorusTask(
+            id="t1",
+            name="t1",
+            runtime=runtime,
+            executor=ShellExecutor(),
+            target=ssh_target,
+        )
+        wf = HorusWorkflow(
+            name="layout",
+            tasks=[task],
+            orchestrator_target=LocalTarget(working_directory="results"),
+        )
+        wf._base_directory = tmp_path
+        wf._resolve_run_paths()
+        assert runtime.script == (tmp_path / "scripts/job.py").resolve()
+
+
+@pytest.mark.unit
 class TestFromYamlBaseDirectory:
     """from_yaml anchors the run at the workflow file's own directory."""
 
     def test_from_yaml_sets_base_directory_to_yaml_parent(
         self, tmp_path: Path, make_workflow_file: MakeWorkflowFileType
     ) -> None:
+        """from_yaml sets _base_directory to the YAML file's parent."""
         wf_content = textwrap.dedent("""\
             name: yaml_layout
             kind: horus_workflow
@@ -196,6 +306,9 @@ class TestFromYamlBaseDirectory:
 
         assert wf._base_directory == Path(workflow_file).resolve().parent
         # And that base dir drives the run root, independent of the CWD.
-        assert wf.run_directory == (
-            Path(workflow_file).resolve().parent / "workflow_results"
-        ).resolve()
+        assert (
+            wf.run_directory
+            == (
+                Path(workflow_file).resolve().parent / "workflow_results"
+            ).resolve()
+        )


### PR DESCRIPTION
## Summary

- **Core fix**: `LocalTarget.resolved_working_directory` now always returns an absolute path — prevents double-path application when a relative `working_directory` (propagated from the orchestrator) is used as both subprocess `cwd` and an in-command path prefix.
- **Run anchoring**: New `BaseWorkflow._resolve_run_paths()` anchors all relative artifact paths and logs to a single `run_directory` (the workflow YAML's folder + orchestrator working dir), so a run is self-contained regardless of the launch CWD.
- **Logger cleanup**: `HorusLogger` now splits file and terminal sinks (`_install_file_sink` / `_install_terminal_sink`) so `set_log_directory()` can redirect logs to the run directory mid-run without touching the terminal sink. Import-time setup installs only the terminal sink — no stray `logs/` folder on import.

## Test plan

- [x] `tests/unit/target/test_local_target.py` — added `test_resolved_working_directory_absolutizes_relative_value`
- [x] `tests/unit/workflow/test_run_layout.py` — new file covering `run_directory`, `_resolve_run_paths()`, and `from_yaml` base-directory anchoring (33 tests, all passing)

## Documentation impact

If a user, plugin, or GUI can observe the difference, it requires documentation.

- [X] No documentation update required
- [ ] Documentation updated / will be updated