### PR TITLE
refactor(artifact): route filesystem ops through ArtifactStore over targets

### DIFF
--- a/src/horus_builtin/artifact/folder.py
+++ b/src/horus_builtin/artifact/folder.py
@@ -20,10 +20,8 @@ Implementation of the FolderArtifact class, which represents a local
 folder/directory artifact in the Horus runtime.
 """
 
-import hashlib
-import os
+import shlex
 import shutil
-import tempfile
 from pathlib import Path
 from typing import ClassVar
 
@@ -42,39 +40,6 @@ class FolderArtifact(BaseArtifact[Path]):
     kind_description: ClassVar[str] = (
         "A directory artifact containing multiple files."
     )
-
-    def exists(self) -> bool:
-        """
-        Check if the folder specified by the path exists and is a directory.
-        """
-        return self.path.is_dir()
-
-    @property
-    def hash(self) -> str | None:
-        """
-        Computes the hash of the folder and its contents by recursively hashing
-        all files in the folder. The hash is computed by combining the relative
-        paths and contents of all files in the folder, ensuring that changes to
-        any file or the addition/removal of files will result in a different
-        hash.
-        """
-        if not self.exists():
-            return None
-
-        sha256 = hashlib.sha256()
-
-        # 1. Get all files and sort them by relative path for determinism
-        # We use rglob("*") to get everything, but only hash files
-        paths = sorted([p for p in self.path.rglob("*") if p.is_file()])
-
-        for path in paths:
-            relative_path = path.relative_to(self.path).as_posix()
-            sha256.update(relative_path.encode("utf-8"))
-
-            # Hash the file contents
-            sha256.update(self.hash_file(path))
-
-        return sha256.hexdigest()
 
     def read(self) -> Path:
         """
@@ -103,56 +68,27 @@ class FolderArtifact(BaseArtifact[Path]):
         shutil.copytree(source_path, self.path)
         self._emit_event(ArtifactEventsEnum.WRITE)
 
-    def package(self) -> Path:
+    def pack_command(self, src: str, pkg: str) -> str | None:
         """
-        Archive the folder into a zip file and return the archive path.
+        Archive the *contents* of the folder at *src* into the gzipped tarball
+        *pkg*.
+
+        Uses ``tar -C <src> .`` so the archive holds the directory's contents
+        rooted at ``.`` (not the directory name itself); the matching
+        :meth:`unpack_command` then extracts straight into the destination
+        directory without nesting.
         """
-        if not self.exists():
-            raise FileNotFoundError(self.path)
+        return f"tar czf {shlex.quote(pkg)} -C {shlex.quote(src)} ."
 
-        # Create a temporary file to be used as the archive path.
-        # shutil.make_archive requires a base name without extension,
-        # so we create a temp file and then remove it after archiving.
-        fd, arch_p = tempfile.mkstemp()
-        os.close(fd)
-        archive_path = Path(arch_p)
+    def unpack_command(self, pkg: str, dest: str) -> str | None:
+        """
+        Extract the gzipped tarball *pkg* into the directory *dest*.
 
-        shutil.make_archive(
-            base_name=str(archive_path),
-            format="zip",
-            root_dir=self.path,
+        The destination is recreated fresh so a re-materialized folder never
+        mixes with stale contents.
+        """
+        q_dest = shlex.quote(dest)
+        return (
+            f"rm -rf {q_dest} && mkdir -p {q_dest} && "
+            f"tar xzf {shlex.quote(pkg)} -C {q_dest}"
         )
-
-        # shutil.make_archive adds .zip, so remove the temp
-        # file and use the generated archive
-        archive_file = archive_path.with_suffix(".zip")
-        if archive_path.exists():
-            archive_path.unlink()
-
-        self._emit_event(ArtifactEventsEnum.PACKAGE)
-        return archive_file
-
-    def unpackage(self, package_path: Path) -> None:
-        """
-        Extract a packaged folder archive into the canonical directory path.
-        """
-        package_path = Path(package_path).resolve()
-
-        if self.path.exists():
-            shutil.rmtree(self.path)
-
-        self.path.mkdir(parents=True, exist_ok=True)
-        shutil.unpack_archive(
-            filename=str(package_path),
-            extract_dir=str(self.path),
-        )
-        self._emit_event(ArtifactEventsEnum.UNPACKAGE)
-
-    def delete(self) -> None:
-        """
-        Deletes the artifact from its location by deleting the folder at the
-        specified path.
-        """
-        if self.exists():
-            shutil.rmtree(self.path)
-            self._emit_event(ArtifactEventsEnum.DELETE)

--- a/src/horus_builtin/target/local.py
+++ b/src/horus_builtin/target/local.py
@@ -23,6 +23,7 @@ Local target: executes tasks in the current process, running commands via
 import asyncio
 import os
 import shlex
+import shutil
 import signal
 import socket
 from collections.abc import AsyncGenerator
@@ -298,6 +299,24 @@ class LocalTarget(BaseTarget):
             path: Directory to create (mapped to a local ``Path``).
         """
         Path(path).mkdir(parents=True, exist_ok=True)
+
+    async def path_exists(self, path: str) -> bool:
+        """
+        Whether *path* exists on the local filesystem (file or directory).
+        """
+        return Path(path).exists()
+
+    async def remove(self, path: str) -> None:
+        """
+        Remove *path* from the local filesystem, recursively for directories.
+
+        Idempotent: a missing path is not an error.
+        """
+        p = Path(path)
+        if p.is_dir() and not p.is_symlink():
+            shutil.rmtree(p)
+        elif p.exists() or p.is_symlink():
+            p.unlink()
 
     async def list_dir(self, path: str) -> list[RemoteDirEntry]:
         """

--- a/src/horus_builtin/task/horus_task.py
+++ b/src/horus_builtin/task/horus_task.py
@@ -25,6 +25,7 @@ from horus_builtin.event.task_event import HorusTaskEvent
 from horus_builtin.target.local import LocalTarget
 from horus_runtime.context import HorusContext
 from horus_runtime.core.artifact.exceptions import ArtifactDoesNotExistError
+from horus_runtime.core.artifact.store import ArtifactStore
 from horus_runtime.core.target.base import BaseTarget
 from horus_runtime.core.task.base import BaseTask
 from horus_runtime.i18n import tr as _
@@ -62,9 +63,11 @@ class HorusTask(BaseTask):
 
         self.runs += 1
 
+        store = ArtifactStore(self.target)
+
         # Gather inputs
         for artifact in self.inputs:
-            if not artifact.exists():
+            if not await store.exists(artifact):
                 raise ArtifactDoesNotExistError(
                     _("Input artifact '%(input_id)s' does not exist")
                     % {"input_id": artifact.id}
@@ -73,7 +76,7 @@ class HorusTask(BaseTask):
         # Execute the command using the executor
         await self.executor.execute(self)
 
-    def is_complete(self) -> bool:
+    async def is_complete(self) -> bool:
         """
         A HorusTask is considered complete if all of its output artifacts
         exist.
@@ -83,13 +86,14 @@ class HorusTask(BaseTask):
         if not self.outputs:
             return False
 
+        store = ArtifactStore(self.target)
         for artifact in self.outputs:
-            if not artifact.exists():
+            if not await store.exists(artifact):
                 return False
 
         return True
 
-    def _reset(self) -> None:
+    async def _reset(self) -> None:
         """
         Reset the task by deleting all output artifacts. This allows the task
         to be re-run from scratch.
@@ -105,7 +109,8 @@ class HorusTask(BaseTask):
             )
         )
 
+        store = ArtifactStore(self.target)
         for artifact in self.outputs:
-            artifact.delete()
+            await store.delete(artifact)
 
         self.runs = 0

--- a/src/horus_builtin/workflow/horus_workflow.py
+++ b/src/horus_builtin/workflow/horus_workflow.py
@@ -97,10 +97,10 @@ class HorusWorkflow(BaseWorkflow):
             # Wait for the task to complete and check for failure
             await task.target.wait()
 
-    def _reset(self) -> None:
+    async def _reset(self) -> None:
         """
         Reset the workflow by deleting all output artifacts of all tasks in the
         workflow. This allows the workflow to be re-run from scratch.
         """
         for task in self.tasks:
