### PR TITLE
fix(workflow): propagate forced re-run to map fan-out clones

### DIFF
--- a/src/horus_builtin/workflow/map.py
+++ b/src/horus_builtin/workflow/map.py
@@ -560,10 +560,6 @@ class MapExpander(HorusTask):
         data["name"] = clone_id
         # Propagate a forced re-run (e.g. CLI ``--no-skip-all``/``--no-skip``,
         # which flips the expander's own ``skip_if_complete``) onto each clone.
-        # Clones are materialized here at runtime, after the CLI has already
-        # mutated the static task list, so without this they would inherit the
-        # template's default ``skip_if_complete=True`` and be skipped when
-        # already complete despite the flag.
         if not self.skip_if_complete:
             data["skip_if_complete"] = False
         clone = BaseTask.model_validate(data)

--- a/src/horus_builtin/workflow/map.py
+++ b/src/horus_builtin/workflow/map.py
@@ -558,6 +558,14 @@ class MapExpander(HorusTask):
         data.setdefault("kind", "horus_task")
         data["id"] = clone_id
         data["name"] = clone_id
+        # Propagate a forced re-run (e.g. CLI ``--no-skip-all``/``--no-skip``,
+        # which flips the expander's own ``skip_if_complete``) onto each clone.
+        # Clones are materialized here at runtime, after the CLI has already
+        # mutated the static task list, so without this they would inherit the
+        # template's default ``skip_if_complete=True`` and be skipped when
+        # already complete despite the flag.
+        if not self.skip_if_complete:
+            data["skip_if_complete"] = False
         clone = BaseTask.model_validate(data)
         clone.target = clone.target.model_copy(deep=True)
         return clone

--- a/tests/unit/workflow/test_map.py
+++ b/tests/unit/workflow/test_map.py
@@ -332,6 +332,52 @@ class TestPartialCompletion:
         assert statuses["score[2]"] == TaskStatus.COMPLETED
         assert wf.status.value == "completed"
 
+    async def test_forced_expander_reruns_completed_clones(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """
+        Forcing a re-run on the expander (as the CLI's ``--no-skip-all`` /
+        ``--no-skip`` does by flipping the static task's
+        ``skip_if_complete``) must propagate to the clones it materializes
+        at runtime, so an already-complete clone re-runs instead of being
+        skipped.
+        """
+        del horus_context
+        # Pre-create clone 1's deterministic output, as in the skip test.
+        gathered_1 = tmp_path / "score.gathered" / "1"
+        gathered_1.mkdir(parents=True)
+        (gathered_1 / "out.txt").write_text("already done")
+
+        split = _split_task(tmp_path, ["a", "b", "c"])
+        gather = _gather_task(tmp_path)
+        wf = HorusWorkflow(
+            name="wf",
+            tasks=[split, gather],
+            orchestrator_target=LocalTarget(
+                working_directory=tmp_path.as_posix()
+            ),
+        )
+        wf.map(
+            id="score",
+            template=_template_task(),
+            over=("split", "batches", "batch"),
+            gather=("gather", "results"),
+        )
+
+        # Mimic the CLI's --no-skip-all: force the expander to re-run. The
+        # clones do not exist yet, so this must reach them when they are built.
+        expander = next(t for t in wf.tasks if t.id == "score")
+        expander.skip_if_complete = False
+
+        await wf.run(trigger_id="split")
+
+        statuses = {t.id: t.status for t in wf.tasks}
+        assert statuses["score[0]"] == TaskStatus.COMPLETED
+        # Without the fix this clone is SKIPPED despite the forced re-run.
+        assert statuses["score[1]"] == TaskStatus.COMPLETED
+        assert statuses["score[2]"] == TaskStatus.COMPLETED
+        assert wf.status.value == "completed"
+
 
 @pytest.mark.unit
 class TestFanInOrdering:


### PR DESCRIPTION
## Problem

`horus run --no-skip-all` (and `--no-skip <id>`) does not force map / fan-out clones to re-run. Already-complete clones are skipped despite the flag, e.g. re-running the loop-map showcase logs `Skipping task iterate[0..4]. Already complete.`

## Root cause

The CLI applies the flag by flipping `skip_if_complete` on the **static** task list at load time (`cli.py`):

```python
for task in workflow.tasks:
    if no_skip_all or task.id in force_ids:
        task.skip_if_complete = False
```

But a `map:` block is a single `MapExpander` at load time — the clones (`iterate[0]`…) don't exist yet. They're materialized later, at runtime, in `MapExpander._run()` via `_build_clone()`, which reconstructs each clone from the serialized `template` dict. That dict never carried the CLI's override, so every clone gets the default `skip_if_complete=True`. The flag reaches static tasks (e.g. `gather`) but never the dynamically-expanded clones.

## Fix

`MapExpander._build_clone` now propagates its own `skip_if_complete` onto each clone. The CLI already flips the expander's `skip_if_complete` (it's in the static task list), so forcing a re-run on the expander now reaches the clones it generates. This also makes `--no-skip <map_id>` force the whole fan-out.

## Testing

- New regression test `test_forced_expander_reruns_completed_clones`: pre-creates a clone's output, forces the expander (as the CLI does), and asserts the clone re-runs (`COMPLETED`) instead of being `SKIPPED`. Verified it fails without the fix.
- Full map suite: 26 passed.
- Manually confirmed on the loop-map showcase: all clones now re-run under `--no-skip-all`.