### PR TITLE
feat(workflow): continueOnFailure failure policy

### DIFF
--- a/src/horus_builtin/workflow/horus_workflow.py
+++ b/src/horus_builtin/workflow/horus_workflow.py
@@ -23,11 +23,10 @@ HorusWorkflow implementation for Horus built-in workflows.
 from typing import ClassVar
 
 from horus_builtin.target.local import LocalTarget
-from horus_builtin.workflow.dag import execution_plan
+from horus_builtin.workflow.scheduler import run_schedule
 from horus_runtime.core.target.base import BaseTarget
 from horus_runtime.core.workflow.base import BaseWorkflow
 from horus_runtime.i18n import tr as _
-from horus_runtime.logging import horus_logger
 
 
 class HorusWorkflow(BaseWorkflow):
@@ -55,47 +54,16 @@ class HorusWorkflow(BaseWorkflow):
 
     async def _run(self, trigger_id: str) -> None:
         """
-        A task is skipped when all of
-        its output artifacts exist (see :meth:`is_complete`).
+        Dispatch tasks via the concurrent ready-set scheduler.
+
+        A task is skipped when all of its output artifacts exist (see
+        :meth:`is_complete`). Every task whose dependencies are satisfied
+        runs as soon as it is ready, concurrently with any other ready task
+        (bounded by :attr:`max_concurrency` when set); see
+        :func:`horus_builtin.workflow.scheduler.run_schedule` for the
+        scheduling loop itself.
         """
-        tasks = {task.id: task for task in self.tasks}
-
-        # No edges means no dependencies: every task runs independently and the
-        # plan is limited to the trigger's own (singleton) scope. Flag it so a
-        # workflow that forgot to wire its edges is diagnosable.
-        if len(self.tasks) > 1 and not self.edges:
-            horus_logger.log.debug(
-                _(
-                    "Workflow %(name)s has multiple tasks but no edges; "
-                    "tasks run independently with no ordering."
-                )
-                % {"name": self.name}
-            )
-
-        plan = execution_plan(
-            self.tasks, trigger_id=trigger_id, edges=self.edges
-        )
-
-        # The edge source map depends only on workflow structure, so build it
-        # once and reuse it for every task instead of rebuilding per task.
-        source_map = self._build_source_map()
-
-        for task_id in plan:
-            task = tasks[task_id]
-
-            # Associate the task with its target before any transfer so
-            # resource-aware targets (which may provision lazily at transfer
-            # time, before dispatch) can read task.resources.
-            task.target.bind(task)
-
-            # Transfer input artifacts to the task's target as needed.
-            await self.transfer_artifacts(task, source_map)
-
-            # Execute the task on its target
-            await task.target.dispatch(task)
-
-            # Wait for the task to complete and check for failure
-            await task.target.wait()
+        await run_schedule(self, trigger_id)
 
     async def _reset(self) -> None:
         """

--- a/src/horus_builtin/workflow/scheduler.py
+++ b/src/horus_builtin/workflow/scheduler.py
@@ -24,17 +24,21 @@ as each one finishes: as soon as a task completes, its dependents that are
 now ready are dispatched too, without waiting for unrelated in-flight tasks.
 
 Scope is intentionally narrow: concurrency plus a ``max_concurrency`` cap.
-Failure handling is still fail-fast (the first failure cancels everything
-else in flight and re-raises), matching the previous serial runner. Resource
-placement and DAG mutation are left to later PRs; the dependency/scope
-recomputation happening on every loop iteration (rather than once up front)
-is the hook that lets a future DAG-mutation PR plug in without touching this
-loop.
+Failure handling supports two policies via ``workflow.failure_policy`` (see
+:attr:`BaseWorkflow.failure_policy`): ``"fail_fast"`` (the default) cancels
+everything else in flight and re-raises, matching the previous serial
+runner; ``"continue"`` lets unrelated branches keep running, blocking only
+the failed task's descendants, and reports every failure at the end via
+:exc:`WorkflowExecutionError`. Resource placement and DAG mutation are left
+to later PRs; the dependency/scope recomputation happening on every loop
+iteration (rather than once up front) is the hook that lets a future
+DAG-mutation PR plug in without touching this loop.
 """
 
 import asyncio
 from typing import TYPE_CHECKING
 
+from horus_builtin.event.task_event import HorusTaskEvent
 from horus_builtin.workflow.dag import (
     UnknownTaskError,
     ancestors,
@@ -42,8 +46,10 @@ from horus_builtin.workflow.dag import (
     descendants,
     topological_sort,
 )
+from horus_runtime.context import HorusContext
 from horus_runtime.core.target.base import BaseTarget
 from horus_runtime.core.workflow.base import BaseWorkflow, _EdgeSource
+from horus_runtime.core.workflow.exceptions import WorkflowExecutionError
 from horus_runtime.i18n import tr as _
 from horus_runtime.logging import horus_logger
 
@@ -159,23 +165,28 @@ def _collect_completions(
     done: set[asyncio.Task[None]],
     running: dict[asyncio.Task[None], str],
     completed: set[str],
-) -> BaseException | None:
+) -> list[tuple[str, BaseException]]:
     """
     Pop every finished task out of *running*, adding successes to
-    *completed*, and return the first exception encountered (if any) in
-    deterministic (task id) order.
+    *completed*, and return every ``(task_id, exception)`` failure
+    encountered, in deterministic (task id) order.
+
+    Under ``fail_fast`` only the first entry is ever used (the caller cancels
+    and re-raises as soon as the list is non-empty), but ``continue`` needs
+    every failure from the batch: several ready tasks can finish in the same
+    ``asyncio.wait`` and more than one can fail at once.
     """
-    failure: BaseException | None = None
+    failures: list[tuple[str, BaseException]] = []
     for fut in sorted(done, key=lambda f: running[f]):
         task_id = running.pop(fut)
         if fut.cancelled():
             continue
         exc = fut.exception()
         if exc is not None:
-            failure = failure or exc
+            failures.append((task_id, exc))
         else:
             completed.add(task_id)
-    return failure
+    return failures
 
 
 async def _cancel_running(running: dict[asyncio.Task[None], str]) -> None:
@@ -196,15 +207,30 @@ async def run_schedule(workflow: BaseWorkflow, trigger_id: str) -> None:
     ``BaseTask.is_complete``, applied inside ``BaseTask.run``). Every task
     whose dependencies are already satisfied is dispatched immediately and
     concurrently with any other ready task, bounded by
-    ``workflow.max_concurrency`` when set. The first task to fail cancels
-    every other task still in flight and re-raises, so ``BaseWorkflow.run``
-    can mark the workflow ``FAILED`` — the same fail-fast contract the
-    previous serial loop provided.
+    ``workflow.max_concurrency`` when set.
+
+    ``workflow.failure_policy`` controls what happens once a task fails:
+
+    - ``"fail_fast"`` (the default): the first task to fail cancels every
+      other task still in flight and re-raises immediately, so
+      ``BaseWorkflow.run`` can mark the workflow ``FAILED`` — the same
+      fail-fast contract the previous serial loop provided.
+    - ``"continue"``: a failed task does not cancel anything. Its
+      descendants are added to a ``blocked`` set and never dispatched (a
+      failed or blocked dependency never enters ``completed``, so a
+      dependent's ``deps[task_id] <= completed`` check never passes for it
+      either — the ``blocked`` set just makes that explicit and avoids
+      mistaking the resulting deadlock for a genuine cycle). Every other
+      branch keeps running to completion. Once nothing more can run, if any
+      task failed, :exc:`WorkflowExecutionError` is raised naming every
+      failed task, so the workflow still ends ``FAILED``.
 
     Raises:
         UnknownTaskError: If trigger_id is not a task in the workflow.
         CyclicDependencyError: If the tasks in scope cannot all be
             scheduled (a cycle keeps the remainder permanently blocked).