-            task.reset()
+            await task.reset()

--- a/src/horus_runtime/core/artifact/base.py
+++ b/src/horus_runtime/core/artifact/base.py
@@ -20,8 +20,6 @@ Defines the Artifact base class, which represents a local file-backed
 artifact in the Horus runtime.
 """
 
-import hashlib
-import shutil
 from abc import abstractmethod
 from pathlib import Path
 from typing import Annotated, Any, ClassVar, Self
@@ -117,29 +115,6 @@ class BaseArtifact[T: Any = Any](AutoRegistry, entry_point="artifact"):
     registry.
     """
 
-    def exists(self) -> bool:
-        """
-        Checks if the artifact exists at the specified path.
-        """
-        return self.path.is_file()
-
-    @property
-    def hash(self) -> str | None:
-        """
-        Computes the hash of the file based on its contents. Returns None if
-        the file does not exist.
-        """
-        return self.hash_file(self.path).hex() if self.exists() else None
-
-    def delete(self) -> None:
-        """
-        Deletes the artifact from its location by deleting the file at the
-        specified path.
-        """
-        if self.exists():
-            self.path.unlink()
-            self._emit_event(ArtifactEventsEnum.DELETE)
-
     @model_validator(mode="after")
     def resolve_path(self) -> Self:
         """
@@ -175,27 +150,40 @@ class BaseArtifact[T: Any = Any](AutoRegistry, entry_point="artifact"):
         Write the native artifact representation to its canonical path.
         """
 
-    def package(self) -> Path:
+    def pack_command(self, src: str, pkg: str) -> str | None:
         """
-        Return the single-file package that transports should move.
-        """
-        if not self.exists():
-            raise FileNotFoundError(self.path)
+        Return a portable shell command that produces the single-file package
+        *pkg* from the artifact materialized at *src*, or ``None`` when the
+        artifact is already a single file (identity packaging).
 
