### PR TITLE
feat(workflow): concurrent ready-set scheduler

### DIFF
--- a/src/horus_builtin/workflow/horus_workflow.py
+++ b/src/horus_builtin/workflow/horus_workflow.py
@@ -23,11 +23,10 @@ HorusWorkflow implementation for Horus built-in workflows.
 from typing import ClassVar
 
 from horus_builtin.target.local import LocalTarget
-from horus_builtin.workflow.dag import execution_plan
+from horus_builtin.workflow.scheduler import run_schedule
 from horus_runtime.core.target.base import BaseTarget
 from horus_runtime.core.workflow.base import BaseWorkflow
 from horus_runtime.i18n import tr as _
-from horus_runtime.logging import horus_logger
 
 
 class HorusWorkflow(BaseWorkflow):
@@ -55,47 +54,16 @@ class HorusWorkflow(BaseWorkflow):
 
     async def _run(self, trigger_id: str) -> None:
         """
-        A task is skipped when all of
-        its output artifacts exist (see :meth:`is_complete`).
+        Dispatch tasks via the concurrent ready-set scheduler.
+
+        A task is skipped when all of its output artifacts exist (see
+        :meth:`is_complete`). Every task whose dependencies are satisfied
+        runs as soon as it is ready, concurrently with any other ready task
+        (bounded by :attr:`max_concurrency` when set); see
+        :func:`horus_builtin.workflow.scheduler.run_schedule` for the
+        scheduling loop itself.
         """
-        tasks = {task.id: task for task in self.tasks}
-
-        # No edges means no dependencies: every task runs independently and the
-        # plan is limited to the trigger's own (singleton) scope. Flag it so a
-        # workflow that forgot to wire its edges is diagnosable.
-        if len(self.tasks) > 1 and not self.edges:
-            horus_logger.log.debug(
-                _(
-                    "Workflow %(name)s has multiple tasks but no edges; "
-                    "tasks run independently with no ordering."
-                )
-                % {"name": self.name}
-            )
-
-        plan = execution_plan(
-            self.tasks, trigger_id=trigger_id, edges=self.edges
-        )
-
-        # The edge source map depends only on workflow structure, so build it
-        # once and reuse it for every task instead of rebuilding per task.
-        source_map = self._build_source_map()
-
-        for task_id in plan:
-            task = tasks[task_id]
-
-            # Associate the task with its target before any transfer so
-            # resource-aware targets (which may provision lazily at transfer
-            # time, before dispatch) can read task.resources.
-            task.target.bind(task)
-
-            # Transfer input artifacts to the task's target as needed.
-            await self.transfer_artifacts(task, source_map)
-
-            # Execute the task on its target
-            await task.target.dispatch(task)
-
-            # Wait for the task to complete and check for failure
-            await task.target.wait()
+        await run_schedule(self, trigger_id)
 
     async def _reset(self) -> None:
         """

--- a/src/horus_builtin/workflow/horus_workflow.py
+++ b/src/horus_builtin/workflow/horus_workflow.py
@@ -46,7 +46,7 @@ class HorusWorkflow(BaseWorkflow):
         "The default workflow implementation for Horus built-in workflows."
     )
 
-    orchestrator_target: BaseTarget = LocalTarget()
+    orchestrator_target: BaseTarget | None = LocalTarget()
     """
     The orchestrator runs locally; root input artifacts (those not produced by
     any upstream task) are sourced from the local filesystem.

--- a/src/horus_builtin/workflow/scheduler.py
+++ b/src/horus_builtin/workflow/scheduler.py
@@ -22,14 +22,6 @@ Replaces a serial "run the topological order one task at a time" loop with a
 scheduler that dispatches every currently-ready task concurrently and reacts
 as each one finishes: as soon as a task completes, its dependents that are
 now ready are dispatched too, without waiting for unrelated in-flight tasks.
-
-Scope is intentionally narrow: concurrency plus a ``max_concurrency`` cap.
-Failure handling is still fail-fast (the first failure cancels everything
-else in flight and re-raises), matching the previous serial runner. Resource
-placement and DAG mutation are left to later PRs; the dependency/scope
-recomputation happening on every loop iteration (rather than once up front)
-is the hook that lets a future DAG-mutation PR plug in without touching this
-loop.
 """
 
 import asyncio
@@ -127,7 +119,7 @@ async def _execute_ready_task(
 ) -> None:
     """
     Run one ready task to completion: acquire a target, bind, transfer