+        WorkflowExecutionError: Under the ``"continue"`` policy, if any task
+            failed during the run.
     """
     tasks_by_id = {task.id: task for task in workflow.tasks}
     if trigger_id not in tasks_by_id:
@@ -238,6 +264,12 @@ async def run_schedule(workflow: BaseWorkflow, trigger_id: str) -> None:
     dispatched: set[str] = set()
     running: dict[asyncio.Task[None], str] = {}
 
+    # `continue`-policy bookkeeping. Both stay empty for `fail_fast`, which
+    # always raises out of the loop on the first failure instead of
+    # populating them.
+    blocked: set[str] = set()
+    failed: dict[str, BaseException] = {}
+
     while True:
         # Recomputed every iteration (instead of once up front) so a future
         # DAG-mutation PR can grow `workflow.tasks`/`workflow.edges` mid-run
@@ -246,19 +278,33 @@ async def run_schedule(workflow: BaseWorkflow, trigger_id: str) -> None:
         scope = ancestors(trigger_id, deps) | descendants(trigger_id, deps)
 
         # Deterministic order when several tasks become ready at once,
-        # matching topological_sort's tie-breaking.
+        # matching topological_sort's tie-breaking. `blocked` tasks are
+        # excluded explicitly for clarity: a blocked task's dependency never
+        # entered `completed` either, so `deps[task_id] <= completed` alone
+        # would already keep it (and everything downstream of it) out of
+        # `ready`.
         ready = sorted(
             task_id
             for task_id in scope
-            if task_id not in dispatched and deps[task_id] <= completed
+            if task_id not in dispatched
+            and task_id not in blocked
+            and deps[task_id] <= completed
         )
 
-        if not ready and not running and (scope - completed):
-            # Nothing is ready and nothing is in flight, yet the scope isn't
-            # fully satisfied: the remaining tasks are stuck on each other.
+        # Tasks left neither completed, blocked, nor failed, with nothing
+        # ready or in flight to get them there, are stuck on each other
+        # rather than on an (already accounted for) upstream failure.
+        stuck = scope - completed - blocked - failed.keys()
+        if not ready and not running and stuck:
             # Reuse topological_sort's cycle detection for a consistent
             # error instead of silently stopping short.
             topological_sort(scope, deps)
+
+        if not ready and not running:
+            # Nothing left that can ever become ready: either everything in
+            # scope completed, or (continue policy) the rest is permanently
+            # blocked behind a failure. Report any failures below the loop.
+            break
 
         if ready:
             source_map_cache = workflow.cached_source_map(source_map_cache)
@@ -271,14 +317,42 @@ async def run_schedule(workflow: BaseWorkflow, trigger_id: str) -> None:
                 )
                 running[wrapper] = task_id
 
-        if not running:
-            break
-
         done, _pending = await asyncio.wait(
             running, return_when=asyncio.FIRST_COMPLETED
         )
 
-        failure = _collect_completions(done, running, completed)
-        if failure is not None:
+        failures = _collect_completions(done, running, completed)
+        if failures and workflow.failure_policy == "fail_fast":
             await _cancel_running(running)
-            raise failure
+            raise failures[0][1]
+
+        for task_id, exc in failures:
+            # `continue` policy: record the failure and block its
+            # descendants (inclusive of task_id itself) instead of aborting.
+            # Unrelated branches already in `running`, or that become ready
+            # on a later iteration, are left alone.
+            failed[task_id] = exc
+            newly_blocked = descendants(task_id, deps) - blocked
+            blocked |= newly_blocked
+            for blocked_id in sorted(newly_blocked - {task_id}):
+                blocked_task = tasks_by_id[blocked_id]
+                message = _(
+                    "Task %(task_name)s blocked: upstream task "
+                    "%(failed_task_name)s failed."
+                ) % {
+                    "task_name": blocked_task.name,
+                    "failed_task_name": tasks_by_id[task_id].name,
+                }
+                horus_logger.log.debug(message)
+                HorusContext.get_context().bus.emit(
+                    HorusTaskEvent(
+                        task_id=blocked_id,
+                        task_name=blocked_task.name,
+                        message=message,
+                    )
+                )
+
+    if failed:
+        raise WorkflowExecutionError(sorted(failed)) from next(
+            iter(failed.values())
+        )

--- a/src/horus_builtin/workflow/scheduler.py
+++ b/src/horus_builtin/workflow/scheduler.py
@@ -1,0 +1,284 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Concurrent ready-set scheduler for Horus built-in workflows.
+
+Replaces a serial "run the topological order one task at a time" loop with a
+scheduler that dispatches every currently-ready task concurrently and reacts
+as each one finishes: as soon as a task completes, its dependents that are
+now ready are dispatched too, without waiting for unrelated in-flight tasks.
+
+Scope is intentionally narrow: concurrency plus a ``max_concurrency`` cap.
+Failure handling is still fail-fast (the first failure cancels everything
+else in flight and re-raises), matching the previous serial runner. Resource
+placement and DAG mutation are left to later PRs; the dependency/scope
+recomputation happening on every loop iteration (rather than once up front)
+is the hook that lets a future DAG-mutation PR plug in without touching this
+loop.
+"""
+
+import asyncio
+from typing import TYPE_CHECKING
+
+from horus_builtin.workflow.dag import (
+    UnknownTaskError,
+    ancestors,
+    build_dependencies,
+    descendants,
+    topological_sort,
+)
+from horus_runtime.core.target.base import BaseTarget
+from horus_runtime.core.workflow.base import BaseWorkflow, _EdgeSource
+from horus_runtime.i18n import tr as _
+from horus_runtime.logging import horus_logger
+
+if TYPE_CHECKING:
+    from horus_runtime.core.task.base import BaseTask
+
+
+class TargetPool:
+    """
+    Hands out an idle target for each dispatched task, giving otherwise
+    single-slot :class:`BaseTarget` instances room for concurrency.
+
+    In a hand-authored DAG each task normally owns its own distinct target
+    object, so there is no contention and every acquisition simply returns
+    the task's declared target. The pool only has to do real work when two
+    ready tasks share the exact same target *instance* (e.g. a workflow that
+    reuses one ``LocalTarget()`` across several task placements): the second
+    concurrent acquisition for that instance gets an idle clone
+    (``target.model_copy()``) instead of blocking. A clone is a valid extra
+    slot because targets sharing a target's class and fields also share its
+    ``location_id`` (same filesystem), so no artifact transfer is needed
+    between the original and the clone.
+
+    Targets are keyed by object identity (``id(target)``), not by task id,
+    because the sharing scenario above is about the target object, not the
+    task.
+    """
+
+    def __init__(self, max_concurrency: int | None) -> None:
+        # Idle instances available for a given declared target, keyed by
+        # id(declared_target). Lazily seeded with the declared target itself
+        # on first acquisition (see `acquire`).
+        self._idle: dict[int, list[BaseTarget]] = {}
+        self._semaphore = (
+            asyncio.Semaphore(max_concurrency)
+            if max_concurrency is not None
+            else None
+        )
+
+    async def acquire(self, declared_target: BaseTarget) -> BaseTarget:
+        """
+        Return an idle target equivalent to *declared_target*.
+
+        Blocks on the ``max_concurrency`` semaphore (if set) before handing
+        out a target, so the cap applies to genuinely concurrent dispatches
+        rather than just to distinct target instances.
+        """
+        if self._semaphore is not None:
+            await self._semaphore.acquire()
+
+        idle = self._idle.setdefault(id(declared_target), [declared_target])
+        if idle:
+            return idle.pop()
+
+        # Every idle instance (the declared target and any prior clones) is
+        # currently in use: mint another clone as an extra slot.
+        clone = declared_target.model_copy()
+        # model_copy() shallow-copies pydantic private attributes, so the
+        # clone would otherwise start out pointing at the declared target's
+        # in-flight `_task_future` and look "busy" before it has run
+        # anything. Clear them so the clone starts genuinely idle.
+        clone._task = None  # noqa: SLF001
+        clone._task_future = None  # noqa: SLF001
+        return clone
+
+    def release(self, declared_target: BaseTarget, target: BaseTarget) -> None:
+        """
+        Return *target* (previously returned by :meth:`acquire` for
+        *declared_target*) to the idle pool.
+        """
+        self._idle[id(declared_target)].append(target)
+        if self._semaphore is not None:
+            self._semaphore.release()
+
+
+async def _execute_ready_task(
+    workflow: BaseWorkflow,
+    task: "BaseTask",
+    source_map: dict[tuple[str, str], _EdgeSource],
+    pool: TargetPool,
+) -> None:
+    """
+    Run one ready task to completion: acquire a target, bind, transfer
+    inputs, dispatch, and wait — mirroring the per-task body of the previous
+    serial loop, but on whichever target the pool hands back (the task's own
+    declared target in the common case, or an idle clone under contention).
+    """
+    declared_target = task.target
+    target = await pool.acquire(declared_target)
+    # `transfer_artifacts` and `dispatch` both operate off `task.target`, so
+    # point it at the target we actually acquired for the duration of the
+    # run and restore it afterwards, leaving the task's declared target
+    # untouched for any subsequent run of the same workflow instance.
+    task.target = target
+    try:
+        # Associate the task with its target before any transfer so
+        # resource-aware targets (which may provision lazily at transfer
+        # time, before dispatch) can read task.resources.
+        target.bind(task)
+
+        # Transfer input artifacts to the task's target as needed.
+        await workflow.transfer_artifacts(task, source_map)
+
+        # Execute the task on its target and wait for it to finish.
+        await target.dispatch(task)
+        await target.wait()
+    finally:
+        task.target = declared_target
+        pool.release(declared_target, target)
+
+
+def _collect_completions(
+    done: set[asyncio.Task[None]],
+    running: dict[asyncio.Task[None], str],
+    completed: set[str],
+) -> BaseException | None:
+    """
+    Pop every finished task out of *running*, adding successes to
+    *completed*, and return the first exception encountered (if any) in
+    deterministic (task id) order.
+    """
+    failure: BaseException | None = None
+    for fut in sorted(done, key=lambda f: running[f]):
+        task_id = running.pop(fut)
+        if fut.cancelled():
+            continue
+        exc = fut.exception()
+        if exc is not None:
+            failure = failure or exc
+        else:
+            completed.add(task_id)
+    return failure
+
+
+async def _cancel_running(running: dict[asyncio.Task[None], str]) -> None:
+    """Cancel every still-running wrapper task and wait for it to unwind."""
+    for fut in running:
+        fut.cancel()
+    if running:
+        await asyncio.wait(list(running))
+    running.clear()
+
+
+async def run_schedule(workflow: BaseWorkflow, trigger_id: str) -> None:
+    """
+    Execute *workflow* from *trigger_id* with a concurrent ready-set
+    scheduler.
+
+    A task is skipped when all of its output artifacts exist (see
+    ``BaseTask.is_complete``, applied inside ``BaseTask.run``). Every task
+    whose dependencies are already satisfied is dispatched immediately and
+    concurrently with any other ready task, bounded by
+    ``workflow.max_concurrency`` when set. The first task to fail cancels
+    every other task still in flight and re-raises, so ``BaseWorkflow.run``
+    can mark the workflow ``FAILED`` — the same fail-fast contract the
+    previous serial loop provided.
+
+    Raises:
+        UnknownTaskError: If trigger_id is not a task in the workflow.
+        CyclicDependencyError: If the tasks in scope cannot all be
+            scheduled (a cycle keeps the remainder permanently blocked).
+    """
+    tasks_by_id = {task.id: task for task in workflow.tasks}
+    if trigger_id not in tasks_by_id:
+        raise UnknownTaskError(
+            _("Trigger task '%(trigger_id)s' not found.")
+            % {"trigger_id": trigger_id}
+        )
+
+    # No edges means no dependencies: every task runs independently and the
+    # plan is limited to the trigger's own (singleton) scope. Flag it so a
+    # workflow that forgot to wire its edges is diagnosable.
+    if len(workflow.tasks) > 1 and not workflow.edges:
+        horus_logger.log.debug(
+            _(
+                "Workflow %(name)s has multiple tasks but no edges; "
+                "tasks run independently with no ordering."
+            )
+            % {"name": workflow.name}
+        )
+
+    pool = TargetPool(workflow.max_concurrency)
+
+    # The source map depends only on workflow structure. It is rebuilt only
+    # when the workflow's revision advances (nothing bumps it yet, so this
+    # effectively builds once, the first time it's needed).
+    source_map_cache: tuple[int, dict[tuple[str, str], _EdgeSource]] | None = (
+        None
+    )
+
+    completed: set[str] = set()
+    dispatched: set[str] = set()
+    running: dict[asyncio.Task[None], str] = {}
+
+    while True:
+        # Recomputed every iteration (instead of once up front) so a future
+        # DAG-mutation PR can grow `workflow.tasks`/`workflow.edges` mid-run
+        # without any change to this loop.
+        deps = build_dependencies(workflow.tasks, workflow.edges)
+        scope = ancestors(trigger_id, deps) | descendants(trigger_id, deps)
+
+        # Deterministic order when several tasks become ready at once,
+        # matching topological_sort's tie-breaking.
+        ready = sorted(
+            task_id
+            for task_id in scope
+            if task_id not in dispatched and deps[task_id] <= completed
+        )
+
+        if not ready and not running and (scope - completed):
+            # Nothing is ready and nothing is in flight, yet the scope isn't
+            # fully satisfied: the remaining tasks are stuck on each other.
+            # Reuse topological_sort's cycle detection for a consistent
+            # error instead of silently stopping short.
+            topological_sort(scope, deps)
+
+        if ready:
+            source_map_cache = workflow.cached_source_map(source_map_cache)
+            source_map = source_map_cache[1]
+            for task_id in ready:
+                task = tasks_by_id[task_id]
+                dispatched.add(task_id)
+                wrapper = asyncio.create_task(
+                    _execute_ready_task(workflow, task, source_map, pool)
+                )
+                running[wrapper] = task_id
+
+        if not running:
+            break
+
+        done, _pending = await asyncio.wait(
+            running, return_when=asyncio.FIRST_COMPLETED
+        )
+
+        failure = _collect_completions(done, running, completed)
+        if failure is not None:
+            await _cancel_running(running)
+            raise failure

