### PR TITLE
refactor(transfer): hoist same-filesystem shortcut into BaseTransferStrategy

### DIFF
--- a/src/horus_runtime/core/transfer/generic.py
+++ b/src/horus_runtime/core/transfer/generic.py
@@ -54,17 +54,11 @@ class GenericTransfer(BaseTransferStrategy):
         """
         Transfer *artifact* from *source* to *destination*.
 
-        Short-circuits when both targets share a filesystem (same
-        ``location_id``); otherwise packages on the source, streams the single
-        package file through the orchestrator, and unpackages on the
-        destination.
+        Packages on the source, streams the single package file through the
+        orchestrator, and unpackages on the destination. The same-filesystem
+        case (equal ``location_id``) is handled upstream by
+        :meth:`BaseTransferStrategy.transfer` and never reaches here.
         """
-        # Same filesystem: nothing to move, just point the artifact at where
-        # the destination expects to find it.
-        if source.location_id == destination.location_id:
-            artifact.path = Path(destination.path_on_target(artifact))
-            return
-
         src_store = ArtifactStore(source)
         dst_store = ArtifactStore(destination)
 

--- a/src/horus_runtime/core/transfer/strategy.py
+++ b/src/horus_runtime/core/transfer/strategy.py
@@ -28,6 +28,7 @@ values such as ``"local.local"``.
 """
 
 from abc import abstractmethod
+from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar, final
 
 from horus_runtime.middleware.transfer import (
@@ -71,7 +72,18 @@ class BaseTransferStrategy[
     ) -> None:
         """
         Transfer *artifact* from *source* target to *destination* target.
+
+        When both targets share a filesystem (equal ``location_id``) there is
+        nothing to move: the artifact is already reachable on the destination,
+        so it is repointed at its on-target path and no strategy runs. This
+        same-filesystem shortcut lives here, at the single entry point every
+        transfer goes through, so no individual strategy has to re-implement
+        it.
         """
+        if source.location_id == destination.location_id:
+            artifact.path = Path(destination.path_on_target(artifact))
+            return
+
         await TransferMiddleware.call_with_middleware(
             TransferMiddlewareContext(
                 transfer_strategy=self,

--- a/tests/unit/transfer/test_transfer.py
+++ b/tests/unit/transfer/test_transfer.py
@@ -23,6 +23,7 @@ from pathlib import Path
 
 import pytest
 
+from horus_builtin.artifact.file import FileArtifact
 from horus_builtin.target.local import LocalTarget
 from horus_builtin.transfer.local_noop import LocalNoOpTransfer
 from horus_runtime.core.artifact.base import BaseArtifact
@@ -214,3 +215,65 @@ class TestBaseTransferStrategy:
         destination = _UnregisteredTarget()
         result = BaseTransferStrategy.get_from_registry(source, destination)
         assert result is None
+
+
+class _OtherUnregisteredTarget(_UnregisteredTarget):
+    """A second target reporting a distinct ``location_id``."""
+
+    kind: str = "_test_other_target"
+    add_to_registry = False
+
+    @property
+    def location_id(self) -> str:
+        return "test://other"
+
+
+class _ExplodingTransfer(BaseTransferStrategy):
+    """A strategy whose ``_transfer`` must never run for same locations."""
+
+    add_to_registry = False
+
+    async def _transfer(
+        self,
+        artifact: BaseArtifact,
+        source: BaseTarget,
+        destination: BaseTarget,
+    ) -> None:
+        """Fail loudly if ever reached."""
+        del artifact, source, destination
+        raise AssertionError("_transfer ran for a same-filesystem pair")
+
+
+@pytest.mark.unit
+class TestSameFilesystemShortCircuit:
+    """
+    The same-filesystem shortcut lives in ``transfer()``, so it applies to
+    every strategy uniformly and no strategy has to implement it.
+    """
+
+    async def test_same_location_skips_strategy_and_repoints(self) -> None:
+        """
+        Equal ``location_id``: ``_transfer`` is never called and the artifact
+        is repointed at its destination ``path_on_target``.
+        """
+        source = _UnregisteredTarget()
+        destination = _UnregisteredTarget()
+        assert source.location_id == destination.location_id
+        artifact = FileArtifact(id="a", path=Path("/data/a.txt"))
+
+        await _ExplodingTransfer().transfer(artifact, source, destination)
+
+        assert artifact.path == Path(destination.path_on_target(artifact))
+
+    async def test_distinct_location_runs_strategy(self) -> None:
+        """
+        Distinct ``location_id``: the shortcut does not fire, so the strategy's
+        ``_transfer`` actually runs.
+        """
+        source = _UnregisteredTarget()
+        destination = _OtherUnregisteredTarget()
+        assert source.location_id != destination.location_id
+        artifact = FileArtifact(id="a", path=Path("/data/a.txt"))
+
+        with pytest.raises(AssertionError, match="same-filesystem"):
+            await _ExplodingTransfer().transfer(artifact, source, destination)


### PR DESCRIPTION
## What

The "source and destination share a filesystem" check previously lived inside `GenericTransfer._transfer`. That meant every other transfer strategy (`SSHToSSHTransfer`, and any future one) had to re-implement the same guard to avoid a pointless copy when both targets resolve to the same `location_id` — a cross-cutting concern leaking into individual strategies.

This moves the check up to `BaseTransferStrategy.transfer`, the single `@final` entry point every transfer flows through:

- When `source.location_id == destination.location_id`, the artifact is already reachable on the destination, so it is repointed at its `path_on_target` and the method returns **before** any middleware or `_transfer` runs.
- `GenericTransfer._transfer` loses its now-redundant short-circuit; it only handles genuine cross-location moves.
- Individual strategies no longer need to know about the same-filesystem case at all.

## Why

A concrete symptom: a workflow with a `local` orchestrator dispatching tasks to a single SSH host produces `ssh → ssh` transfers between the *same* host. `SSHToSSHTransfer` (in `horus-ssh`) would try to `scp` using the artifact's stale local orchestrator path, instead of recognising there is nothing to move. Rather than patch each strategy, the shortcut belongs once, at the call site.

## Tests

- Added `TestSameFilesystemShortCircuit`: an intentionally-exploding strategy proves `_transfer` is **never** entered for a same-`location_id` pair (and the artifact is repointed to `path_on_target`), while a distinct-location pair still invokes `_transfer`.
- Existing `test_same_location_short_circuits` (in `test_store.py`) still passes unchanged, now exercising the shortcut through the base wrapper.
- Full suite: 434 passed; ruff + mypy `--strict` clean.

## Companion PR

Depends on this landing to let `horus-ssh` drop its local copy of the same guard: temple-compute/horus-ssh#10.

## Docs update

https://github.com/temple-compute/horus-docs/pull/34