-    inputs, dispatch, and wait — mirroring the per-task body of the previous
+    inputs, dispatch, and wait, mirroring the per-task body of the previous
     serial loop, but on whichever target the pool hands back (the task's own
     declared target in the common case, or an idle clone under contention).
     """
@@ -239,9 +231,8 @@ async def run_schedule(workflow: BaseWorkflow, trigger_id: str) -> None:
     running: dict[asyncio.Task[None], str] = {}
 
     while True:
-        # Recomputed every iteration (instead of once up front) so a future
-        # DAG-mutation PR can grow `workflow.tasks`/`workflow.edges` mid-run
-        # without any change to this loop.
+        # Recomputed every iteration (instead of once up front) so a
+        # DAG-mutation can grow `workflow.tasks`/`workflow.edges` mid-run.
         deps = build_dependencies(workflow.tasks, workflow.edges)
         scope = ancestors(trigger_id, deps) | descendants(trigger_id, deps)
 

--- a/src/horus_builtin/workflow/scheduler.py
+++ b/src/horus_builtin/workflow/scheduler.py
@@ -1,0 +1,284 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Concurrent ready-set scheduler for Horus built-in workflows.
+
+Replaces a serial "run the topological order one task at a time" loop with a
+scheduler that dispatches every currently-ready task concurrently and reacts
+as each one finishes: as soon as a task completes, its dependents that are
+now ready are dispatched too, without waiting for unrelated in-flight tasks.
+
+Scope is intentionally narrow: concurrency plus a ``max_concurrency`` cap.
+Failure handling is still fail-fast (the first failure cancels everything
+else in flight and re-raises), matching the previous serial runner. Resource
+placement and DAG mutation are left to later PRs; the dependency/scope
+recomputation happening on every loop iteration (rather than once up front)
+is the hook that lets a future DAG-mutation PR plug in without touching this
+loop.
+"""
+
+import asyncio
+from typing import TYPE_CHECKING
+
+from horus_builtin.workflow.dag import (
+    UnknownTaskError,
+    ancestors,
+    build_dependencies,
+    descendants,
+    topological_sort,
+)
+from horus_runtime.core.target.base import BaseTarget
+from horus_runtime.core.workflow.base import BaseWorkflow, _EdgeSource
+from horus_runtime.i18n import tr as _
+from horus_runtime.logging import horus_logger
+
+if TYPE_CHECKING:
+    from horus_runtime.core.task.base import BaseTask
+
+
+class TargetPool:
+    """
+    Hands out an idle target for each dispatched task, giving otherwise
+    single-slot :class:`BaseTarget` instances room for concurrency.
+
+    In a hand-authored DAG each task normally owns its own distinct target
+    object, so there is no contention and every acquisition simply returns
+    the task's declared target. The pool only has to do real work when two
+    ready tasks share the exact same target *instance* (e.g. a workflow that
+    reuses one ``LocalTarget()`` across several task placements): the second
+    concurrent acquisition for that instance gets an idle clone
+    (``target.model_copy()``) instead of blocking. A clone is a valid extra
+    slot because targets sharing a target's class and fields also share its
+    ``location_id`` (same filesystem), so no artifact transfer is needed
+    between the original and the clone.
+
+    Targets are keyed by object identity (``id(target)``), not by task id,
+    because the sharing scenario above is about the target object, not the
+    task.
+    """
+
+    def __init__(self, max_concurrency: int | None) -> None:
+        # Idle instances available for a given declared target, keyed by
+        # id(declared_target). Lazily seeded with the declared target itself
+        # on first acquisition (see `acquire`).
+        self._idle: dict[int, list[BaseTarget]] = {}
+        self._semaphore = (
+            asyncio.Semaphore(max_concurrency)
+            if max_concurrency is not None
+            else None
+        )
+
+    async def acquire(self, declared_target: BaseTarget) -> BaseTarget:
+        """
+        Return an idle target equivalent to *declared_target*.
+
+        Blocks on the ``max_concurrency`` semaphore (if set) before handing
+        out a target, so the cap applies to genuinely concurrent dispatches
+        rather than just to distinct target instances.
+        """
+        if self._semaphore is not None:
+            await self._semaphore.acquire()
+
+        idle = self._idle.setdefault(id(declared_target), [declared_target])
+        if idle:
+            return idle.pop()
+
+        # Every idle instance (the declared target and any prior clones) is
+        # currently in use: mint another clone as an extra slot.
+        clone = declared_target.model_copy()
+        # model_copy() shallow-copies pydantic private attributes, so the
+        # clone would otherwise start out pointing at the declared target's
+        # in-flight `_task_future` and look "busy" before it has run
+        # anything. Clear them so the clone starts genuinely idle.
+        clone._task = None  # noqa: SLF001
+        clone._task_future = None  # noqa: SLF001
+        return clone
+
+    def release(self, declared_target: BaseTarget, target: BaseTarget) -> None:
+        """
+        Return *target* (previously returned by :meth:`acquire` for
+        *declared_target*) to the idle pool.
+        """
+        self._idle[id(declared_target)].append(target)
+        if self._semaphore is not None:
+            self._semaphore.release()
+
+
+async def _execute_ready_task(
+    workflow: BaseWorkflow,
+    task: "BaseTask",
+    source_map: dict[tuple[str, str], _EdgeSource],
+    pool: TargetPool,
+) -> None:
+    """
+    Run one ready task to completion: acquire a target, bind, transfer
+    inputs, dispatch, and wait — mirroring the per-task body of the previous
+    serial loop, but on whichever target the pool hands back (the task's own
+    declared target in the common case, or an idle clone under contention).
+    """
+    declared_target = task.target
+    target = await pool.acquire(declared_target)
+    # `transfer_artifacts` and `dispatch` both operate off `task.target`, so
+    # point it at the target we actually acquired for the duration of the
+    # run and restore it afterwards, leaving the task's declared target
+    # untouched for any subsequent run of the same workflow instance.
+    task.target = target
+    try:
+        # Associate the task with its target before any transfer so
+        # resource-aware targets (which may provision lazily at transfer
+        # time, before dispatch) can read task.resources.
+        target.bind(task)
+
+        # Transfer input artifacts to the task's target as needed.
+        await workflow.transfer_artifacts(task, source_map)
+
+        # Execute the task on its target and wait for it to finish.
+        await target.dispatch(task)
+        await target.wait()
+    finally:
+        task.target = declared_target
+        pool.release(declared_target, target)
+
+
+def _collect_completions(
+    done: set[asyncio.Task[None]],
+    running: dict[asyncio.Task[None], str],
+    completed: set[str],
+) -> BaseException | None:
+    """
+    Pop every finished task out of *running*, adding successes to
+    *completed*, and return the first exception encountered (if any) in
+    deterministic (task id) order.
+    """
+    failure: BaseException | None = None
+    for fut in sorted(done, key=lambda f: running[f]):
+        task_id = running.pop(fut)
+        if fut.cancelled():
+            continue
+        exc = fut.exception()
+        if exc is not None:
+            failure = failure or exc
+        else:
+            completed.add(task_id)
+    return failure
+
+
+async def _cancel_running(running: dict[asyncio.Task[None], str]) -> None:
+    """Cancel every still-running wrapper task and wait for it to unwind."""
+    for fut in running:
+        fut.cancel()
+    if running:
+        await asyncio.wait(list(running))
+    running.clear()
+
+
+async def run_schedule(workflow: BaseWorkflow, trigger_id: str) -> None:
+    """
+    Execute *workflow* from *trigger_id* with a concurrent ready-set
+    scheduler.
+
+    A task is skipped when all of its output artifacts exist (see
+    ``BaseTask.is_complete``, applied inside ``BaseTask.run``). Every task
+    whose dependencies are already satisfied is dispatched immediately and
+    concurrently with any other ready task, bounded by
+    ``workflow.max_concurrency`` when set. The first task to fail cancels
+    every other task still in flight and re-raises, so ``BaseWorkflow.run``
+    can mark the workflow ``FAILED`` — the same fail-fast contract the
+    previous serial loop provided.
+
+    Raises:
+        UnknownTaskError: If trigger_id is not a task in the workflow.
+        CyclicDependencyError: If the tasks in scope cannot all be
+            scheduled (a cycle keeps the remainder permanently blocked).
+    """
+    tasks_by_id = {task.id: task for task in workflow.tasks}
+    if trigger_id not in tasks_by_id:
+        raise UnknownTaskError(
+            _("Trigger task '%(trigger_id)s' not found.")
+            % {"trigger_id": trigger_id}
+        )
+
+    # No edges means no dependencies: every task runs independently and the
+    # plan is limited to the trigger's own (singleton) scope. Flag it so a
+    # workflow that forgot to wire its edges is diagnosable.
+    if len(workflow.tasks) > 1 and not workflow.edges:
+        horus_logger.log.debug(
+            _(
+                "Workflow %(name)s has multiple tasks but no edges; "
+                "tasks run independently with no ordering."
+            )
+            % {"name": workflow.name}
+        )
+
+    pool = TargetPool(workflow.max_concurrency)
+
+    # The source map depends only on workflow structure. It is rebuilt only
+    # when the workflow's revision advances (nothing bumps it yet, so this
+    # effectively builds once, the first time it's needed).
+    source_map_cache: tuple[int, dict[tuple[str, str], _EdgeSource]] | None = (
+        None
+    )
+
+    completed: set[str] = set()
+    dispatched: set[str] = set()
+    running: dict[asyncio.Task[None], str] = {}
+
+    while True:
+        # Recomputed every iteration (instead of once up front) so a future
+        # DAG-mutation PR can grow `workflow.tasks`/`workflow.edges` mid-run
+        # without any change to this loop.
+        deps = build_dependencies(workflow.tasks, workflow.edges)
+        scope = ancestors(trigger_id, deps) | descendants(trigger_id, deps)
+
+        # Deterministic order when several tasks become ready at once,
+        # matching topological_sort's tie-breaking.
+        ready = sorted(
+            task_id
+            for task_id in scope
+            if task_id not in dispatched and deps[task_id] <= completed
+        )
+
+        if not ready and not running and (scope - completed):
+            # Nothing is ready and nothing is in flight, yet the scope isn't
+            # fully satisfied: the remaining tasks are stuck on each other.
+            # Reuse topological_sort's cycle detection for a consistent
+            # error instead of silently stopping short.
+            topological_sort(scope, deps)
+
+        if ready:
+            source_map_cache = workflow.cached_source_map(source_map_cache)
+            source_map = source_map_cache[1]
+            for task_id in ready:
+                task = tasks_by_id[task_id]
+                dispatched.add(task_id)
+                wrapper = asyncio.create_task(
+                    _execute_ready_task(workflow, task, source_map, pool)
+                )
+                running[wrapper] = task_id
+
+        if not running:
+            break
+
+        done, _pending = await asyncio.wait(
+            running, return_when=asyncio.FIRST_COMPLETED
+        )
+
+        failure = _collect_completions(done, running, completed)
+        if failure is not None:
+            await _cancel_running(running)
+            raise failure