--- a/src/horus_runtime/core/workflow/base.py
+++ b/src/horus_runtime/core/workflow/base.py
@@ -152,12 +152,32 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
     ``run()``; do not set manually.
     """
 
+    max_concurrency: int | None = None
+    """
+    Upper bound on the number of tasks the scheduler dispatches at once.
+    ``None`` (the default) means unbounded: every task that becomes ready is
+    dispatched immediately. Set this to cap resource usage (e.g. a shared
+    machine with limited CPUs) when the DAG's natural parallelism would
+    otherwise over-subscribe it.
+    """
+
     _base_directory: Path | None = PrivateAttr(default=None)
     """
     Directory relative paths are anchored to (the run directory and, through
     it, artifact paths and logs). Set to the workflow YAML's folder by
     :meth:`from_yaml`; ``None`` for programmatically-built workflows, which
     fall back to the process CWD. Runtime-only state, not serialized.
+    """
+
+    _revision: int = PrivateAttr(default=0)
+    """
+    Monotonically increasing counter for the workflow's DAG structure
+    (tasks/edges/artifacts). Nothing bumps it yet: today the DAG is fixed for
+    the lifetime of a run, so it is built once and stays at ``0``. It exists
+    so a future dynamic-DAG feature (fan-out/map/loops) can increment it when
+    mutating the graph mid-run, and the scheduler's cached source map (see
+    :meth:`cached_source_map`) picks up the change without any changes to the
+    scheduler itself.
     """
 
     @model_validator(mode="after")
@@ -317,6 +337,23 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
                     None, roots_by_id.get(edge.source_output)
                 )
         return source_map
+
+    def cached_source_map(
+        self,
+        cached: tuple[int, dict[tuple[str, str], _EdgeSource]] | None,
+    ) -> tuple[int, dict[tuple[str, str], _EdgeSource]]:
+        """
+        Return ``(self._revision, source_map)``, rebuilding the source map
+        only when ``_revision`` has advanced past *cached*.
+
+        Intended for callers (namely the scheduler) that need the source map
+        across several iterations of a run: pass back the tuple you got last
+        time and only a genuinely stale cache triggers a rebuild via
+        :meth:`_build_source_map`. Passing ``None`` always rebuilds.
+        """
+        if cached is not None and cached[0] == self._revision:
+            return cached
+        return self._revision, self._build_source_map()
 
     async def transfer_artifacts(
         self,

--- a/src/horus_runtime/core/workflow/base.py
+++ b/src/horus_runtime/core/workflow/base.py
@@ -34,7 +34,7 @@ from abc import abstractmethod
 from asyncio import CancelledError
 from collections.abc import Awaitable
 from pathlib import Path
-from typing import ClassVar, NamedTuple, Self, final
+from typing import ClassVar, Literal, NamedTuple, Self, final
 from uuid import UUID, uuid4
 
 import yaml
@@ -159,6 +159,23 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
     dispatched immediately. Set this to cap resource usage (e.g. a shared
     machine with limited CPUs) when the DAG's natural parallelism would
     otherwise over-subscribe it.
+    """
+
+    failure_policy: Literal["fail_fast", "continue"] = "fail_fast"
+    """
+    How the scheduler reacts to a task failure.
+
+    - ``"fail_fast"`` (the default): the first task to fail cancels every
+      other task still in flight and the run stops immediately, matching the
+      runtime's historical behavior.
+    - ``"continue"``: a failed task does not abort the run. Its descendants
+      are never dispatched (they permanently lack a satisfied dependency),
+      but every other branch of the DAG keeps running to completion. Once
+      nothing more can run, the workflow still ends ``FAILED`` if any task
+      failed, naming every failed task.
+
+    Either way a task failure always results in a ``FAILED`` workflow; the
+    policy only controls how much of the DAG gets to run first.
     """
 
     _base_directory: Path | None = PrivateAttr(default=None)