-        self._emit_event(ArtifactEventsEnum.PACKAGE)
-        return self.path
-
-    def unpackage(self, package_path: Path) -> None:
+        The command is executed by
+        :class:`~horus_runtime.core.artifact.store.ArtifactStore` on the target
+        where the artifact lives, so it must be POSIX-portable and reference
+        only *src* and *pkg*. Both are target-side paths.
         """
-        Materialize a packaged artifact file at the canonical path.
-        """
-        package_path = package_path.resolve()
-        if package_path == self.path:
-            return
+        del src, pkg
+        return None
 
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(package_path, self.path)
-        self._emit_event(ArtifactEventsEnum.UNPACKAGE)
+    def unpack_command(self, pkg: str, dest: str) -> str | None:
+        """
+        Return a portable shell command that materializes the artifact at
+        *dest* from the single-file package *pkg*, or ``None`` when the
+        artifact is a single file (identity: the store moves *pkg* into place).
+
+        Executed by the :class:`.ArtifactStore` on the destination target; must
+        be POSIX-portable and reference only *pkg* and *dest*.
+        """
+        del pkg, dest
+        return None
+
+    def emit_event(self, event_name: ArtifactEventsEnum) -> None:
+        """
+        Emit the standard artifact event. Public entry point used by
+        :class:`~horus_runtime.core.artifact.store.ArtifactStore` after it
+        performs a filesystem operation (delete, package, unpackage) on behalf
+        of the artifact.
+        """
+        self._emit_event(event_name)
 
     def _emit_event(self, event_name: ArtifactEventsEnum) -> None:
         """
@@ -209,16 +197,3 @@ class BaseArtifact[T: Any = Any](AutoRegistry, entry_point="artifact"):
                 event_name=event_name,
             )
         )
-
-    @staticmethod
-    def hash_file(path: Path) -> bytes:
-        """
-        Computes the hash of the file contents.
-        """
-        buffer = 65536
-        sha256 = hashlib.sha256()
-        with open(path, "rb") as f:
-            while chunk := f.read(buffer):
-                sha256.update(chunk)
-
-        return sha256.digest()

--- a/src/horus_runtime/core/artifact/store.py
+++ b/src/horus_runtime/core/artifact/store.py
@@ -1,0 +1,174 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Mediator between artifacts and the filesystem where they physically live.
+
+An artifact's existence and lifecycle depend on *where* it materializes, which
+is owned by the target. The :class:`ArtifactStore` binds an artifact to a
+target and performs those operations through the target's artifact-agnostic
+filesystem primitives, so neither
+:class:`~horus_runtime.core.artifact.base.BaseArtifact` nor
+:class:`~horus_runtime.core.target.base.BaseTarget` has to carry the
+cross-cutting logic.
+"""
+
+import shlex
+from pathlib import PurePosixPath
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+from horus_builtin.event.artifact_event import ArtifactEventsEnum
+from horus_runtime.i18n import tr as _
+
+if TYPE_CHECKING:
+    from horus_runtime.core.artifact.base import BaseArtifact
+    from horus_runtime.core.target.channel import ChannelProcess
+
+
+@runtime_checkable
+class TargetFilesystem(Protocol):
+    """
+    The minimal filesystem surface an :class:`ArtifactStore` needs from a
+    target. :class:`~horus_runtime.core.target.base.BaseTarget` satisfies this
+    structurally.
+    """
+
+    @property
+    def resolved_working_directory(self) -> str:
+        """Base directory on the target for per-run generated files."""
+        ...
+
+    def path_on_target(self, artifact: "BaseArtifact") -> str:
+        """Absolute path where *artifact* lives on the target's filesystem."""
+        ...
+
+    async def path_exists(self, path: str) -> bool:
+        """Whether *path* exists on the target's filesystem."""
+        ...
+
+    async def remove(self, path: str) -> None:
+        """Remove *path* (file or directory) on the target's filesystem."""
+        ...
+
+    async def run_command_sync(
+        self,
+        cmd: str,
+        *,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> "ChannelProcess":
+        """Run *cmd* synchronously on the target over a live channel."""
+        ...
+
+
+class ArtifactStore:
+    """
+    Performs artifact lifecycle operations against the filesystem of a specific
+    target.
+    """
+
+    def __init__(self, target: TargetFilesystem) -> None:
+        self.target = target
+
+    async def exists(self, artifact: "BaseArtifact") -> bool:
+        """
+        Check whether *artifact* has materialized on the target.
+        """
+        return await self.target.path_exists(
+            self.target.path_on_target(artifact)
+        )
+
+    async def delete(self, artifact: "BaseArtifact") -> None:
+        """
+        Delete *artifact* from the target, emitting the standard delete event
+        when it existed.
+        """
+        path = self.target.path_on_target(artifact)
+        if not await self.target.path_exists(path):
+            return
+
+        await self.target.remove(path)
+        artifact.emit_event(ArtifactEventsEnum.DELETE)
+
+    async def package(self, artifact: "BaseArtifact") -> str:
+        """
+        Produce a single transferable file representing *artifact* on the
+        target and return its path.
+
+        Single-file artifacts (``pack_command`` returns ``None``) are their
+        own package, so the artifact's own path is returned untouched.
+        Otherwise the artifact's pack command runs on the target to build a
+        package under the target's working directory.
+        """
+        src = self.target.path_on_target(artifact)
+        pkg = self._package_path(src)
+        cmd = artifact.pack_command(src, pkg)
+        if cmd is None:
+            return src
+
+        await self._run(cmd, artifact, "package")
+        artifact.emit_event(ArtifactEventsEnum.PACKAGE)
+        return pkg
+
+    async def unpackage(
+        self, artifact: "BaseArtifact", package_path: str
+    ) -> None:
+        """
+        Materialize *artifact* on the target from the single-file package at
+        *package_path*.
+
+        Single-file artifacts (``unpack_command`` returns ``None``) are moved
+        into place; others run their unpack command on the target.
+        """
+        dest = self.target.path_on_target(artifact)
+        cmd = artifact.unpack_command(package_path, dest)
+        if cmd is None:
+            if package_path != dest:
+                parent = str(PurePosixPath(dest).parent)
+                cmd = (
+                    f"mkdir -p {shlex.quote(parent)} && "
+                    f"mv -f {shlex.quote(package_path)} {shlex.quote(dest)}"
+                )
+                await self._run(cmd, artifact, "unpackage")
+        else:
+            await self._run(cmd, artifact, "unpackage")
+
+        artifact.emit_event(ArtifactEventsEnum.UNPACKAGE)
+
+    def _package_path(self, src: str) -> str:
+        """
+        Path for a generated package on the target, kept distinct from the
+        artifact's own path so packaging never clobbers the source.
+        """
+        name = PurePosixPath(src).name
+        base = self.target.resolved_working_directory
+        return f"{base}/{name}.horuspkg"
+
+    async def _run(self, cmd: str, artifact: "BaseArtifact", op: str) -> None:
+        """
+        Run *cmd* on the target and raise when it exits non-zero.
+        """
+        proc = await self.target.run_command_sync(cmd)
+        rc = await proc.wait()
+        if rc != 0:
+            raise RuntimeError(
+                _(
+                    "Failed to %(op)s artifact '%(id)s' on target "
+                    "(exit code %(rc)s)"
+                )
+                % {"op": op, "id": artifact.id, "rc": rc}
+            )

--- a/src/horus_runtime/core/artifact/store.py
+++ b/src/horus_runtime/core/artifact/store.py
@@ -21,58 +21,19 @@ Mediator between artifacts and the filesystem where they physically live.
 An artifact's existence and lifecycle depend on *where* it materializes, which
 is owned by the target. The :class:`ArtifactStore` binds an artifact to a
 target and performs those operations through the target's artifact-agnostic
-filesystem primitives, so neither
-:class:`~horus_runtime.core.artifact.base.BaseArtifact` nor
-:class:`~horus_runtime.core.target.base.BaseTarget` has to carry the
-cross-cutting logic.
+filesystem primitives.
 """
 
 import shlex
 from pathlib import PurePosixPath
-from typing import TYPE_CHECKING, Protocol, runtime_checkable
+from typing import TYPE_CHECKING
 
 from horus_builtin.event.artifact_event import ArtifactEventsEnum
+from horus_runtime.core.target.base import BaseTarget
 from horus_runtime.i18n import tr as _
 
 if TYPE_CHECKING:
     from horus_runtime.core.artifact.base import BaseArtifact
-    from horus_runtime.core.target.channel import ChannelProcess
-
-
-@runtime_checkable
-class TargetFilesystem(Protocol):
-    """
-    The minimal filesystem surface an :class:`ArtifactStore` needs from a
-    target. :class:`~horus_runtime.core.target.base.BaseTarget` satisfies this
-    structurally.
-    """
-
-    @property
-    def resolved_working_directory(self) -> str:
-        """Base directory on the target for per-run generated files."""
-        ...
-
-    def path_on_target(self, artifact: "BaseArtifact") -> str:
-        """Absolute path where *artifact* lives on the target's filesystem."""
-        ...
-
-    async def path_exists(self, path: str) -> bool:
-        """Whether *path* exists on the target's filesystem."""
-        ...
-
-    async def remove(self, path: str) -> None:
-        """Remove *path* (file or directory) on the target's filesystem."""
-        ...
-
-    async def run_command_sync(
-        self,
-        cmd: str,
-        *,
-        cwd: str | None = None,
-        env: dict[str, str] | None = None,
-    ) -> "ChannelProcess":
-        """Run *cmd* synchronously on the target over a live channel."""
-        ...
 
 
 class ArtifactStore:
@@ -81,7 +42,7 @@ class ArtifactStore:
     target.
     """
 
-    def __init__(self, target: TargetFilesystem) -> None:
+    def __init__(self, target: BaseTarget) -> None:
         self.target = target
 
     async def exists(self, artifact: "BaseArtifact") -> bool:

--- a/src/horus_runtime/core/target/base.py
+++ b/src/horus_runtime/core/target/base.py
@@ -20,6 +20,7 @@ The Horus target indicates where a task should be dispatched and executed.
 """
 
 import asyncio
+import shlex
 from abc import abstractmethod
 from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar, final
@@ -381,3 +382,23 @@ class BaseTarget(AutoRegistry, entry_point="target"):
             One :class:`.RemoteDirEntry` per top-level child, or an empty list
             if *path* does not exist or is not a directory.
         """
+
+    async def path_exists(self, path: str) -> bool:
+        """
+        Whether *path* exists on the target host (file or directory).
+
+        The default probes over a shell channel; targets that can answer
+        natively (local filesystem, SFTP, agent API) should override this.
+        """
+        out = await self.run_command_sync(f"test -e {shlex.quote(path)}")
+        return await out.wait() == 0
+
+    async def remove(self, path: str) -> None:
+        """
+        Remove *path* (file or directory, recursively) on the target host.
+
+        Idempotent: removing a missing path is not an error. The default runs
+        over a shell channel; targets that can answer natively should override.
+        """
+        out = await self.run_command_sync(f"rm -rf {shlex.quote(path)}")
+        await out.wait()

--- a/src/horus_runtime/core/task/base.py
+++ b/src/horus_runtime/core/task/base.py
@@ -215,7 +215,7 @@ class BaseTask(AutoRegistry, entry_point="task"):
         - ``FAILED``    — set on any other exception (re-raised after)
         """
         ctx = HorusContext.get_context()
-        if self.skip_if_complete and self.is_complete():
+        if self.skip_if_complete and await self.is_complete():
             ctx.bus.emit(
                 HorusTaskEvent(
                     message=_("Skipping task %(task_name)s. Already complete.")
@@ -280,7 +280,7 @@ class BaseTask(AutoRegistry, entry_point="task"):
         """
 
     @abstractmethod
-    def is_complete(self) -> bool:
+    async def is_complete(self) -> bool:
         """
         Determine whether the task is complete by checking the existence and
         integrity of its output artifacts. This method should be implemented by
@@ -289,7 +289,7 @@ class BaseTask(AutoRegistry, entry_point="task"):
         """
 
     @final
-    def reset(self) -> None:
+    async def reset(self) -> None:
         """
         Reset the task. This allows the task to be re-run from scratch.
 
@@ -300,10 +300,10 @@ class BaseTask(AutoRegistry, entry_point="task"):
         horus_logger.log.debug(
             _("Task %(task_name)s reset → IDLE") % {"task_name": self.name}
         )
-        self._reset()
+        await self._reset()
 
     @abstractmethod
-    def _reset(self) -> None:
+    async def _reset(self) -> None:
         """
         Subclass-specific reset logic. Override this in subclasses when
         additional state must be cleared on reset. Do not set ``self.status``

--- a/src/horus_runtime/core/transfer/generic.py
+++ b/src/horus_runtime/core/transfer/generic.py
@@ -1,0 +1,106 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Target-agnostic transfer strategy.
+
+Moves an artifact between any two targets using only the shared filesystem
+primitives every target implements: the source packages the artifact where it
+lives, the bytes flow through the orchestrator via ``get_file`` / ``put_file``,
+and the destination unpackages it in place. It is used as the fallback when no
+location-specific strategy is registered for a ``(source, destination)`` pair.
+"""
+
+from pathlib import Path, PurePosixPath
+
+from horus_runtime.core.artifact.base import BaseArtifact
+from horus_runtime.core.artifact.store import ArtifactStore
+from horus_runtime.core.target.base import BaseTarget
+from horus_runtime.core.transfer.strategy import BaseTransferStrategy
+from horus_runtime.logging import horus_logger
+
+
+class GenericTransfer(BaseTransferStrategy):
+    """
+    Fallback transfer that works over any pair of targets.
+
+    Not registered by key (``add_to_registry = False``); the orchestrator uses
+    it directly when :meth:`BaseTransferStrategy.get_from_registry` finds no
+    specific strategy, so location-specific strategies always take precedence.
+    """
+
+    add_to_registry = False
+
+    async def _transfer(
+        self,
+        artifact: BaseArtifact,
+        source: BaseTarget,
+        destination: BaseTarget,
+    ) -> None:
+        """
+        Transfer *artifact* from *source* to *destination*.
+
+        Short-circuits when both targets share a filesystem (same
+        ``location_id``); otherwise packages on the source, streams the single
+        package file through the orchestrator, and unpackages on the
+        destination.
+        """
+        # Same filesystem: nothing to move, just point the artifact at where
+        # the destination expects to find it.
+        if source.location_id == destination.location_id:
+            artifact.path = Path(destination.path_on_target(artifact))
+            return
+
+        src_store = ArtifactStore(source)
+        dst_store = ArtifactStore(destination)
+
+        src_path = source.path_on_target(artifact)
+        pkg_src = await src_store.package(artifact)
+
+        data = await source.get_file(pkg_src)
+
+        name = PurePosixPath(pkg_src).name
+        pkg_dst = f"{destination.resolved_working_directory}/{name}"
+        await destination.put_file(data, pkg_dst)
+
+        dest_path = destination.path_on_target(artifact)
+        await dst_store.unpackage(artifact, pkg_dst)
+
+        # Point the artifact at its materialized destination path before any
+        # cleanup, so path_on_target/downstream templating resolve correctly.
+        artifact.path = Path(dest_path)
+
+        # Best-effort cleanup of staging packages. Never remove a package that
+        # *is* the real artifact: identity packaging leaves pkg_src == the
+        # source file, and for a single file pkg_dst == the destination file.
+        if pkg_src != src_path:
+            await self._safe_remove(source, pkg_src)
+        if pkg_dst != dest_path:
+            await self._safe_remove(destination, pkg_dst)
+
+    @staticmethod
+    async def _safe_remove(target: BaseTarget, path: str) -> None:
+        """Remove *path* on *target*, logging (not raising) on failure."""
+        try:
+            await target.remove(path)
+        except Exception as exc:
+            horus_logger.log.debug(
+                "Failed to clean up staging package '%s' on %s: %s",
+                path,
+                target.kind,
+                exc,
+            )

--- a/src/horus_runtime/core/workflow/base.py
+++ b/src/horus_runtime/core/workflow/base.py
@@ -46,8 +46,8 @@ from horus_runtime.core.target.base import BaseTarget
 from horus_runtime.core.task.base import BaseTask
 from horus_runtime.core.transfer.exceptions import (
     OrchestratorTargetNotSetError,
-    TransferStrategyNotFoundError,
 )
+from horus_runtime.core.transfer.generic import GenericTransfer
 from horus_runtime.core.transfer.strategy import BaseTransferStrategy
 from horus_runtime.core.workflow.edge import WorkflowEdge
 from horus_runtime.core.workflow.exceptions import (
@@ -349,8 +349,6 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
         Raises:
             OrchestratorTargetNotSetError: When a root artifact cannot be
                 accessed by the destination and no orchestrator_target is set.
-            TransferStrategyNotFoundError: When no registered strategy handles
-                the resolved source → destination target pair.
         """
         if source_map is None:
             source_map = self._build_source_map()
@@ -374,14 +372,17 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
             src_artifact = source.artifact if source is not None else None
             transfer_art = (src_artifact or artifact).model_copy()
 
-            # Look up the registered strategy for this (source, dest) pair.
+            # Look up the registered strategy for this (source, dest) pair,
+            # falling back to the target-agnostic GenericTransfer when no
+            # location-specific strategy is registered.
             strategy_cls = BaseTransferStrategy.get_from_registry(
                 source_target, task.target
             )
-            if strategy_cls is None:
-                raise TransferStrategyNotFoundError(
-                    source_target.kind, task.target.kind
-                )
+            strategy = (
+                strategy_cls()
+                if strategy_cls is not None
+                else GenericTransfer()
+            )
 
             horus_logger.log.debug(
                 _(
@@ -392,15 +393,13 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
                     "id": transfer_art.id,
                     "src": source_target.kind,
                     "dst": task.target.kind,
-                    "strategy": strategy_cls.__name__,
+                    "strategy": type(strategy).__name__,
                 }
             )
 
             # Perform the transfer, then point the consumer input at the
             # materialized location so its body templating resolves correctly.
-            await strategy_cls().transfer(
-                transfer_art, source_target, task.target
-            )
+            await strategy.transfer(transfer_art, source_target, task.target)
             artifact.path = transfer_art.path
 
     @property
@@ -580,7 +579,7 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
         """
 
     @final
-    def reset(self) -> None:
+    async def reset(self) -> None:
         """
         Reset the workflow by deleting all output artifacts of all tasks in the
         workflow. This allows the workflow to be re-run from scratch.
@@ -590,10 +589,10 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
             _("Resetting workflow %(workflow_name)s.")
             % {"workflow_name": self.name}
         )
-        self._reset()
+        await self._reset()
 
     @abstractmethod
-    def _reset(self) -> None:
+    async def _reset(self) -> None:
         """
         Subclass-specific reset logic. Override this in subclasses when
         additional state must be cleared on reset. Do not set ``self.status``

--- a/tests/unit/artifact/test_builtin_artifact.py
+++ b/tests/unit/artifact/test_builtin_artifact.py
@@ -19,7 +19,6 @@
 Unit tests for artifact_registry module.
 """
 
-import hashlib
 import tempfile
 from pathlib import Path
 
@@ -30,9 +29,6 @@ from horus_builtin.artifact.file import FileArtifact
 from horus_builtin.artifact.folder import FolderArtifact
 from horus_runtime.context import HorusContext
 from horus_runtime.core.artifact.base import BaseArtifact
-
-SHA_HEX_LENGTH = 64  # Length of SHA-256 hash in hexadecimal representation
-SHA_HEX_LENGTH_BYTES = 32  # Length of SHA-256 hash in bytes
 
 
 @pytest.mark.unit
@@ -140,85 +136,6 @@ class TestFileArtifact:
             assert artifact.kind == "file"
             assert artifact.path == test_file.resolve()
 
-    def test_hash_property_existing_file(self) -> None:
-        """
-        Test hash property with an existing file.
-        """
-        with tempfile.TemporaryDirectory() as temp_dir:
-            test_file = Path(temp_dir) / "test.txt"
-            test_content = "Hello, Horus Runtime!"
-            test_file.write_text(test_content)
-
-            artifact = FileArtifact(id="test_file", path=test_file)
-
-            # Calculate expected hash
-            expected_hash = hashlib.sha256(test_content.encode()).hexdigest()
-
-            assert artifact.hash == expected_hash
-            assert isinstance(artifact.hash, str)
-
-    def test_hash_property_nonexistent_file(self) -> None:
-        """
-        Test hash property returns None for non-existent file.
-        """
-        artifact = FileArtifact(
-            id="nonexistent_file", path=Path("/nonexistent/file.txt")
-        )
-        assert artifact.hash is None
-
-    def test_hash_property_empty_file(self) -> None:
-        """
-        Test hash property with empty file.
-        """
-        with tempfile.TemporaryDirectory() as temp_dir:
-            empty_file = Path(temp_dir) / "empty.txt"
-            empty_file.write_text("")  # Create empty file
-
-            artifact = FileArtifact(id="empty_file", path=empty_file)
-
-            # Hash of empty content
-            expected_hash = hashlib.sha256(b"").hexdigest()
-            assert artifact.hash == expected_hash
-
-    def test_hash_changes_with_content(self) -> None:
-        """
-        Test that hash changes when file content changes.
-        """
-        with tempfile.TemporaryDirectory() as temp_dir:
-            test_file = Path(temp_dir) / "changeable.txt"
-
-            # Initial content
-            test_file.write_text("Initial content")
-            artifact = FileArtifact(id="changeable_file", path=test_file)
-            hash1 = artifact.hash
-
-            # Change content
-            test_file.write_text("Modified content")
-            hash2 = artifact.hash
-
-            assert hash1 != hash2
-            assert hash1 is not None
-            assert hash2 is not None
-
-    def test_large_file_hash_performance(self) -> None:
-        """
-        Test hash calculation with larger file (tests chunked reading).
-        """
-        with tempfile.TemporaryDirectory() as temp_dir:
-            large_file = Path(temp_dir) / "large.txt"
-
-            # Create a file larger than the hash buffer (65536 bytes)
-            large_content = "A" * 100000  # 100KB
-            large_file.write_text(large_content)
-
-            artifact = FileArtifact(id="large_file", path=large_file)
-
-            # Should complete without error
-            file_hash = artifact.hash
-            assert file_hash is not None
-            assert isinstance(file_hash, str)
-            assert len(file_hash) == SHA_HEX_LENGTH
-
     def test_read_returns_file_contents(
         self, horus_context: HorusContext
     ) -> None:
@@ -249,37 +166,19 @@ class TestFileArtifact:
 
             assert test_file.read_text() == "hello"
 
-    def test_package_returns_canonical_file_path(
-        self, horus_context: HorusContext
-    ) -> None:
+    def test_file_pack_unpack_commands_are_identity(self) -> None:
         """
-        Test that packaging a file artifact returns its canonical path.
+        A single-file artifact is its own package: both command builders
+        return None so the store handles it by identity.
         """
-        del horus_context
         with tempfile.TemporaryDirectory() as temp_dir:
             test_file = Path(temp_dir) / "test.txt"
             test_file.write_text("hello")
 
             artifact = FileArtifact(id="test_file", path=test_file)
 
-            assert artifact.package() == test_file.resolve()
-
-    def test_unpackage_copies_packaged_file_to_artifact_path(
-        self, horus_context: HorusContext
-    ) -> None:
-        """
-        Test that unpackage copies the packaged file into place.
-        """
-        del horus_context
-        with tempfile.TemporaryDirectory() as temp_dir:
-            package_path = Path(temp_dir) / "package.txt"
-            target_path = Path(temp_dir) / "output" / "artifact.txt"
-            package_path.write_text("hello")
-
-            artifact = FileArtifact(id="artifact_file", path=target_path)
-            artifact.unpackage(package_path)
-
-            assert target_path.read_text() == "hello"
+            assert artifact.pack_command(str(test_file), "/tmp/pkg") is None
+            assert artifact.unpack_command("/tmp/pkg", str(test_file)) is None
 
 
 @pytest.mark.unit
@@ -298,143 +197,6 @@ class TestFolderArtifact:
             assert artifact is not None
             assert artifact.kind == "folder"
             assert artifact.path == Path(temp_dir).resolve()
-
-    def test_exists_method_existing_directory(self) -> None:
-        """
-        Test exists method with existing directory.
-        """
-        with tempfile.TemporaryDirectory() as temp_dir:
-            artifact = FolderArtifact(id="test_folder", path=Path(temp_dir))
-            assert artifact.exists() is True
-
-    def test_exists_method_nonexistent_directory(self) -> None:
-        """
-        Test exists method with non-existent directory.
-        """
-        artifact = FolderArtifact(
-            id="nonexistent_folder", path=Path("/nonexistent/directory")
-        )
-        assert artifact.exists() is False
-
-    def test_exists_method_file_not_directory(self) -> None:
-        """
-        Test exists method returns False when path exists but is a file.
-        """
-        with tempfile.TemporaryDirectory() as temp_dir:
-            test_file = Path(temp_dir) / "not_a_folder.txt"
-            test_file.write_text("I am a file")
-
-            artifact = FolderArtifact(id="not_a_folder", path=test_file)
-            assert (
-                artifact.exists() is False
-            )  # File exists but it's not a directory
-
-    def test_hash_property_empty_folder(self) -> None:
-        """
-        Test hash property with empty folder.
-        """
-        with tempfile.TemporaryDirectory() as temp_dir:
-            artifact = FolderArtifact(id="empty_folder", path=Path(temp_dir))
-
-            folder_hash = artifact.hash
-
-            # Empty folder should have deterministic hash
-            assert folder_hash is not None
-            assert isinstance(folder_hash, str)
-            assert len(folder_hash) == SHA_HEX_LENGTH
-
-    def test_hash_property_nonexistent_folder(self) -> None:
-        """
-        Test hash property returns None for non-existent folder.
-        """
-        artifact = FolderArtifact(
-            id="nonexistent_folder", path=Path("/nonexistent/folder")
-        )
-        assert artifact.hash is None
-
-    def test_hash_property_multiple_files(self) -> None:
-        """
-        Test hash property with folder containing multiple files.
-        """
-        with tempfile.TemporaryDirectory() as temp_dir:
-            # Create multiple files in specific order
-            files_data = [
-                ("a_first.txt", "Content A"),
-                ("b_second.txt", "Content B"),
-                ("z_last.txt", "Content Z"),
-            ]
-
-            for filename, content in files_data:
-                file_path = Path(temp_dir) / filename
-                file_path.write_text(content)
-
-            artifact = FolderArtifact(id="test_folder", path=Path(temp_dir))
-            folder_hash = artifact.hash
-
-            assert folder_hash is not None
-            assert isinstance(folder_hash, str)
-
-            # Verify deterministic ordering (alphabetical by relative path)
-            # Hash should be consistent regardless of file creation order
-            artifact2 = FolderArtifact(id="test_folder", path=Path(temp_dir))
-            assert artifact2.hash == folder_hash
-
-    def test_hash_empty_folders_ignored(self) -> None:
-        """
-        Test that empty subfolders don't affect hash (only files are hashed).
-        """
-        with tempfile.TemporaryDirectory() as temp_dir:
-            # Create folder with empty subdirectory
-            empty_subdir = Path(temp_dir) / "empty"
-            empty_subdir.mkdir()
-
-            artifact = FolderArtifact(id="test_folder", path=Path(temp_dir))
-            hash_with_empty_dir = artifact.hash
-
-            # Remove empty directory
-            empty_subdir.rmdir()
-
-            hash_without_empty_dir = artifact.hash
-
-            # Hash should be the same (empty directories don't
-            # contribute to hash)
-            assert hash_with_empty_dir == hash_without_empty_dir
-
-    def test_folder_with_special_characters(self) -> None:
-        """
-        Test folder hash with files containing special characters.
-        """
-        with tempfile.TemporaryDirectory() as temp_dir:
-            # Create files with Unicode and special characters in names/content
-            special_file = Path(temp_dir) / "special_字符.txt"
-            special_file.write_text("Content with émojis 🚀 and ñoño")
-
-            artifact = FolderArtifact(id="special_folder", path=Path(temp_dir))
-            folder_hash = artifact.hash
-
-            assert folder_hash is not None
-            assert isinstance(folder_hash, str)
-
-    def test_large_folder_structure(self) -> None:
-        """
-        Test hash calculation with larger folder structure.
-        """
-        with tempfile.TemporaryDirectory() as temp_dir:
-            # Create multiple levels and files
-            for i in range(10):
-                subdir = Path(temp_dir) / f"subdir_{i:02d}"
-                subdir.mkdir()
-                for j in range(5):
-                    file_path = subdir / f"file_{j}.txt"
-                    file_path.write_text(f"Content {i}-{j}")
-
-            artifact = FolderArtifact(id="large_folder", path=Path(temp_dir))
-            folder_hash = artifact.hash
-
-            # Should complete without error even with many files
-            assert folder_hash is not None
-            assert isinstance(folder_hash, str)
-            assert len(folder_hash) == SHA_HEX_LENGTH
 
     def test_read_returns_folder_path(
         self, horus_context: HorusContext
@@ -470,51 +232,33 @@ class TestFolderArtifact:
             assert (target_path / "a.txt").read_text() == "A"
             assert (target_path / "nested" / "b.txt").read_text() == "B"
 
-    def test_package_creates_zip_archive(
-        self, horus_context: HorusContext
-    ) -> None:
+    def test_pack_command_tars_folder_contents(self) -> None:
         """
-        Test that packaging a folder creates a zip archive.
+        A folder's pack command tars the directory's *contents* (via
+        ``tar -C src .``) into the package path.
         """
-        del horus_context
-        with tempfile.TemporaryDirectory() as temp_dir:
-            folder_path = Path(temp_dir) / "folder"
-            folder_path.mkdir()
-            (folder_path / "a.txt").write_text("A")
+        artifact = FolderArtifact(id="f", path=Path("/work/data"))
 
-            artifact = FolderArtifact(id="test_folder", path=folder_path)
-            package_path = artifact.package()
+        cmd = artifact.pack_command("/work/data", "/tmp/data.horuspkg")
 
-            assert package_path.suffix == ".zip"
-            assert package_path.exists()
+        assert cmd is not None
+        assert "tar czf" in cmd
+        assert "-C /work/data ." in cmd
+        assert "/tmp/data.horuspkg" in cmd
 
-    def test_unpackage_extracts_archive_to_folder(
-        self, horus_context: HorusContext
-    ) -> None:
+    def test_unpack_command_extracts_into_fresh_dest(self) -> None:
         """
-        Test that unpackage extracts a packaged folder archive.
+        A folder's unpack command recreates the destination and extracts the
+        tarball into it.
         """
-        del horus_context
-        with tempfile.TemporaryDirectory() as temp_dir:
-            source_path = Path(temp_dir) / "source"
-            target_path = Path(temp_dir) / "target"
-            source_path.mkdir()
-            (source_path / "a.txt").write_text("A")
-            (source_path / "nested").mkdir()
-            (source_path / "nested" / "b.txt").write_text("B")
+        artifact = FolderArtifact(id="f", path=Path("/work/data"))
 
-            source_artifact = FolderArtifact(
-                id="source_folder", path=source_path
-            )
-            package_path = source_artifact.package()
+        cmd = artifact.unpack_command("/tmp/data.horuspkg", "/dest/data")
 
-            target_artifact = FolderArtifact(
-                id="target_folder", path=target_path
-            )
-            target_artifact.unpackage(package_path)
-
-            assert (target_path / "a.txt").read_text() == "A"
-            assert (target_path / "nested" / "b.txt").read_text() == "B"
+        assert cmd is not None
+        assert "rm -rf /dest/data" in cmd
+        assert "mkdir -p /dest/data" in cmd
+        assert "tar xzf /tmp/data.horuspkg -C /dest/data" in cmd
 
 
 class ConcreteLocalArtifact(BaseArtifact):
@@ -524,25 +268,6 @@ class ConcreteLocalArtifact(BaseArtifact):
 
     add_to_registry = False
     kind: str = "local_test"
-
-    def exists(self) -> bool:
-        """
-        Test exists implementation based on the local path.
-        """
-        return self.path.exists()
-
-    @property
-    def hash(self) -> str | None:
-        """
-        Test hash property.
-        """
-        return "test_hash" if self.exists() else None
-
-    def delete(self) -> None:
-        """
-        Test delete method.
-        """
-        pass
 
     def read(self) -> Path:
         """
@@ -590,79 +315,6 @@ class TestBaseArtifactPathBehavior:
             )
 
             assert artifact.path == test_file.resolve()
-
-    def test_exists_method_file_exists(self) -> None:
-        """
-        Test exists method when file exists.
-        """
-        with tempfile.TemporaryDirectory() as temp_dir:
-            test_file = Path(temp_dir) / "existing_file.txt"
-            test_file.write_text("content")
-
-            artifact = ConcreteLocalArtifact(
-                id="existing_file_artifact", path=test_file
-            )
-            assert artifact.exists() is True
-
-    def test_exists_method_file_not_exists(self) -> None:
-        """
-        Test exists method when file does not exist.
-        """
-        artifact = ConcreteLocalArtifact(
-            id="nonexistent_file_artifact",
-            path=Path("/nonexistent/path/file.txt"),
-        )
-        assert artifact.exists() is False
-
-    def test_hash_file_static_method(self) -> None:
-        """
-        Test the static hash_file method.
-        """
-        with tempfile.TemporaryDirectory() as temp_dir:
-            test_file = Path(temp_dir) / "test.txt"
-            test_content = "Hello, Horus!"
-            test_file.write_text(test_content)
-
-            hash_bytes = BaseArtifact.hash_file(test_file)
-
-            assert isinstance(hash_bytes, bytes)
-            assert len(hash_bytes) == SHA_HEX_LENGTH_BYTES
-
-            # Hash should be consistent
-            hash_bytes2 = BaseArtifact.hash_file(test_file)
-            assert hash_bytes == hash_bytes2
-
-    def test_hash_file_different_contents(self) -> None:
-        """
-        Test that different file contents produce different hashes.
-        """
-        with tempfile.TemporaryDirectory() as temp_dir:
-            file1 = Path(temp_dir) / "file1.txt"
-            file2 = Path(temp_dir) / "file2.txt"
-
-            file1.write_text("Content A")
-            file2.write_text("Content B")
-
-            hash1 = BaseArtifact.hash_file(file1)
-            hash2 = BaseArtifact.hash_file(file2)
-
-            assert hash1 != hash2
-
-    def test_hash_file_large_file(self) -> None:
-        """
-        Test hash_file method with large file to verify chunked reading.
-        """
-        with tempfile.TemporaryDirectory() as temp_dir:
-            large_file = Path(temp_dir) / "large.txt"
-
-            # Create a file larger than the 64KB buffer
-            large_content = "A" * (65536 * 2)  # 128KB
-            large_file.write_text(large_content)
-
-            hash_bytes = BaseArtifact.hash_file(large_file)
-
-            assert isinstance(hash_bytes, bytes)
-            assert len(hash_bytes) == SHA_HEX_LENGTH_BYTES
 
     def test_path_update_on_model_validation(self) -> None:
         """

--- a/tests/unit/artifact/test_store.py
+++ b/tests/unit/artifact/test_store.py
@@ -29,7 +29,9 @@ from horus_builtin.artifact.folder import FolderArtifact
 from horus_builtin.target.local import LocalTarget
 from horus_runtime.context import HorusContext
 from horus_runtime.core.artifact.base import BaseArtifact
-from horus_runtime.core.artifact.store import ArtifactStore, TargetFilesystem
+from horus_runtime.core.artifact.store import (
+    ArtifactStore,
+)
 from horus_runtime.core.transfer.generic import GenericTransfer
 
 
@@ -57,12 +59,8 @@ class _FarLocalTarget(LocalTarget):
 @pytest.mark.unit
 class TestLocalTargetFilesystemPrimitives:
     """
-    LocalTarget must satisfy the TargetFilesystem protocol natively.
+    LocalTarget must satisfy everything needed for the ArtifactStore.
     """
-
-    def test_local_target_satisfies_protocol(self) -> None:
-        """LocalTarget structurally implements TargetFilesystem."""
-        assert isinstance(LocalTarget(), TargetFilesystem)
 
     async def test_path_exists_for_file_and_dir(self) -> None:
         """path_exists is True for files and directories, False otherwise."""

--- a/tests/unit/artifact/test_store.py
+++ b/tests/unit/artifact/test_store.py
@@ -1,0 +1,294 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Unit tests for ArtifactStore and the target filesystem primitives it uses.
+"""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from horus_builtin.artifact.file import FileArtifact
+from horus_builtin.artifact.folder import FolderArtifact
+from horus_builtin.target.local import LocalTarget
+from horus_runtime.context import HorusContext
+from horus_runtime.core.artifact.base import BaseArtifact
+from horus_runtime.core.artifact.store import ArtifactStore, TargetFilesystem
+from horus_runtime.core.transfer.generic import GenericTransfer
+
+
+class _FarLocalTarget(LocalTarget):
+    """
+    A local target that pretends to live on a distinct machine.
+
+    It reuses the real local filesystem primitives but reports a unique
+    ``location_id`` (so transfers do not short-circuit) and SSH-like
+    ``path_on_target`` semantics (``working_directory/<name>``), letting tests
+    exercise the full package -> get_file -> put_file -> unpackage path against
+    the local filesystem.
+    """
+
+    add_to_registry = False
+
+    @property
+    def location_id(self) -> str:
+        return f"far://{self.resolved_working_directory}"
+
+    def path_on_target(self, artifact: BaseArtifact) -> str:
+        return f"{self.resolved_working_directory}/{Path(artifact.path).name}"
+
+
+@pytest.mark.unit
+class TestLocalTargetFilesystemPrimitives:
+    """
+    LocalTarget must satisfy the TargetFilesystem protocol natively.
+    """
+
+    def test_local_target_satisfies_protocol(self) -> None:
+        """LocalTarget structurally implements TargetFilesystem."""
+        assert isinstance(LocalTarget(), TargetFilesystem)
+
+    async def test_path_exists_for_file_and_dir(self) -> None:
+        """path_exists is True for files and directories, False otherwise."""
+        target = LocalTarget()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            file_path = Path(temp_dir) / "f.txt"
+            file_path.write_text("hi")
+
+            assert await target.path_exists(str(file_path)) is True
+            assert await target.path_exists(temp_dir) is True
+            assert (
+                await target.path_exists(str(Path(temp_dir) / "missing"))
+                is False
+            )
+
+    async def test_remove_file(self) -> None:
+        """Remove deletes a single file."""
+        target = LocalTarget()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            file_path = Path(temp_dir) / "f.txt"
+            file_path.write_text("hi")
+
+            await target.remove(str(file_path))
+            assert not file_path.exists()
+
+    async def test_remove_directory_recursively(self) -> None:
+        """Remove deletes a directory and its contents."""
+        target = LocalTarget()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            nested = Path(temp_dir) / "dir" / "nested"
+            nested.mkdir(parents=True)
+            (nested / "a.txt").write_text("A")
+
+            await target.remove(str(Path(temp_dir) / "dir"))
+            assert not (Path(temp_dir) / "dir").exists()
+
+    async def test_remove_missing_path_is_noop(self) -> None:
+        """Removing a missing path does not raise."""
+        target = LocalTarget()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Should not raise.
+            await target.remove(str(Path(temp_dir) / "missing"))
+
+
+@pytest.mark.unit
+class TestArtifactStore:
+    """
+    ArtifactStore maps artifacts to target filesystem operations.
+    """
+
+    async def test_exists_true_for_existing_file(self) -> None:
+        """Exists is True when the file artifact has materialized."""
+        store = ArtifactStore(LocalTarget())
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "f.txt"
+            path.write_text("hi")
+            artifact = FileArtifact(id="a", path=path)
+
+            assert await store.exists(artifact) is True
+
+    async def test_exists_false_for_missing_file(self) -> None:
+        """Exists is False when the file artifact is absent."""
+        store = ArtifactStore(LocalTarget())
+        artifact = FileArtifact(id="a", path=Path("/nonexistent/f.txt"))
+
+        assert await store.exists(artifact) is False
+
+    async def test_exists_true_for_existing_folder(self) -> None:
+        """Exists is True for a materialized folder artifact (generic -e)."""
+        store = ArtifactStore(LocalTarget())
+        with tempfile.TemporaryDirectory() as temp_dir:
+            artifact = FolderArtifact(id="a", path=Path(temp_dir))
+
+            assert await store.exists(artifact) is True
+
+    async def test_delete_removes_file_and_emits_event(
+        self, horus_context: HorusContext
+    ) -> None:
+        """Delete removes a file artifact from the target."""
+        del horus_context
+        store = ArtifactStore(LocalTarget())
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "f.txt"
+            path.write_text("hi")
+            artifact = FileArtifact(id="a", path=path)
+
+            await store.delete(artifact)
+
+            assert not path.exists()
+
+    async def test_delete_removes_folder(
+        self, horus_context: HorusContext
+    ) -> None:
+        """Delete removes a folder artifact recursively."""
+        del horus_context
+        store = ArtifactStore(LocalTarget())
+        with tempfile.TemporaryDirectory() as temp_dir:
+            folder = Path(temp_dir) / "dir"
+            folder.mkdir()
+            (folder / "a.txt").write_text("A")
+            artifact = FolderArtifact(id="a", path=folder)
+
+            await store.delete(artifact)
+
+            assert not folder.exists()
+
+    async def test_delete_missing_artifact_is_noop(
+        self, horus_context: HorusContext
+    ) -> None:
+        """Deleting a missing artifact does not raise or emit."""
+        del horus_context
+        store = ArtifactStore(LocalTarget())
+        artifact = FileArtifact(id="a", path=Path("/nonexistent/f.txt"))
+
+        # Should not raise.
+        await store.delete(artifact)
+
+    async def test_package_file_is_identity(
+        self, horus_context: HorusContext
+    ) -> None:
+        """Packaging a single-file artifact returns its own path unchanged."""
+        del horus_context
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "f.txt"
+            path.write_text("hi")
+            target = LocalTarget(working_directory=temp_dir)
+            store = ArtifactStore(target)
+            artifact = FileArtifact(id="a", path=path)
+
+            pkg = await store.package(artifact)
+
+            assert pkg == target.path_on_target(artifact)
+
+    async def test_package_unpackage_folder_round_trip(
+        self, horus_context: HorusContext
+    ) -> None:
+        """Packaging then unpackaging a folder restores its contents."""
+        del horus_context
+        with tempfile.TemporaryDirectory() as temp_dir:
+            base = Path(temp_dir)
+            src = base / "src" / "data"
+            (src / "nested").mkdir(parents=True)
+            (src / "a.txt").write_text("A")
+            (src / "nested" / "b.txt").write_text("B")
+
+            target = LocalTarget(working_directory=str(base))
+            store = ArtifactStore(target)
+
+            src_art = FolderArtifact(id="data", path=src)
+            pkg = await store.package(src_art)
+            assert Path(pkg).is_file()
+
+            dest = base / "out" / "data"
+            dest_art = FolderArtifact(id="data", path=dest)
+            await store.unpackage(dest_art, pkg)
+
+            assert (dest / "a.txt").read_text() == "A"
+            assert (dest / "nested" / "b.txt").read_text() == "B"
+
+
+@pytest.mark.unit
+class TestGenericTransfer:
+    """
+    GenericTransfer moves artifacts over any target pair via the store.
+    """
+
+    async def test_same_location_short_circuits(
+        self, horus_context: HorusContext
+    ) -> None:
+        """Same location_id: no move, artifact repointed to path_on_target."""
+        del horus_context
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "f.txt"
+            path.write_text("hi")
+            src = LocalTarget(working_directory=temp_dir)
+            dst = LocalTarget(working_directory=temp_dir)
+            artifact = FileArtifact(id="a", path=path)
+
+            await GenericTransfer().transfer(artifact, src, dst)
+
+            assert artifact.path == Path(dst.path_on_target(artifact))
+
+    async def test_cross_location_folder_transfer(
+        self, horus_context: HorusContext
+    ) -> None:
+        """
+        Distinct locations: a folder is packaged on the source, streamed, and
+        unpackaged intact at the destination.
+        """
+        del horus_context
+        with (
+            tempfile.TemporaryDirectory() as src_dir,
+            tempfile.TemporaryDirectory() as dst_dir,
+        ):
+            src_data = Path(src_dir) / "data"
+            (src_data / "nested").mkdir(parents=True)
+            (src_data / "a.txt").write_text("A")
+            (src_data / "nested" / "b.txt").write_text("B")
+
+            source = _FarLocalTarget(working_directory=src_dir)
+            destination = _FarLocalTarget(working_directory=dst_dir)
+            artifact = FolderArtifact(id="data", path=src_data)
+
+            await GenericTransfer().transfer(artifact, source, destination)
+
+            dest_dir_path = Path(dst_dir) / "data"
+            assert (dest_dir_path / "a.txt").read_text() == "A"
+            assert (dest_dir_path / "nested" / "b.txt").read_text() == "B"
+            assert artifact.path == Path(destination.path_on_target(artifact))
+
+    async def test_cross_location_file_transfer(
+        self, horus_context: HorusContext
+    ) -> None:
+        """A single file transfers by identity across distinct locations."""
+        del horus_context
+        with (
+            tempfile.TemporaryDirectory() as src_dir,
+            tempfile.TemporaryDirectory() as dst_dir,
+        ):
+            src_file = Path(src_dir) / "f.txt"
+            src_file.write_text("payload")
+
+            source = _FarLocalTarget(working_directory=src_dir)
+            destination = _FarLocalTarget(working_directory=dst_dir)
+            artifact = FileArtifact(id="f", path=src_file)
+
+            await GenericTransfer().transfer(artifact, source, destination)
+
+            assert Path(dst_dir, "f.txt").read_text() == "payload"

--- a/tests/unit/middleware/test_task_log_file.py
+++ b/tests/unit/middleware/test_task_log_file.py
@@ -25,6 +25,7 @@ from horus_builtin.executor.shell import ShellExecutor
 from horus_builtin.middleware.task_log_file import TaskLogFileMiddleware
 from horus_builtin.runtime.command import CommandRuntime
 from horus_builtin.target.local import LocalTarget
+from horus_runtime.core.target.base import BaseTarget
 from horus_runtime.core.task.base import BaseTask
 from horus_runtime.logging import horus_logger
 from horus_runtime.middleware.task import TaskMiddlewareContext
@@ -32,15 +33,15 @@ from horus_runtime.middleware.task import TaskMiddlewareContext
 
 class _ConcreteTask(BaseTask):
     kind: str = "test_log_task"
-    target: LocalTarget = LocalTarget()
+    target: BaseTarget = LocalTarget()
 
-    async def _run(self) -> None:  # pragma: no cover - not exercised here
+    async def _run(self) -> None:
         pass
 
-    def is_complete(self) -> bool:
+    async def is_complete(self) -> bool:
         return False
 
-    def _reset(self) -> None:
+    async def _reset(self) -> None:
         pass
 
 

--- a/tests/unit/task/test_builtin_function_task.py
+++ b/tests/unit/task/test_builtin_function_task.py
@@ -284,7 +284,7 @@ class TestFunctionTaskExecution:
         await task.run()
         assert task.runs == 1
 
-        task.reset()
+        await task.reset()
         assert task.runs == 0
 
     async def test_run_awaits_async_function(self) -> None:

--- a/tests/unit/task/test_builtin_task.py
+++ b/tests/unit/task/test_builtin_task.py
@@ -328,6 +328,6 @@ class TestHorusTaskExecution:
         assert task.runs == 1
 
         # Reset the task
-        task.reset()
+        await task.reset()
 
         assert task.runs == 0

--- a/tests/unit/task/test_task_base.py
+++ b/tests/unit/task/test_task_base.py
@@ -52,13 +52,13 @@ class ConcreteTestTask(BaseTask):
         Test implementation of run method.
         """
 
-    def is_complete(self) -> bool:
+    async def is_complete(self) -> bool:
         """
         Always return True for testing purposes.
         """
         return True
 
-    def _reset(self) -> None:
+    async def _reset(self) -> None:
         """
         Do nothing for testing purposes.
         """
@@ -169,10 +169,10 @@ class TestBaseTaskValidation:
                 # for the autoregistry to work.
                 """
 
-                def is_complete(self) -> bool:
+                async def is_complete(self) -> bool:
                     return True
 
-                def _reset(self) -> None:
+                async def _reset(self) -> None:
                     pass
 
                 async def _run(self) -> None:
@@ -304,7 +304,7 @@ class TestBaseTaskReset:
     Tests for the reset / _reset contract on BaseTask.
     """
 
-    def test_reset_sets_status_to_idle(
+    async def test_reset_sets_status_to_idle(
         self,
     ) -> None:
         """
@@ -313,11 +313,11 @@ class TestBaseTaskReset:
         task = _make_concrete_task()
         task.status = TaskStatus.COMPLETED
 
-        task.reset()
+        await task.reset()
 
         assert task.status == TaskStatus.IDLE
 
-    def test_default_reset_is_noop(
+    async def test_default_reset_is_noop(
         self,
     ) -> None:
         """
@@ -327,6 +327,6 @@ class TestBaseTaskReset:
         task = _make_concrete_task()
 
         # Should not raise
-        task.reset()
+        await task.reset()
 
         assert task.status == TaskStatus.IDLE

--- a/tests/unit/workflow/test_builtin_workflow.py
+++ b/tests/unit/workflow/test_builtin_workflow.py
@@ -35,6 +35,7 @@ from horus_builtin.workflow.dag import UnknownTaskError
 from horus_builtin.workflow.horus_workflow import HorusWorkflow
 from horus_runtime.context import HorusContext
 from horus_runtime.core.artifact.base import BaseArtifact
+from horus_runtime.core.artifact.store import ArtifactStore
 from horus_runtime.core.task.exceptions import TaskExecutionError
 from horus_runtime.core.transfer.strategy import BaseTransferStrategy
 from horus_runtime.core.workflow.edge import WorkflowEdge
@@ -286,7 +287,12 @@ class TestWorkflowRun:
         wf = HorusWorkflow.from_yaml(wf_file)
 
         with (
-            patch.object(FileArtifact, "exists", return_value=True),
+            patch.object(
+                ArtifactStore,
+                "exists",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
             patch.object(HorusTask, "_run") as mock_run,
         ):
             await wf.run(trigger_id="test_task_id")
@@ -348,7 +354,9 @@ class TestWorkflowRun:
             ],
         )
 
-        with patch.object(FileArtifact, "exists", return_value=True):
+        with patch.object(
+            ArtifactStore, "exists", new_callable=AsyncMock, return_value=True
+        ):
             await wf.run(trigger_id="producer")
 
         # Two tasks, two calls

--- a/tests/unit/workflow/test_workflow.py
+++ b/tests/unit/workflow/test_workflow.py
@@ -53,7 +53,7 @@ class ConcreteWorkflow(BaseWorkflow):
         """
         del trigger_id
 
-    def _reset(self) -> None:
+    async def _reset(self) -> None:
         """
         Reset the workflow to its initial state.
         """


### PR DESCRIPTION
## Why

Artifact existence, deletion, and packaging were implemented with local `pathlib`/`shutil` calls on `BaseArtifact`. These break the moment an artifact lives on a **different machine** than the orchestrator — the core scenario for hybrid execution. A local `path.exists()` reports the orchestrator's filesystem, not where the artifact actually is; `package()`/`unpackage()` can only zip/copy locally.

## What

Introduce an **`ArtifactStore`** that binds an artifact to a target and performs lifecycle operations through the target's artifact-agnostic filesystem primitives, so artifact handling is transparent across local and remote targets.

- **Target primitives**: add `BaseTarget.path_exists` / `remove` (shell defaults over `run_command_sync`; native overrides on `LocalTarget`). Remove the local-only `BaseArtifact.exists` / `hash` / `delete`.
- **`ArtifactStore.exists` / `delete`**: existence and deletion now run where the artifact lives. The task/workflow `reset` chain and `HorusTask.is_complete` become `async` — this also fixes a silent skip bug where `is_complete()` was evaluated as a truthy coroutine.
- **Packaging over the target**: replace local-only `package()`/`unpackage()` with artifact-supplied **pack/unpack shell-command builders** (`FolderArtifact` → `tar`; single-file artifacts → identity), executed on the target via `ArtifactStore.package`/`unpackage`. A remote folder is now tarred on its own host, moved as one file, and untarred on the destination.
- **`GenericTransfer`**: a target-agnostic fallback strategy (`package → get_file → put_file → unpackage`) used when no location-specific strategy is registered. Any target pair that implements the shared primitives can exchange artifacts. Registered strategies still take precedence, so optimized pair-specific paths (e.g. SSH↔SSH direct scp) are unaffected.

## Design notes

- `ArtifactStore` depends on a small `TargetFilesystem` `Protocol`, keeping the cross-cutting logic off both `BaseArtifact` and `BaseTarget`.
- The generic path routes bytes through the orchestrator (`get_file`→`put_file`) — the accepted tradeoff for generality; large artifacts hold the package in memory. Pair-specific strategies can still stream directly.

## Tests

- New `tests/unit/artifact/test_store.py` drives the real mechanism: `path_exists`/`remove`, `exists`/`delete`, and `package`/`unpackage` round-trips via actual `tar`/`untar` subprocesses; `GenericTransfer` cross-location file & folder transfers through real `get_file`/`put_file`; and the same-location short-circuit.
- Existing artifact/task/workflow tests updated for the async reset chain and the removed local-only methods.
- Full suite green (433 passed), ruff clean.

## Follow-ups

- **horus-ssh**: `SSHTarget` already implements every primitive the generic strategy needs, so `LocalToSSH`/`SSHToLocal` can be retired in favor of `GenericTransfer` (optionally keeping `SSHToSSH` as a direct-scp optimization). Separate PR.


## horus-docs
Documentation update for the `ArtifactStore` / target-primitive model. Separate PR.

https://github.com/temple-compute/horus-docs/pull/33