--- a/src/horus_runtime/core/workflow/base.py
+++ b/src/horus_runtime/core/workflow/base.py
@@ -152,12 +152,32 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
     ``run()``; do not set manually.
     """
 
+    max_concurrency: int | None = None
+    """
+    Upper bound on the number of tasks the scheduler dispatches at once.
+    ``None`` (the default) means unbounded: every task that becomes ready is
+    dispatched immediately. Set this to cap resource usage (e.g. a shared
+    machine with limited CPUs) when the DAG's natural parallelism would
+    otherwise over-subscribe it.
+    """
+
     _base_directory: Path | None = PrivateAttr(default=None)
     """
     Directory relative paths are anchored to (the run directory and, through
     it, artifact paths and logs). Set to the workflow YAML's folder by
     :meth:`from_yaml`; ``None`` for programmatically-built workflows, which
     fall back to the process CWD. Runtime-only state, not serialized.
+    """
+
+    _revision: int = PrivateAttr(default=0)
+    """
+    Monotonically increasing counter for the workflow's DAG structure
+    (tasks/edges/artifacts). Nothing bumps it yet: today the DAG is fixed for
+    the lifetime of a run, so it is built once and stays at ``0``. It exists
+    so a future dynamic-DAG feature (fan-out/map/loops) can increment it when
+    mutating the graph mid-run, and the scheduler's cached source map (see
+    :meth:`cached_source_map`) picks up the change without any changes to the
+    scheduler itself.
     """
 
     @model_validator(mode="after")
@@ -317,6 +337,23 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
                     None, roots_by_id.get(edge.source_output)
                 )
         return source_map
+
+    def cached_source_map(
+        self,
+        cached: tuple[int, dict[tuple[str, str], _EdgeSource]] | None,
+    ) -> tuple[int, dict[tuple[str, str], _EdgeSource]]:
+        """
+        Return ``(self._revision, source_map)``, rebuilding the source map
+        only when ``_revision`` has advanced past *cached*.
+
+        Intended for callers (namely the scheduler) that need the source map
+        across several iterations of a run: pass back the tuple you got last
+        time and only a genuinely stale cache triggers a rebuild via
+        :meth:`_build_source_map`. Passing ``None`` always rebuilds.
+        """
+        if cached is not None and cached[0] == self._revision:
+            return cached
+        return self._revision, self._build_source_map()
 
     async def transfer_artifacts(
         self,

--- a/src/horus_runtime/core/workflow/base.py
+++ b/src/horus_runtime/core/workflow/base.py
@@ -172,12 +172,7 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
     _revision: int = PrivateAttr(default=0)
     """
     Monotonically increasing counter for the workflow's DAG structure