--- a/src/horus_runtime/core/workflow/exceptions.py
+++ b/src/horus_runtime/core/workflow/exceptions.py
@@ -110,3 +110,24 @@ class DuplicateEdgeTargetError(WorkflowError):
             )
             % {"input": target_input, "target": target}
         )
+
+
+class WorkflowExecutionError(WorkflowError):
+    """
+    Raised by the scheduler when a run finishes under the ``"continue"``
+    failure policy (see :attr:`BaseWorkflow.failure_policy`) with one or more
+    failed tasks.
+
+    Under ``"fail_fast"`` the triggering task's own exception propagates
+    directly, so this error never applies there. Under ``"continue"`` the
+    scheduler lets unrelated branches run to completion before reporting the
+    failure, so this error is raised afterwards, naming every task that
+    failed, to still transition the workflow to ``FAILED``.
+    """
+
+    def __init__(self, failed_task_ids: list[str]):
+        self.failed_task_ids = failed_task_ids
+        super().__init__(
+            _("Workflow finished with failed task(s): %(tasks)s.")
+            % {"tasks": ", ".join(failed_task_ids)}
+        )

--- a/tests/unit/workflow/test_scheduler.py
+++ b/tests/unit/workflow/test_scheduler.py
@@ -37,6 +37,8 @@ from horus_runtime.core.artifact.base import BaseArtifact
 from horus_runtime.core.task.exceptions import TaskExecutionError
 from horus_runtime.core.task.status import TaskStatus
 from horus_runtime.core.workflow.edge import WorkflowEdge
