### PR TITLE
feat(workflow): transfer flag on WorkflowEdge for ordering-only edges

### DIFF
--- a/src/horus_runtime/core/workflow/base.py
+++ b/src/horus_runtime/core/workflow/base.py
@@ -216,7 +216,11 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
         - target an existing task and one of its declared input ids;
         - source either an existing task's declared output id, or a root
           artifact id via the ``artifact-<rootId>`` convention;
-        - be the only edge feeding its ``(target, target_input)``.
+        - be the only ``transfer=True`` edge feeding its
+          ``(target, target_input)``. Ordering-only (``transfer=False``)
+          edges are exempt: any number of them may feed the same input,
+          alongside at most one ``transfer=True`` edge, since they never
+          contribute a transfer source (see :meth:`_build_source_map`).
         """
         task_inputs = {t.id: {a.id for a in t.inputs} for t in self.tasks}
         task_outputs = {t.id: {a.id for a in t.outputs} for t in self.tasks}
@@ -232,11 +236,15 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
                     "target input", edge.target_input
                 )
 
-            # At most one edge may feed a given consumer input.
-            key = (edge.target, edge.target_input)
-            if key in seen_targets:
-                raise DuplicateEdgeTargetError(edge.target, edge.target_input)
-            seen_targets.add(key)
+            # At most one transfer edge may feed a given consumer input.
+            # Ordering-only edges (transfer=False) are exempt.
+            if edge.transfer:
+                key = (edge.target, edge.target_input)
+                if key in seen_targets:
+                    raise DuplicateEdgeTargetError(
+                        edge.target, edge.target_input
+                    )
+                seen_targets.add(key)
 
             # Source must resolve to a task output or a root artifact.
             if edge.source in task_outputs:
@@ -294,6 +302,11 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
         :class:`_EdgeSource`. Edges are validated at construction
         (see :meth:`check_edges_resolve`), so every entry resolves to a real
         producer output or root artifact.
+
+        Only ``transfer=True`` edges contribute an entry: ordering-only
+        (``transfer=False``) edges affect DAG ordering (see
+        :func:`horus_builtin.workflow.dag.build_dependencies`) but never
+        supply a transfer source.
         """
         targets_by_task = {t.id: t.target for t in self.tasks}
         outputs_by_task = {
@@ -303,6 +316,8 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
 
         source_map: dict[tuple[str, str], _EdgeSource] = {}
         for edge in self.edges:
+            if not edge.transfer:
+                continue
             key = (edge.target, edge.target_input)
             producer_target = targets_by_task.get(edge.source)
             if producer_target is not None:

--- a/src/horus_runtime/core/workflow/edge.py
+++ b/src/horus_runtime/core/workflow/edge.py
@@ -41,3 +41,16 @@ class WorkflowEdge(BaseModel):
 
     target_input: str
     """Input artifact id on the consumer task."""
+
+    transfer: bool = True
+    """
+    Whether this edge also carries data: when ``True`` (the default) the
+    source's output is transferred to the target input, as every existing
+    edge has always done. When ``False`` the edge is ordering-only: it still
+    makes ``target`` depend on ``source`` in the DAG, but contributes no
+    transfer source for ``target_input`` and is exempt from the "at most one
+    edge per (target, target_input)" rule, so several ordering-only edges (or
+    one ordering-only edge alongside a single ``transfer=True`` edge) may all
+    feed the same input. This is what lets many producers order-gate one
+    consumer whose actual data input is, say, a folder populated out of band.
+    """

--- a/tests/unit/workflow/test_edges.py
+++ b/tests/unit/workflow/test_edges.py
@@ -34,7 +34,11 @@ from horus_builtin.executor.shell import ShellExecutor
 from horus_builtin.runtime.command import CommandRuntime
 from horus_builtin.target.local import LocalTarget
 from horus_builtin.task.horus_task import HorusTask
-from horus_builtin.workflow.dag import CyclicDependencyError, execution_plan
+from horus_builtin.workflow.dag import (
+    CyclicDependencyError,
+    build_dependencies,
+    execution_plan,
+)
 from horus_builtin.workflow.horus_workflow import HorusWorkflow
 from horus_runtime.core.artifact.base import BaseArtifact
 from horus_runtime.core.transfer.strategy import BaseTransferStrategy
@@ -68,7 +72,12 @@ def _task(
 
 
 def _edge(
-    source: str, source_output: str, target: str, target_input: str
+    source: str,
+    source_output: str,
+    target: str,
+    target_input: str,
+    *,
+    transfer: bool = True,
 ) -> WorkflowEdge:
     """Build a WorkflowEdge from the four endpoint ids."""
     return WorkflowEdge(
@@ -76,6 +85,7 @@ def _edge(
         source_output=source_output,
         target=target,
         target_input=target_input,
+        transfer=transfer,
     )
 
 
@@ -435,5 +445,140 @@ class TestEdgeValidation:
                 edges=[
                     _edge("p1", "o1", "c", "in"),
                     _edge("p2", "o2", "c", "in"),
+                ],
+            )
+
+
+@pytest.mark.unit
+class TestOrderingOnlyEdges:
+    """
+    ``transfer=False`` edges express dependency ordering without feeding a
+    transfer source, so several may (eventually, for many-to-one fan-in) all
+    order-gate the same consumer input.
+    """
+
+    def test_ordering_only_edge_resolves_and_orders(
+        self, tmp_path: Path
+    ) -> None:
+        """A transfer=False edge still creates a DAG dependency."""
+        producer = _task(
+            task_id="producer",
+            inputs=[],
+            outputs=[FileArtifact(id="out", path=tmp_path / "p.txt")],
+        )
+        consumer = _task(
+            task_id="consumer",
+            inputs=[FileArtifact(id="in", path=tmp_path / "c.txt")],
+            outputs=[],
+        )
+        edges = [_edge("producer", "out", "consumer", "in", transfer=False)]
+        wf = HorusWorkflow(
+            name="ordering_only", tasks=[producer, consumer], edges=edges
+        )
+        assert wf.edges[0].transfer is False
+
+        plan = execution_plan(
+            [consumer, producer], trigger_id="producer", edges=edges
+        )
+        assert plan == ["producer", "consumer"]
+
+    def test_two_ordering_only_edges_into_same_input_allowed(
+        self, tmp_path: Path
+    ) -> None:
+        """
+        Two transfer=False edges may feed one input (no
+        DuplicateEdgeTargetError), and neither contributes a transfer source.
+        """
+        p1 = _task(
+            task_id="p1",
+            inputs=[],
+            outputs=[FileArtifact(id="o1", path=tmp_path / "1.txt")],
+        )
+        p2 = _task(
+            task_id="p2",
+            inputs=[],
+            outputs=[FileArtifact(id="o2", path=tmp_path / "2.txt")],
+        )
+        c = _task(
+            task_id="c",
+            inputs=[FileArtifact(id="in", path=tmp_path / "c.txt")],
+            outputs=[],
+        )
+        edges = [
+            _edge("p1", "o1", "c", "in", transfer=False),
+            _edge("p2", "o2", "c", "in", transfer=False),
+        ]
+        wf = HorusWorkflow(name="fan_in", tasks=[p1, p2, c], edges=edges)
+
+        # Ordering still holds for both producers.
+        deps = build_dependencies(wf.tasks, wf.edges)
+        assert deps["c"] == {"p1", "p2"}
+
+        # No transfer source is registered for the fed input.
+        source_map = wf._build_source_map()
+        assert ("c", "in") not in source_map
+
+    def test_transfer_and_ordering_only_edge_coexist(
+        self, tmp_path: Path
+    ) -> None:
+        """
+        One transfer=True edge plus one transfer=False edge into the same
+        input is allowed; the source map resolves only the transfer edge.
+        """
+        p1 = _task(
+            task_id="p1",
+            inputs=[],
+            outputs=[FileArtifact(id="o1", path=tmp_path / "1.txt")],
+        )
+        p2 = _task(
+            task_id="p2",
+            inputs=[],
+            outputs=[FileArtifact(id="o2", path=tmp_path / "2.txt")],
+        )
+        c = _task(
+            task_id="c",
+            inputs=[FileArtifact(id="in", path=tmp_path / "c.txt")],
+            outputs=[],
+        )
+        edges = [
+            _edge("p1", "o1", "c", "in", transfer=True),
+            _edge("p2", "o2", "c", "in", transfer=False),
+        ]
+        wf = HorusWorkflow(name="mixed", tasks=[p1, p2, c], edges=edges)
+
+        deps = build_dependencies(wf.tasks, wf.edges)
+        assert deps["c"] == {"p1", "p2"}
+
+        source_map = wf._build_source_map()
+        source = source_map[("c", "in")]
+        assert source.artifact is not None
+        assert source.artifact.id == "o1"
+
+    def test_two_transfer_edges_into_same_input_still_raises(
+        self, tmp_path: Path
+    ) -> None:
+        """Two transfer=True edges into one input are still rejected."""
+        p1 = _task(
+            task_id="p1",
+            inputs=[],
+            outputs=[FileArtifact(id="o1", path=tmp_path / "1.txt")],
+        )
+        p2 = _task(
+            task_id="p2",
+            inputs=[],
+            outputs=[FileArtifact(id="o2", path=tmp_path / "2.txt")],
+        )
+        c = _task(
+            task_id="c",
+            inputs=[FileArtifact(id="in", path=tmp_path / "c.txt")],
+            outputs=[],
+        )
+        with pytest.raises(DuplicateEdgeTargetError):
+            HorusWorkflow(
+                name="bad",
+                tasks=[p1, p2, c],
+                edges=[
+                    _edge("p1", "o1", "c", "in", transfer=True),
+                    _edge("p2", "o2", "c", "in", transfer=True),
                 ],
             )


### PR DESCRIPTION
Closes #114.

## Summary

Adds `transfer: bool = True` to `WorkflowEdge` so an edge can express dependency ordering without transferring data.

- `transfer=True` (default): behaves exactly as before — resolves the edge, feeds a transfer source, and is subject to the existing "at most one edge per (target, target_input)" rule.
- `transfer=False`: ordering-only. The edge still validates its endpoints and still makes `target` depend on `source` for DAG purposes, but is exempt from the duplicate-target check and contributes no entry to the transfer source map.

## Rationale

This unblocks many-to-one fan-in for the upcoming map/loop work: N producer tasks can each order-gate one consumer whose actual data input (e.g. a populated folder) isn't fed by any single upstream edge. Today that's impossible because at most one edge may feed a given `(target, target_input)`. With `transfer=False`, any number of ordering-only edges — plus at most one `transfer=True` edge — can feed the same input.

## Changes

- `WorkflowEdge.transfer: bool = True` with docstring explaining the ordering-only semantics.
- `BaseWorkflow.check_edges_resolve`: the duplicate-target check now only applies to `transfer=True` edges; `transfer=False` edges still validate endpoints.
- `BaseWorkflow._build_source_map`: skips `transfer=False` edges, so they never contribute a transfer source.
- `horus_builtin.workflow.dag.build_dependencies` already counted every edge for ordering regardless of any transfer semantics, so no change was needed there — confirmed with a dedicated test.

## Tests

Added to `tests/unit/workflow/test_edges.py` (`TestOrderingOnlyEdges`):
- A `transfer=False` edge resolves and produces a DAG dependency (`execution_plan` orders accordingly).
- Two `transfer=False` edges into the same input are allowed and contribute no transfer source.
- One `transfer=True` + one `transfer=False` edge into the same input coexist; the source map resolves only the transfer edge.
- Two `transfer=True` edges into the same input still raise `DuplicateEdgeTargetError`.

Full suite: `make test`, `make lint`, `make type-check` all pass.

## Docs

https://github.com/temple-compute/horus-docs/pull/35