-    (tasks/edges/artifacts). Nothing bumps it yet: today the DAG is fixed for
-    the lifetime of a run, so it is built once and stays at ``0``. It exists
-    so a future dynamic-DAG feature (fan-out/map/loops) can increment it when
-    mutating the graph mid-run, and the scheduler's cached source map (see
-    :meth:`cached_source_map`) picks up the change without any changes to the
-    scheduler itself.
+    (tasks/edges/artifacts).
     """
 
     @model_validator(mode="after")

--- a/tests/unit/workflow/test_scheduler.py
+++ b/tests/unit/workflow/test_scheduler.py
@@ -1,0 +1,444 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Unit tests for the concurrent ready-set scheduler.
+"""
+
+import asyncio
+from pathlib import Path
+from typing import ClassVar, cast
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from horus_builtin.artifact.file import FileArtifact
+from horus_builtin.executor.shell import ShellExecutor
+from horus_builtin.runtime.command import CommandRuntime
+from horus_builtin.target.local import LocalTarget
+from horus_builtin.task.horus_task import HorusTask
+from horus_builtin.workflow.horus_workflow import HorusWorkflow
+from horus_runtime.context import HorusContext
+from horus_runtime.core.artifact.base import BaseArtifact
+from horus_runtime.core.task.exceptions import TaskExecutionError
+from horus_runtime.core.task.status import TaskStatus
+from horus_runtime.core.workflow.edge import WorkflowEdge
+
+
+def _task(
+    task_id: str,
+    *,
+    tmp_path: Path,
+    inputs: list[FileArtifact] | None = None,
+    outputs: list[FileArtifact] | None = None,
+    task_cls: type[HorusTask] = HorusTask,
+) -> HorusTask:
+    """Build a minimal task of *task_cls*, defaulting to a plain HorusTask."""
+    return task_cls(
+        id=task_id,
+        name=task_id,
+        inputs=cast(list[BaseArtifact], inputs or []),
+        outputs=cast(list[BaseArtifact], outputs or []),
+        runtime=CommandRuntime(command=f"echo {task_id}"),
+        executor=ShellExecutor(),
+        target=LocalTarget(working_directory=tmp_path.as_posix()),
+    )
+
+
+def _edge(
+    source: str, source_output: str, target: str, target_input: str
+) -> WorkflowEdge:
+    return WorkflowEdge(
+        source=source,
+        source_output=source_output,
+        target=target,
+        target_input=target_input,
+    )
+
+
+class _PassTask(HorusTask):
+    """
+    A task whose ``_run`` does nothing (no real command, no input-artifact
+    check). Used as a downstream sink in tests that patch
+    ``transfer_artifacts`` to a no-op: with a real ``HorusTask``, the sink
+    would fail its own real input-existence check since nothing actually
+    materializes the (mocked-away) transfer.
+    """
+
+    add_to_registry: ClassVar[bool] = False
+
+    async def _run(self) -> None:
+        self.runs += 1
+
+
+@pytest.mark.unit
+class TestConcurrentReadySet:
+    """
+    The scheduler dispatches every currently-ready task concurrently instead
+    of one at a time. ``transfer_artifacts`` is patched to a no-op in most of
+    these tests: they exercise scheduling/ordering, not artifact I/O (which
+    is covered separately in ``test_builtin_workflow.py`` and
+    ``test_edges.py``).
+    """
+
+    async def test_two_independent_tasks_reach_running_concurrently(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """
+        Two tasks with no dependency on each other, but both required by a
+        common downstream sink, must both reach RUNNING before either is
+        allowed to finish. Each task blocks on a shared barrier that only
+        opens once *both* have started, so a serial scheduler would deadlock
+        here (proven by wrapping the run in a timeout) while a concurrent one
+        proceeds normally.
+        """
+        del horus_context
+        started: set[str] = set()
+        both_started = asyncio.Event()
+
+        class BarrierTask(HorusTask):
+            add_to_registry: ClassVar[bool] = False
+
+            async def _run(self) -> None:
+                started.add(self.id)
+                if len(started) == 2:
+                    both_started.set()
+                await asyncio.wait_for(both_started.wait(), timeout=5)
+
+        task_a = _task("a", tmp_path=tmp_path, task_cls=BarrierTask)
+        task_b = _task("b", tmp_path=tmp_path, task_cls=BarrierTask)
+        sink = _task(
+            "sink",
+            tmp_path=tmp_path,
+            task_cls=_PassTask,
+            inputs=[
+                FileArtifact(id="from_a", path=tmp_path / "a.out"),
+                FileArtifact(id="from_b", path=tmp_path / "b.out"),
+            ],
+        )
+        task_a.outputs = [FileArtifact(id="out_a", path=tmp_path / "a.out")]
+        task_b.outputs = [FileArtifact(id="out_b", path=tmp_path / "b.out")]
+
+        wf = HorusWorkflow(
+            name="concurrent_independent",
+            tasks=[task_a, task_b, sink],
+            edges=[
+                _edge("a", "out_a", "sink", "from_a"),
+                _edge("b", "out_b", "sink", "from_b"),
+            ],
+        )
+
+        with patch.object(
+            HorusWorkflow, "transfer_artifacts", new=AsyncMock()
+        ):
+            await asyncio.wait_for(wf.run(trigger_id="sink"), timeout=10)
+
+        assert started == {"a", "b"}
+
+    async def test_diamond_runs_children_after_parent_and_sink_after_both(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """
+        Diamond A -> {B, C} -> D: B and C only start after A finishes, and D
+        only starts once both B and C have finished.
+        """
+        del horus_context
+        order: list[str] = []
+
+        class OrderTask(HorusTask):
+            add_to_registry: ClassVar[bool] = False
+
+            async def _run(self) -> None:
+                order.append(self.id)
+
+        a = _task(
+            "a",
+            tmp_path=tmp_path,
+            task_cls=OrderTask,
+            outputs=[FileArtifact(id="a_out", path=tmp_path / "a.out")],
+        )
+        b = _task(
+            "b",
+            tmp_path=tmp_path,
+            task_cls=OrderTask,
+            inputs=[FileArtifact(id="b_in", path=tmp_path / "a.out")],
+            outputs=[FileArtifact(id="b_out", path=tmp_path / "b.out")],
+        )
+        c = _task(
+            "c",
+            tmp_path=tmp_path,
+            task_cls=OrderTask,
+            inputs=[FileArtifact(id="c_in", path=tmp_path / "a.out")],
+            outputs=[FileArtifact(id="c_out", path=tmp_path / "c.out")],
+        )
+        d = _task(
+            "d",
+            tmp_path=tmp_path,
+            task_cls=OrderTask,
+            inputs=[
+                FileArtifact(id="d_in_b", path=tmp_path / "b.out"),
+                FileArtifact(id="d_in_c", path=tmp_path / "c.out"),
+            ],
+        )
+
+        wf = HorusWorkflow(
+            name="diamond",
+            tasks=[d, c, b, a],  # definition order deliberately scrambled
+            edges=[
+                _edge("a", "a_out", "b", "b_in"),
+                _edge("a", "a_out", "c", "c_in"),
+                _edge("b", "b_out", "d", "d_in_b"),
+                _edge("c", "c_out", "d", "d_in_c"),
+            ],
+        )
+
+        with patch.object(
+            HorusWorkflow, "transfer_artifacts", new=AsyncMock()
+        ):
+            await asyncio.wait_for(wf.run(trigger_id="a"), timeout=10)
+
+        assert order[0] == "a"
+        assert order[-1] == "d"
+        assert set(order[1:3]) == {"b", "c"}
+
+    async def test_max_concurrency_one_never_overlaps(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """
+        With ``max_concurrency=1``, three tasks that all become ready at the
+        same time (siblings fed by a common parent) still never have more
+        than one RUNNING at once.
+        """
+        del horus_context
+        state = {"current": 0, "max_seen": 0}
+
+        class ConcurrencyTask(HorusTask):
+            add_to_registry: ClassVar[bool] = False
+
+            async def _run(self) -> None:
+                state["current"] += 1
+                state["max_seen"] = max(state["max_seen"], state["current"])
+                # Yield control so a scheduler that (incorrectly) allowed
+                # overlap would have a chance to start a sibling here.
+                await asyncio.sleep(0.01)
+                state["current"] -= 1
+
+        root = _task(
+            "root",
+            tmp_path=tmp_path,
+            task_cls=ConcurrencyTask,
+            outputs=[FileArtifact(id="root_out", path=tmp_path / "root.out")],
+        )
+        children = [
+            _task(
+                child_id,
+                tmp_path=tmp_path,
+                task_cls=ConcurrencyTask,
+                inputs=[FileArtifact(id="in", path=tmp_path / "root.out")],
+            )
+            for child_id in ("b", "c", "e")
+        ]
+
+        wf = HorusWorkflow(
+            name="fanout",
+            tasks=[root, *children],
+            edges=[
+                _edge("root", "root_out", child.id, "in") for child in children
+            ],
+            max_concurrency=1,
+        )
+
+        with patch.object(
+            HorusWorkflow, "transfer_artifacts", new=AsyncMock()
+        ):
+            await asyncio.wait_for(wf.run(trigger_id="root"), timeout=10)
+
+        assert state["max_seen"] == 1
+
+    async def test_failure_cancels_concurrent_sibling_and_stops_downstream(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """
+        Fail-fast is preserved under concurrency: when one of two
+        concurrently-running root tasks fails, the other (still in flight,
+        blocked indefinitely) is cancelled, the original exception propagates
+        out of ``run()``, and their common downstream sink never starts.
+        """
+        del horus_context
+
+        class FailingTask(HorusTask):
+            add_to_registry: ClassVar[bool] = False
+
+            async def _run(self) -> None:
+                raise TaskExecutionError("boom")
+
+        class BlockingTask(HorusTask):
+            add_to_registry: ClassVar[bool] = False
+
+            async def _run(self) -> None:
+                # Blocks forever unless cancelled by the scheduler's
+                # fail-fast path.
+                await asyncio.Event().wait()
+
+        failing = _task(
+            "failing",
+            tmp_path=tmp_path,
+            task_cls=FailingTask,
+            outputs=[FileArtifact(id="f_out", path=tmp_path / "f.out")],
+        )
+        blocking = _task(
+            "blocking",
+            tmp_path=tmp_path,
+            task_cls=BlockingTask,
+            outputs=[FileArtifact(id="b_out", path=tmp_path / "b.out")],
+        )
+        sink = _task(
+            "sink",
+            tmp_path=tmp_path,
+            task_cls=_PassTask,
+            inputs=[
+                FileArtifact(id="from_f", path=tmp_path / "f.out"),
+                FileArtifact(id="from_b", path=tmp_path / "b.out"),
+            ],
+        )
+
+        wf = HorusWorkflow(
+            name="fail_fast_concurrent",
+            tasks=[failing, blocking, sink],
+            edges=[
+                _edge("failing", "f_out", "sink", "from_f"),
+                _edge("blocking", "b_out", "sink", "from_b"),
+            ],
+        )
+
+        with (
+            patch.object(HorusWorkflow, "transfer_artifacts", new=AsyncMock()),
+            pytest.raises(TaskExecutionError),
+        ):
+            await asyncio.wait_for(wf.run(trigger_id="sink"), timeout=10)
+
+        assert blocking.status == TaskStatus.CANCELED
+        assert sink.runs == 0
+
+    async def test_cycle_raises_instead_of_stopping_silently(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """
+        A cycle expressed through edges leaves the involved tasks
+        permanently blocked on each other; the scheduler must raise instead
+        of quietly finishing with nothing left running.
+        """
+        del horus_context
+        a = _task(
+            "a",
+            tmp_path=tmp_path,
+            inputs=[FileArtifact(id="a_in", path=tmp_path / "a.in")],
+            outputs=[FileArtifact(id="a_out", path=tmp_path / "a.out")],
+        )
+        b = _task(
+            "b",
+            tmp_path=tmp_path,
+            inputs=[FileArtifact(id="b_in", path=tmp_path / "b.in")],
+            outputs=[FileArtifact(id="b_out", path=tmp_path / "b.out")],
+        )
+        wf = HorusWorkflow(
+            name="cyclic",
+            tasks=[a, b],
+            edges=[
+                _edge("a", "a_out", "b", "b_in"),
+                _edge("b", "b_out", "a", "a_in"),
+            ],
+        )
+
+        with pytest.raises(Exception, match="Cycle detected"):
+            await asyncio.wait_for(wf.run(trigger_id="a"), timeout=10)
+
+    async def test_shared_target_instance_gets_idle_clone(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """
+        Two ready tasks that declare the exact same target *instance* do not
+        block each other: the second acquisition gets an idle clone of that
+        target instead of waiting for the first to finish, so both tasks
+        genuinely overlap.
+        """
+        del horus_context
+        shared_target = LocalTarget(working_directory=tmp_path.as_posix())
+        started: set[str] = set()
+        both_started = asyncio.Event()
+        seen_target_ids: list[int] = []
+
+        class SharedTargetTask(HorusTask):
+            add_to_registry: ClassVar[bool] = False
+
+            async def _run(self) -> None:
+                seen_target_ids.append(id(self.target))
+                started.add(self.id)
+                if len(started) == 2:
+                    both_started.set()
+                await asyncio.wait_for(both_started.wait(), timeout=5)
+
+        task_a = SharedTargetTask(
+            id="a",
+            name="a",
+            outputs=[FileArtifact(id="out_a", path=tmp_path / "a.out")],
+            runtime=CommandRuntime(command="echo a"),
+            executor=ShellExecutor(),
+            target=shared_target,
+        )
+        task_b = SharedTargetTask(
+            id="b",
+            name="b",
+            outputs=[FileArtifact(id="out_b", path=tmp_path / "b.out")],
+            runtime=CommandRuntime(command="echo b"),
+            executor=ShellExecutor(),
+            target=shared_target,
+        )
+        sink = _task(
+            "sink",
+            tmp_path=tmp_path,
+            task_cls=_PassTask,
+            inputs=[
+                FileArtifact(id="from_a", path=tmp_path / "a.out"),
+                FileArtifact(id="from_b", path=tmp_path / "b.out"),
+            ],
+        )
+
+        wf = HorusWorkflow(
+            name="shared_target",
+            tasks=[task_a, task_b, sink],
+            edges=[
+                _edge("a", "out_a", "sink", "from_a"),
+                _edge("b", "out_b", "sink", "from_b"),
+            ],
+        )
+
+        with patch.object(
+            HorusWorkflow, "transfer_artifacts", new=AsyncMock()
+        ):
+            await asyncio.wait_for(wf.run(trigger_id="sink"), timeout=10)
+
+        # Both tasks overlapped (the barrier only opens once both started)
+        # using two distinct target instances: one is the shared declared
+        # target, the other an idle clone minted for the second acquirer.
+        assert started == {"a", "b"}
+        assert len(set(seen_target_ids)) == 2
+        assert id(shared_target) in seen_target_ids
+        # The declared target instance itself is restored on task_a/task_b
+        # once each finishes running.
+        assert task_a.target is shared_target
+        assert task_b.target is shared_target


### PR DESCRIPTION
Closes #110.

## Summary

Replaces `HorusWorkflow._run`'s serial `for task_id in execution_plan(...)` loop with a concurrent ready-set scheduler (`horus_builtin/workflow/scheduler.py`). Every task whose dependencies are already satisfied is dispatched immediately and runs concurrently with any other ready task; the scheduler reacts to each completion (rather than a fixed topological order) to unblock newly-ready downstream tasks.

## Design

- `run_schedule(workflow, trigger_id)` recomputes `deps`/`scope` (via `build_dependencies`/`ancestors`/`descendants`) on every loop iteration instead of once up front. Nothing mutates the DAG in this PR, but this is the seam a later dynamic-DAG PR (fan-out/map/loops) can use to grow `tasks`/`edges` mid-run without touching the scheduler loop.
- `TargetPool` gives otherwise single-slot `BaseTarget`s room for concurrency: a ready task normally gets its own declared target back; if that exact target *instance* is already in use by another concurrently-running task (e.g. a workflow that reuses one `LocalTarget()` across placements), the pool hands out an idle `target.model_copy()` clone instead of blocking. Cloning is a valid extra slot because targets of the same class share `location_id` (same filesystem). `max_concurrency` (new `BaseWorkflow` field, `None` = unbounded) is enforced via an `asyncio.Semaphore` inside the pool, so the cap governs genuinely concurrent dispatches.
- Fail-fast is preserved: the first task to raise cancels every task still in flight (and awaits their unwind) before re-raising, so `BaseWorkflow.run` still marks the workflow `FAILED` — matching the previous serial runner's contract exactly.
- Added `BaseWorkflow._revision` (private, never bumped in this PR) and `BaseWorkflow.cached_source_map()` so the scheduler's per-iteration loop doesn't rebuild the edge source map unless the workflow's structure actually changed — again, wiring for a future PR rather than behavior change today.
- At `max_concurrency=1` and with a hand-authored DAG (each task owning a distinct target), behavior is backward-compatible with the old serial runner: exactly one task in flight at a time, same fail-fast semantics, same topological ordering for a linear/diamond DAG.

## Test coverage

New `tests/unit/workflow/test_scheduler.py`:
- two independent tasks (converging on a common downstream sink) both reach RUNNING before either is allowed to finish, via a shared `asyncio.Event` barrier (a serial scheduler would deadlock here)
- diamond `A -> {B, C} -> D` runs B and C only after A, and D only after both
- `max_concurrency=1` never has more than one task RUNNING at once
- fail-fast under concurrency: one of two concurrently-running tasks fails, the other (blocked indefinitely) gets cancelled, the original exception propagates out of `run()`, and their common downstream sink never starts
- a cycle expressed through edges raises instead of the run silently finishing short
- two tasks sharing the exact same target instance both run concurrently, one via the declared target and one via an idle clone

All existing workflow tests (`test_builtin_workflow.py`, `test_edges.py`, `test_run_layout.py`, `test_workflow.py`) pass unchanged, including dependency-order execution, skip-on-existing-outputs, and stop-on-first-failure.

## Verification

`ruff check`, `ruff format --check`, `mypy`, and the full test suite (440 tests, 95% coverage) all pass.


## Docs

https://github.com/temple-compute/horus-docs/pull/36