+from horus_runtime.core.workflow.exceptions import WorkflowExecutionError
+from horus_runtime.core.workflow.status import WorkflowStatus
 
 
 def _task(
@@ -442,3 +444,130 @@ class TestConcurrentReadySet:
         # once each finishes running.
         assert task_a.target is shared_target
         assert task_b.target is shared_target
+
+
+@pytest.mark.unit
+class TestFailurePolicy:
+    """
+    Tests for ``workflow.failure_policy``: ``"fail_fast"`` (the default,
+    covered by ``TestConcurrentReadySet.``
+    ``test_failure_cancels_concurrent_sibling_and_stops_downstream``) versus
+    ``"continue"``.
+    """
+
+    def test_default_failure_policy_is_fail_fast(self) -> None:
+        """
+        A workflow that doesn't set ``failure_policy`` gets the historical
+        fail-fast behavior.
+        """
+        wf = HorusWorkflow(name="default_policy", tasks=[])
+        assert wf.failure_policy == "fail_fast"
+
+    async def test_continue_policy_blocks_only_failed_branch(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """
+        Under ``failure_policy="continue"``, a failed task's descendants are
+        never dispatched, but an unrelated sibling branch fed by the same
+        root still runs to completion. The workflow still ends FAILED, via a
+        ``WorkflowExecutionError`` naming the failed task.
+        """
+        del horus_context
+
+        class FailingTask(HorusTask):
+            add_to_registry: ClassVar[bool] = False
+
+            async def _run(self) -> None:
+                raise TaskExecutionError("boom")
+
+        root = _task(
+            "root",
+            tmp_path=tmp_path,
+            task_cls=_PassTask,
+            outputs=[FileArtifact(id="root_out", path=tmp_path / "root.out")],
+        )
+        b = _task(
+            "b",
+            tmp_path=tmp_path,
+            task_cls=FailingTask,
+            inputs=[FileArtifact(id="b_in", path=tmp_path / "root.out")],
+            outputs=[FileArtifact(id="b_out", path=tmp_path / "b.out")],
+        )
+        b_child = _task(
+            "b_child",
+            tmp_path=tmp_path,
+            task_cls=_PassTask,
+            inputs=[FileArtifact(id="child_in", path=tmp_path / "b.out")],
+        )
+        c = _task(
+            "c",
+            tmp_path=tmp_path,
+            task_cls=_PassTask,
+            inputs=[FileArtifact(id="c_in", path=tmp_path / "root.out")],
+        )
+
+        wf = HorusWorkflow(
+            name="continue_policy",
+            tasks=[root, b, b_child, c],
+            edges=[
+                _edge("root", "root_out", "b", "b_in"),
+                _edge("root", "root_out", "c", "c_in"),
+                _edge("b", "b_out", "b_child", "child_in"),
+            ],
+            failure_policy="continue",
+        )
+
+        with (
+            patch.object(HorusWorkflow, "transfer_artifacts", new=AsyncMock()),
+            pytest.raises(WorkflowExecutionError, match="b") as exc_info,
+        ):
+            await asyncio.wait_for(wf.run(trigger_id="root"), timeout=10)
+
+        assert exc_info.value.failed_task_ids == ["b"]
+        assert c.runs == 1
+        assert c.status == TaskStatus.COMPLETED
+        assert b.status == TaskStatus.FAILED
+        # b_child is blocked behind b's failure: it never even reaches
+        # RUNNING, let alone executes.
+        assert b_child.runs == 0
+        assert b_child.status == TaskStatus.IDLE
+        assert wf.status == WorkflowStatus.FAILED
+
+    async def test_continue_policy_with_no_failures_completes_normally(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """
+        ``failure_policy="continue"`` behaves exactly like the default when
+        nothing fails: every task runs to completion, the workflow ends
+        COMPLETED, and no ``WorkflowExecutionError`` is raised.
+        """
+        del horus_context
+
+        a = _task(
+            "a",
+            tmp_path=tmp_path,
+            task_cls=_PassTask,
+            outputs=[FileArtifact(id="a_out", path=tmp_path / "a.out")],
+        )
+        b = _task(
+            "b",
+            tmp_path=tmp_path,
+            task_cls=_PassTask,
+            inputs=[FileArtifact(id="b_in", path=tmp_path / "a.out")],
+        )
+
+        wf = HorusWorkflow(
+            name="continue_no_failures",
+            tasks=[a, b],
+            edges=[_edge("a", "a_out", "b", "b_in")],
+            failure_policy="continue",
+        )
+
+        with patch.object(
+            HorusWorkflow, "transfer_artifacts", new=AsyncMock()
+        ):
+            await asyncio.wait_for(wf.run(trigger_id="a"), timeout=10)
+
+        assert a.runs == 1
+        assert b.runs == 1
+        assert wf.status == WorkflowStatus.COMPLETED

--- a/tests/unit/workflow/test_scheduler.py
+++ b/tests/unit/workflow/test_scheduler.py
@@ -1,0 +1,444 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Unit tests for the concurrent ready-set scheduler.
+"""
+
+import asyncio
+from pathlib import Path
+from typing import ClassVar, cast
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from horus_builtin.artifact.file import FileArtifact
+from horus_builtin.executor.shell import ShellExecutor
+from horus_builtin.runtime.command import CommandRuntime
+from horus_builtin.target.local import LocalTarget
+from horus_builtin.task.horus_task import HorusTask
+from horus_builtin.workflow.horus_workflow import HorusWorkflow
+from horus_runtime.context import HorusContext
+from horus_runtime.core.artifact.base import BaseArtifact
+from horus_runtime.core.task.exceptions import TaskExecutionError
+from horus_runtime.core.task.status import TaskStatus
+from horus_runtime.core.workflow.edge import WorkflowEdge
+
+
+def _task(
+    task_id: str,
+    *,
+    tmp_path: Path,
+    inputs: list[FileArtifact] | None = None,
+    outputs: list[FileArtifact] | None = None,
+    task_cls: type[HorusTask] = HorusTask,
+) -> HorusTask:
+    """Build a minimal task of *task_cls*, defaulting to a plain HorusTask."""
+    return task_cls(
+        id=task_id,
+        name=task_id,
+        inputs=cast(list[BaseArtifact], inputs or []),
+        outputs=cast(list[BaseArtifact], outputs or []),
+        runtime=CommandRuntime(command=f"echo {task_id}"),
+        executor=ShellExecutor(),
+        target=LocalTarget(working_directory=tmp_path.as_posix()),
+    )
+
+
+def _edge(
+    source: str, source_output: str, target: str, target_input: str
+) -> WorkflowEdge:
+    return WorkflowEdge(
+        source=source,
+        source_output=source_output,
+        target=target,
+        target_input=target_input,
+    )
+
+
+class _PassTask(HorusTask):
+    """
+    A task whose ``_run`` does nothing (no real command, no input-artifact
+    check). Used as a downstream sink in tests that patch
+    ``transfer_artifacts`` to a no-op: with a real ``HorusTask``, the sink
+    would fail its own real input-existence check since nothing actually
+    materializes the (mocked-away) transfer.
+    """
+
+    add_to_registry: ClassVar[bool] = False
+
+    async def _run(self) -> None:
+        self.runs += 1
+
+
+@pytest.mark.unit
+class TestConcurrentReadySet:
+    """
+    The scheduler dispatches every currently-ready task concurrently instead
+    of one at a time. ``transfer_artifacts`` is patched to a no-op in most of
+    these tests: they exercise scheduling/ordering, not artifact I/O (which
+    is covered separately in ``test_builtin_workflow.py`` and
+    ``test_edges.py``).
+    """
+
+    async def test_two_independent_tasks_reach_running_concurrently(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """
+        Two tasks with no dependency on each other, but both required by a
+        common downstream sink, must both reach RUNNING before either is
+        allowed to finish. Each task blocks on a shared barrier that only
+        opens once *both* have started, so a serial scheduler would deadlock
+        here (proven by wrapping the run in a timeout) while a concurrent one
+        proceeds normally.
+        """
+        del horus_context
+        started: set[str] = set()
+        both_started = asyncio.Event()
+
+        class BarrierTask(HorusTask):
+            add_to_registry: ClassVar[bool] = False
+
+            async def _run(self) -> None:
+                started.add(self.id)
+                if len(started) == 2:
+                    both_started.set()
+                await asyncio.wait_for(both_started.wait(), timeout=5)
+
+        task_a = _task("a", tmp_path=tmp_path, task_cls=BarrierTask)
+        task_b = _task("b", tmp_path=tmp_path, task_cls=BarrierTask)
+        sink = _task(
+            "sink",
+            tmp_path=tmp_path,
+            task_cls=_PassTask,
+            inputs=[
+                FileArtifact(id="from_a", path=tmp_path / "a.out"),
+                FileArtifact(id="from_b", path=tmp_path / "b.out"),
+            ],
+        )
+        task_a.outputs = [FileArtifact(id="out_a", path=tmp_path / "a.out")]
+        task_b.outputs = [FileArtifact(id="out_b", path=tmp_path / "b.out")]
+
+        wf = HorusWorkflow(
+            name="concurrent_independent",
+            tasks=[task_a, task_b, sink],
+            edges=[
+                _edge("a", "out_a", "sink", "from_a"),
+                _edge("b", "out_b", "sink", "from_b"),
+            ],
+        )
+
+        with patch.object(
+            HorusWorkflow, "transfer_artifacts", new=AsyncMock()
+        ):
+            await asyncio.wait_for(wf.run(trigger_id="sink"), timeout=10)
+
+        assert started == {"a", "b"}
+
+    async def test_diamond_runs_children_after_parent_and_sink_after_both(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """
+        Diamond A -> {B, C} -> D: B and C only start after A finishes, and D
+        only starts once both B and C have finished.
+        """
+        del horus_context
+        order: list[str] = []
+
+        class OrderTask(HorusTask):
+            add_to_registry: ClassVar[bool] = False
+
+            async def _run(self) -> None:
+                order.append(self.id)
+
+        a = _task(
+            "a",
+            tmp_path=tmp_path,
+            task_cls=OrderTask,
+            outputs=[FileArtifact(id="a_out", path=tmp_path / "a.out")],
+        )
+        b = _task(
+            "b",
+            tmp_path=tmp_path,
+            task_cls=OrderTask,
+            inputs=[FileArtifact(id="b_in", path=tmp_path / "a.out")],
+            outputs=[FileArtifact(id="b_out", path=tmp_path / "b.out")],
+        )
+        c = _task(
+            "c",
+            tmp_path=tmp_path,
+            task_cls=OrderTask,
+            inputs=[FileArtifact(id="c_in", path=tmp_path / "a.out")],
+            outputs=[FileArtifact(id="c_out", path=tmp_path / "c.out")],
+        )
+        d = _task(
+            "d",
+            tmp_path=tmp_path,
+            task_cls=OrderTask,
+            inputs=[
+                FileArtifact(id="d_in_b", path=tmp_path / "b.out"),
+                FileArtifact(id="d_in_c", path=tmp_path / "c.out"),
+            ],
+        )
+
+        wf = HorusWorkflow(
+            name="diamond",
+            tasks=[d, c, b, a],  # definition order deliberately scrambled
+            edges=[
+                _edge("a", "a_out", "b", "b_in"),
+                _edge("a", "a_out", "c", "c_in"),
+                _edge("b", "b_out", "d", "d_in_b"),
+                _edge("c", "c_out", "d", "d_in_c"),
+            ],
+        )
+
+        with patch.object(
+            HorusWorkflow, "transfer_artifacts", new=AsyncMock()
+        ):
+            await asyncio.wait_for(wf.run(trigger_id="a"), timeout=10)
+
+        assert order[0] == "a"
+        assert order[-1] == "d"
+        assert set(order[1:3]) == {"b", "c"}
+
+    async def test_max_concurrency_one_never_overlaps(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """
+        With ``max_concurrency=1``, three tasks that all become ready at the
+        same time (siblings fed by a common parent) still never have more
+        than one RUNNING at once.
+        """
+        del horus_context
+        state = {"current": 0, "max_seen": 0}
+
+        class ConcurrencyTask(HorusTask):
+            add_to_registry: ClassVar[bool] = False
+
+            async def _run(self) -> None:
+                state["current"] += 1
+                state["max_seen"] = max(state["max_seen"], state["current"])
+                # Yield control so a scheduler that (incorrectly) allowed
+                # overlap would have a chance to start a sibling here.
+                await asyncio.sleep(0.01)
+                state["current"] -= 1
+
+        root = _task(
+            "root",
+            tmp_path=tmp_path,
+            task_cls=ConcurrencyTask,
+            outputs=[FileArtifact(id="root_out", path=tmp_path / "root.out")],
+        )
+        children = [
+            _task(
+                child_id,
+                tmp_path=tmp_path,
+                task_cls=ConcurrencyTask,
+                inputs=[FileArtifact(id="in", path=tmp_path / "root.out")],
+            )
+            for child_id in ("b", "c", "e")
+        ]
+
+        wf = HorusWorkflow(
+            name="fanout",
+            tasks=[root, *children],
+            edges=[
+                _edge("root", "root_out", child.id, "in") for child in children
+            ],
+            max_concurrency=1,
+        )
+
+        with patch.object(
+            HorusWorkflow, "transfer_artifacts", new=AsyncMock()
+        ):
+            await asyncio.wait_for(wf.run(trigger_id="root"), timeout=10)
+
+        assert state["max_seen"] == 1
+
+    async def test_failure_cancels_concurrent_sibling_and_stops_downstream(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """
+        Fail-fast is preserved under concurrency: when one of two
+        concurrently-running root tasks fails, the other (still in flight,
+        blocked indefinitely) is cancelled, the original exception propagates
+        out of ``run()``, and their common downstream sink never starts.
+        """
+        del horus_context
+
+        class FailingTask(HorusTask):
+            add_to_registry: ClassVar[bool] = False
+
+            async def _run(self) -> None:
+                raise TaskExecutionError("boom")
+
+        class BlockingTask(HorusTask):
+            add_to_registry: ClassVar[bool] = False
+
+            async def _run(self) -> None:
+                # Blocks forever unless cancelled by the scheduler's
+                # fail-fast path.
+                await asyncio.Event().wait()
+
+        failing = _task(
+            "failing",
+            tmp_path=tmp_path,
+            task_cls=FailingTask,
+            outputs=[FileArtifact(id="f_out", path=tmp_path / "f.out")],
+        )
+        blocking = _task(
+            "blocking",
+            tmp_path=tmp_path,
+            task_cls=BlockingTask,
+            outputs=[FileArtifact(id="b_out", path=tmp_path / "b.out")],
+        )
+        sink = _task(
+            "sink",
+            tmp_path=tmp_path,
+            task_cls=_PassTask,
+            inputs=[
+                FileArtifact(id="from_f", path=tmp_path / "f.out"),
+                FileArtifact(id="from_b", path=tmp_path / "b.out"),
+            ],
+        )
+
+        wf = HorusWorkflow(
+            name="fail_fast_concurrent",
+            tasks=[failing, blocking, sink],
+            edges=[
+                _edge("failing", "f_out", "sink", "from_f"),
+                _edge("blocking", "b_out", "sink", "from_b"),
+            ],
+        )
+
+        with (
+            patch.object(HorusWorkflow, "transfer_artifacts", new=AsyncMock()),
+            pytest.raises(TaskExecutionError),
+        ):
+            await asyncio.wait_for(wf.run(trigger_id="sink"), timeout=10)
+
+        assert blocking.status == TaskStatus.CANCELED
+        assert sink.runs == 0
+
+    async def test_cycle_raises_instead_of_stopping_silently(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """
+        A cycle expressed through edges leaves the involved tasks
+        permanently blocked on each other; the scheduler must raise instead
+        of quietly finishing with nothing left running.
+        """
+        del horus_context
+        a = _task(
+            "a",
+            tmp_path=tmp_path,
+            inputs=[FileArtifact(id="a_in", path=tmp_path / "a.in")],
+            outputs=[FileArtifact(id="a_out", path=tmp_path / "a.out")],
+        )
+        b = _task(
+            "b",
+            tmp_path=tmp_path,
+            inputs=[FileArtifact(id="b_in", path=tmp_path / "b.in")],
+            outputs=[FileArtifact(id="b_out", path=tmp_path / "b.out")],
+        )
+        wf = HorusWorkflow(
+            name="cyclic",
+            tasks=[a, b],
+            edges=[
+                _edge("a", "a_out", "b", "b_in"),
+                _edge("b", "b_out", "a", "a_in"),
+            ],
+        )
+
+        with pytest.raises(Exception, match="Cycle detected"):
+            await asyncio.wait_for(wf.run(trigger_id="a"), timeout=10)
+
+    async def test_shared_target_instance_gets_idle_clone(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """
+        Two ready tasks that declare the exact same target *instance* do not
+        block each other: the second acquisition gets an idle clone of that
+        target instead of waiting for the first to finish, so both tasks
+        genuinely overlap.
+        """
+        del horus_context
+        shared_target = LocalTarget(working_directory=tmp_path.as_posix())
+        started: set[str] = set()
+        both_started = asyncio.Event()
+        seen_target_ids: list[int] = []
+
+        class SharedTargetTask(HorusTask):
+            add_to_registry: ClassVar[bool] = False
+
+            async def _run(self) -> None:
+                seen_target_ids.append(id(self.target))
+                started.add(self.id)
+                if len(started) == 2:
+                    both_started.set()
+                await asyncio.wait_for(both_started.wait(), timeout=5)
+
+        task_a = SharedTargetTask(
+            id="a",
+            name="a",
+            outputs=[FileArtifact(id="out_a", path=tmp_path / "a.out")],
+            runtime=CommandRuntime(command="echo a"),
+            executor=ShellExecutor(),
+            target=shared_target,
+        )
+        task_b = SharedTargetTask(
+            id="b",
+            name="b",
+            outputs=[FileArtifact(id="out_b", path=tmp_path / "b.out")],
+            runtime=CommandRuntime(command="echo b"),
+            executor=ShellExecutor(),
+            target=shared_target,
+        )
+        sink = _task(
+            "sink",
+            tmp_path=tmp_path,
+            task_cls=_PassTask,
+            inputs=[
+                FileArtifact(id="from_a", path=tmp_path / "a.out"),
+                FileArtifact(id="from_b", path=tmp_path / "b.out"),
+            ],
+        )
+
+        wf = HorusWorkflow(
+            name="shared_target",
+            tasks=[task_a, task_b, sink],
+            edges=[
+                _edge("a", "out_a", "sink", "from_a"),
+                _edge("b", "out_b", "sink", "from_b"),
+            ],
+        )
+
+        with patch.object(
+            HorusWorkflow, "transfer_artifacts", new=AsyncMock()
+        ):
+            await asyncio.wait_for(wf.run(trigger_id="sink"), timeout=10)
+
+        # Both tasks overlapped (the barrier only opens once both started)
+        # using two distinct target instances: one is the shared declared
+        # target, the other an idle clone minted for the second acquirer.
+        assert started == {"a", "b"}
+        assert len(set(seen_target_ids)) == 2
+        assert id(shared_target) in seen_target_ids
+        # The declared target instance itself is restored on task_a/task_b
+        # once each finishes running.
+        assert task_a.target is shared_target
+        assert task_b.target is shared_target


### PR DESCRIPTION
Closes #111. Closes #42.

Stacked on #118 (concurrent scheduler) — review that PR first; this diff only makes sense on top of it.

## Summary

Adds `BaseWorkflow.failure_policy: Literal["fail_fast", "continue"] = "fail_fast"`, giving a workflow control over how the scheduler reacts to a task failure:

- **`fail_fast`** (default, unchanged): the first task to fail cancels every other in-flight task and re-raises immediately, exactly as before this PR.
- **`continue`**: a failed task no longer aborts the run. The scheduler computes `descendants(failed_id, deps)` and adds them to a `blocked` set so they are never dispatched — a blocked (or failed) dependency never enters `completed`, so a dependent's `deps[task_id] <= completed` check never passes for it either; the explicit `blocked` set just makes that intent clear and lets the scheduler tell "permanently blocked by a failure" apart from a genuine dependency cycle. Every other branch of the DAG keeps running to completion. Once nothing more can become ready, if anything failed, the scheduler raises a new `WorkflowExecutionError` naming every failed task, so `BaseWorkflow.run` still transitions the workflow to `FAILED`.

Either policy always ends a run with failures in `FAILED`; the policy only controls how much of the DAG gets to run before that happens.

A `HorusTaskEvent` is emitted (and debug-logged) for each task that becomes newly blocked, naming the upstream failure, so the event bus / TUI has something to show for it without inventing a new task status or event type.

## Files changed

- `src/horus_runtime/core/workflow/base.py` — `failure_policy` field + docstring.
- `src/horus_runtime/core/workflow/exceptions.py` — new `WorkflowExecutionError`.
- `src/horus_builtin/workflow/scheduler.py` — `continue` branch in `run_schedule`, failure/blocked bookkeeping, and a fix to the loop's stuck-vs-cycle check so a `continue`-policy run terminates instead of looping forever once everything left is blocked.
- `tests/unit/workflow/test_scheduler.py` — new `TestFailurePolicy` class.

## Test plan

- [x] `make test` — 443 passed, 95.20% coverage (threshold 90%).
- [x] `make lint` — ruff + mypy clean.
- New tests: `continue` policy blocks only the failed branch while an unrelated sibling completes and `WorkflowExecutionError` names the failed task; `continue` policy with no failures completes normally; default `failure_policy` is `fail_fast`.
- Existing `fail_fast` scheduler tests (including `test_failure_cancels_concurrent_sibling_and_stops_downstream`) still pass unchanged.

## Docs
https://github.com/temple-compute/horus-docs/pull/37/changes