### PR TITLE
fix(tui): show skipped tasks in blue instead of gray

### DIFF
--- a/src/horus_builtin/event/tui_subscriber.py
+++ b/src/horus_builtin/event/tui_subscriber.py
@@ -73,7 +73,7 @@ _STATUS_STYLE: dict[TaskStatus, str] = {
     TaskStatus.COMPLETED: "bold green",
     TaskStatus.FAILED: "bold red",
     TaskStatus.CANCELED: "magenta",
-    TaskStatus.SKIPPED: "dim",
+    TaskStatus.SKIPPED: "blue",
 }
 
 # Glyph per task status (RUNNING uses an animated spinner instead).


### PR DESCRIPTION
## What

In the TUI dashboard, skipped tasks were colored with the Rich style `"dim"`, rendering as gray — the same treatment as `IDLE` tasks, which made skipped tasks hard to distinguish.

This changes the skipped-task style to `"blue"` so skipped tasks stand out as a deliberate, distinct outcome.

## Details

- Single edit to `_STATUS_STYLE[TaskStatus.SKIPPED]` in `src/horus_builtin/event/tui_subscriber.py`.
- This one map drives color in both render paths, so the change applies to both the per-task table and the dependency DAG tree.
- `IDLE` keeps `"dim"`, so skipped is now visually distinct from idle.
- No test changes required; `tests/unit/event/test_tui_subscriber.py` has no assertions on the color value.

## Testing

- `pytest tests/unit/event/test_tui_subscriber.py` → 7 passed.