### PR TITLE
feat(workflow): auto-schedule runtime-added tasks; JSON write mkdir

### DIFF
--- a/src/horus_builtin/artifact/json.py
+++ b/src/horus_builtin/artifact/json.py
@@ -21,6 +21,7 @@ folder/directory artifact in the Horus runtime.
 """
 
 import json
+from pathlib import Path
 from typing import Any, ClassVar, cast
 
 from horus_builtin.event.artifact_event import ArtifactEventsEnum
@@ -55,7 +56,11 @@ class JSONArtifact[T: Any = Any](BaseArtifact[T]):
     def write(self, value: T) -> None:
         """
         Serialize and write the JSON artifact contents.
+
+        Parent directories are created as needed so a task can write an output
+        into a not-yet-existing results/ folder without a manual ``mkdir``.
         """
+        Path(self.path).parent.mkdir(parents=True, exist_ok=True)
         with open(self.path, "w") as f:
             json.dump(value, f)
         self._emit_event(ArtifactEventsEnum.WRITE)

--- a/src/horus_builtin/task/function.py
+++ b/src/horus_builtin/task/function.py
@@ -74,6 +74,7 @@ class FunctionTask(HorusTask):
         inputs: list[BaseArtifact] | None = None,
         outputs: list[BaseArtifact] | None = None,
         target: BaseTarget | None = None,
+        skip_if_complete: bool = True,
     ) -> Callable[[Callable[..., Any]], "FunctionTask"]:
         """
         Decorator factory for registering a Python function as a Horus task
@@ -92,6 +93,7 @@ class FunctionTask(HorusTask):
                 inputs=inputs or [],
                 outputs=outputs or [],
                 target=target or LocalTarget(),
+                skip_if_complete=skip_if_complete,
             )
 
             wf.tasks.append(t)

--- a/src/horus_builtin/workflow/scheduler.py
+++ b/src/horus_builtin/workflow/scheduler.py
@@ -202,6 +202,24 @@ async def _cancel_running(running: dict[asyncio.Task[None], str]) -> None:
     running.clear()
 
 
+def _dependencies_with_implicit(
+    workflow: BaseWorkflow,
+) -> dict[str, set[str]]:
+    """
+    Edge-derived dependency map for *workflow*, augmented with its runtime-only
+    implicit deps (a task added mid-run gated behind its creator; see
+    ``BaseWorkflow.add_task``/``expand``). Recomputed every scheduler loop so a
+    mid-run mutation is reflected immediately, and merged before scope is
+    derived so a newly added, edge-less task enters scope as a descendant of
+    its in-scope creator.
+    """
+    deps = build_dependencies(workflow.tasks, workflow.edges)
+    for task_id, creators in workflow.implicit_task_dependencies.items():
+        if task_id in deps:
+            deps[task_id] |= creators & deps.keys()
+    return deps
+
+
 async def run_schedule(workflow: BaseWorkflow, trigger_id: str) -> None:
     """
     Execute *workflow* from *trigger_id* with a concurrent ready-set
@@ -282,7 +300,7 @@ async def run_schedule(workflow: BaseWorkflow, trigger_id: str) -> None:
         # too, otherwise a task added after the loop started would compute
         # as "ready" below but be missing from a stale lookup.
         tasks_by_id = {task.id: task for task in workflow.tasks}
-        deps = build_dependencies(workflow.tasks, workflow.edges)
+        deps = _dependencies_with_implicit(workflow)
         scope = ancestors(trigger_id, deps) | descendants(trigger_id, deps)
 
         # Deterministic order when several tasks become ready at once,

--- a/src/horus_runtime/context.py
+++ b/src/horus_runtime/context.py
@@ -67,6 +67,7 @@ def running_task(task_id: str) -> Iterator[None]:
     finally:
         _current_task_id.reset(token)
 
+
 _runtime_ctx: ContextVar["HorusContext"] = ContextVar("horus_runtime_context")
 
 

--- a/src/horus_runtime/context.py
+++ b/src/horus_runtime/context.py
@@ -21,6 +21,8 @@ Runtime initialization, plugin loading, and global context management for
 horus-runtime.
 """
 
+from collections.abc import Iterator
+from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Union
@@ -34,6 +36,36 @@ from horus_runtime.registry.auto_registry import AutoRegistry
 
 if TYPE_CHECKING:
     from horus_runtime.core.workflow.base import BaseWorkflow
+
+_current_task_id: ContextVar[str | None] = ContextVar(
+    "horus_current_task_id", default=None
+)
+"""
+Id of the task currently executing in this (async) context, or ``None`` when
+no task is running. Set by :meth:`BaseTask.run` for the duration of a task's
+execution so code invoked from inside a task — notably the runtime DAG-mutation
+API (``BaseWorkflow.add_task``) — can discover which task created it and gate
+the new task behind that creator. Being a :class:`~contextvars.ContextVar`, it
+is naturally isolated per concurrently running task.
+"""
+
+
+def current_task_id() -> str | None:
+    """Return the id of the task running in the current context, if any."""
+    return _current_task_id.get()
+
+
+@contextmanager
+def running_task(task_id: str) -> Iterator[None]:
+    """
+    Mark *task_id* as the task executing in the current context for the
+    duration of the ``with`` block, restoring the previous value on exit.
+    """
+    token = _current_task_id.set(task_id)
+    try:
+        yield
+    finally:
+        _current_task_id.reset(token)
 
 _runtime_ctx: ContextVar["HorusContext"] = ContextVar("horus_runtime_context")
 

--- a/src/horus_runtime/core/task/base.py
+++ b/src/horus_runtime/core/task/base.py
@@ -29,7 +29,7 @@ from typing import TYPE_CHECKING, ClassVar, Self, final
 from pydantic import Field, model_validator
 
 from horus_builtin.event.task_event import HorusTaskEvent
-from horus_runtime.context import HorusContext
+from horus_runtime.context import HorusContext, running_task
 from horus_runtime.core.artifact.base import BaseArtifact
 from horus_runtime.core.executor.base import BaseExecutor
 from horus_runtime.core.executor.exceptions import IncompatibleRuntimeError
@@ -237,50 +237,57 @@ class BaseTask(AutoRegistry, entry_point="task"):
         - ``FAILED``    — set on any other exception (re-raised after)
         """
         ctx = HorusContext.get_context()
-        if self.skip_if_complete and await self.is_complete():
-            ctx.bus.emit(
-                HorusTaskEvent(
-                    message=_("Skipping task %(task_name)s. Already complete.")
-                    % {"task_name": self.name},
-                    task_id=self.id,
-                    task_name=self.name,
+        # Publish this task as the "current task" for the duration of its
+        # execution so code it invokes (notably ``BaseWorkflow.add_task``) can
+        # discover its creator and gate any runtime-added task behind it.
+        with running_task(self.id):
+            if self.skip_if_complete and await self.is_complete():
+                ctx.bus.emit(
+                    HorusTaskEvent(
+                        message=_(
+                            "Skipping task %(task_name)s. Already complete."
+                        )
+                        % {"task_name": self.name},
+                        task_id=self.id,
+                        task_name=self.name,
+                    )
                 )
-            )
-            self.status = TaskStatus.SKIPPED
+                self.status = TaskStatus.SKIPPED
+                horus_logger.log.debug(
+                    _("Task %(task_name)s status → SKIPPED")
+                    % {"task_name": self.name}
+                )
+                return
+            self.status = TaskStatus.RUNNING
             horus_logger.log.debug(
-                _("Task %(task_name)s status → SKIPPED")
+                _("Task %(task_name)s status → RUNNING")
                 % {"task_name": self.name}
             )
-            return
-        self.status = TaskStatus.RUNNING
-        horus_logger.log.debug(
-            _("Task %(task_name)s status → RUNNING") % {"task_name": self.name}
-        )
-        try:
-            await TaskMiddleware.call_with_middleware(
-                TaskMiddlewareContext(task=self),
-                self._run,
-            )
-        except CancelledError:
-            self.status = TaskStatus.CANCELED
-            horus_logger.log.debug(
-                _("Task %(task_name)s status → CANCELED")
-                % {"task_name": self.name}
-            )
-            raise
-        except Exception:
-            self.status = TaskStatus.FAILED
-            horus_logger.log.debug(
-                _("Task %(task_name)s status → FAILED")
-                % {"task_name": self.name}
-            )
-            raise
-        else:
-            self.status = TaskStatus.COMPLETED
-            horus_logger.log.debug(
-                _("Task %(task_name)s status → COMPLETED")
-                % {"task_name": self.name}
-            )
+            try:
+                await TaskMiddleware.call_with_middleware(
+                    TaskMiddlewareContext(task=self),
+                    self._run,
+                )
+            except CancelledError:
+                self.status = TaskStatus.CANCELED
+                horus_logger.log.debug(
+                    _("Task %(task_name)s status → CANCELED")
+                    % {"task_name": self.name}
+                )
+                raise
+            except Exception:
+                self.status = TaskStatus.FAILED
+                horus_logger.log.debug(
+                    _("Task %(task_name)s status → FAILED")
+                    % {"task_name": self.name}
+                )
+                raise
+            else:
+                self.status = TaskStatus.COMPLETED
+                horus_logger.log.debug(
+                    _("Task %(task_name)s status → COMPLETED")
+                    % {"task_name": self.name}
+                )
 
     async def sync_status(self) -> TaskStatus:
         """

--- a/src/horus_runtime/core/workflow/base.py
+++ b/src/horus_runtime/core/workflow/base.py
@@ -52,7 +52,7 @@ from horus_builtin.workflow.loop import (
     lower_loop_entry,
 )
 from horus_builtin.workflow.map import MapExpander, lower_map_entry, map_task
-from horus_runtime.context import HorusContext
+from horus_runtime.context import HorusContext, current_task_id
 from horus_runtime.core.artifact.base import BaseArtifact
 from horus_runtime.core.placement import ResourceCapacity
 from horus_runtime.core.target.base import BaseTarget
@@ -212,6 +212,21 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
     it, artifact paths and logs). Set to the workflow YAML's folder by
     :meth:`from_yaml`; ``None`` for programmatically-built workflows, which
     fall back to the process CWD. Runtime-only state, not serialized.
+    """
+
+    _implicit_task_deps: dict[str, set[str]] = PrivateAttr(
+        default_factory=dict
+    )
+    """
+    Runtime-only ordering dependencies not expressed by any edge:
+    ``new_task_id -> {creator_task_id}``. Populated when
+    :meth:`add_task`/:meth:`expand` is called from inside a running task and
+    the new task has no incoming task edge of its own — it is gated behind its
+    creator so a task generated mid-run (e.g. by a ``plan`` step expanding the
+    DAG) runs after the step that created it, without the caller having to
+    invent a placeholder edge. Merged into the scheduler's dependency map
+    (see :func:`horus_builtin.workflow.scheduler.run_schedule`) alongside the
+    edge-derived deps. Never serialized.
     """
 
     _revision: int = PrivateAttr(default=0)
@@ -504,6 +519,49 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
     # every loop iteration, so a mutation applied while a task is running
     # takes effect on the next iteration with no further plumbing.
 
+    @property
+    def implicit_task_dependencies(self) -> dict[str, set[str]]:
+        """
+        A copy of the runtime-only ``new_task_id -> {creator_task_id}``
+        ordering dependencies (see :attr:`_implicit_task_deps`). The scheduler
+        folds these into its edge-derived dependency map every loop iteration.
+        """
+        return {
+            task_id: set(creators)
+            for task_id, creators in self._implicit_task_deps.items()
+        }
+
+    def _gate_new_tasks_behind_creator(self, new_task_ids: set[str]) -> None:
+        """
+        Record an implicit ordering dependency from each brand-new task with
+        no incoming task edge onto the task that created it (the task running
+        in the current context, if any).
+
+        This is what makes a task added mid-run reachable: the scheduler's
+        scope is ``ancestors(trigger) | descendants(trigger)``, so a task with
+        no path back to the trigger would never run. Gating it behind its
+        creator — which is itself in scope — makes it a descendant and orders
+        it strictly after the creator completes.
+
+        A no-op outside a running task (static, construction-time building is
+        unchanged) and for any new task that already has an incoming task edge
+        (e.g. map/loop clones wired to their source), which is already ordered
+        by that edge and must not be forced behind the expander instead.
+        """
+        creator = current_task_id()
+        if creator is None:
+            return
+        # Task ids that are already the target of a task -> task edge: those
+        # are ordered by an explicit edge and need no implicit gating.
+        task_ids = {task.id for task in self.tasks}
+        wired_targets = {
+            edge.target for edge in self.edges if edge.source in task_ids
+        }
+        for task_id in new_task_ids:
+            if task_id == creator or task_id in wired_targets:
+                continue
+            self._implicit_task_deps.setdefault(task_id, set()).add(creator)
+
     def add_artifact(self, artifact: BaseArtifact) -> None:
         """
         Add a standalone root artifact to the live workflow.
@@ -556,6 +614,7 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
 
         self.tasks.append(task)
         self._anchor_task(task)
+        self._gate_new_tasks_behind_creator({task.id})
         self._revision += 1
 
     def add_edge(self, edge: WorkflowEdge) -> None:
@@ -702,6 +761,10 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
         self.edges.extend(new_edges)
         for task in new_tasks:
             self._anchor_task(task)
+        # Runs after edges are appended so a new task wired by one of the
+        # batch's own edges (e.g. a map/loop clone, or a fan-in join fed by
+        # its producers) is recognised as already-ordered and left ungated.
+        self._gate_new_tasks_behind_creator({task.id for task in new_tasks})
         self._revision += 1
 
     @classmethod

--- a/tests/unit/workflow/test_dynamic_mutation.py
+++ b/tests/unit/workflow/test_dynamic_mutation.py
@@ -37,7 +37,7 @@ from horus_builtin.task.function import FunctionTask
 from horus_builtin.task.horus_task import HorusTask
 from horus_builtin.workflow.dag import CyclicDependencyError
 from horus_builtin.workflow.horus_workflow import HorusWorkflow
-from horus_runtime.context import HorusContext
+from horus_runtime.context import HorusContext, running_task
 from horus_runtime.core.artifact.base import BaseArtifact
 from horus_runtime.core.task.base import BaseTask
 from horus_runtime.core.task.status import TaskStatus
@@ -344,6 +344,54 @@ class TestExpand:
 
 
 @pytest.mark.unit
+class TestImplicitCreatorGating:
+    """
+    A task added mid-run with no incoming edge is gated behind the task that
+    created it, so it enters the scheduler's scope and runs afterwards. A task
+    added with an edge (or outside any running task) is left ungated.
+    """
+
+    def test_edgeless_add_task_inside_running_task_is_gated(self) -> None:
+        """add_task from inside a running task records creator -> new dep."""
+        wf = HorusWorkflow(name="wf", tasks=[_task("creator")])
+
+        with running_task("creator"):
+            wf.add_task(_task("child"))
+
+        assert wf.implicit_task_dependencies == {"child": {"creator"}}
+
+    def test_add_task_outside_a_running_task_is_not_gated(self) -> None:
+        """Static, construction-time add_task records no implicit dep."""
+        wf = HorusWorkflow(name="wf", tasks=[_task("t1")])
+
+        wf.add_task(_task("t2"))
+
+        assert wf.implicit_task_dependencies == {}
+
+    def test_task_wired_by_own_edge_is_not_gated(self, tmp_path: Path) -> None:
+        """
+        A new task that already has an incoming task edge (e.g. a map/loop
+        clone, or a fan-in join) is ordered by that edge and must not also be
+        forced behind the creator.
+        """
+        producer = _task(
+            "producer",
+            outputs=[FileArtifact(id="out", path=tmp_path / "out.txt")],
+        )
+        wf = HorusWorkflow(name="wf", tasks=[producer])
+
+        consumer = _task(
+            "consumer",
+            inputs=[FileArtifact(id="in", path=tmp_path / "in.txt")],
+        )
+        edge = _edge("producer", "out", "consumer", "in")
+        with running_task("producer"):
+            wf.expand(tasks=[consumer], edges=[edge])
+
+        assert wf.implicit_task_dependencies == {}
+
+
+@pytest.mark.unit
 class TestTaskWorkflowProperty:
     """BaseTask.workflow reaches the live workflow via HorusContext."""
 
@@ -422,3 +470,57 @@ class TestDynamicMutationEndToEnd:
         marker_path = (tmp_path / "marker.txt").resolve()
         assert marker_path.exists()
         assert marker_path.read_text() == "HELLO"
+
+    async def test_edgeless_injected_task_runs_after_its_creator(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """
+        A trigger injects a downstream task with **no** edge back to itself
+        (the programmatic dynamic-DAG pattern: the task is generated during the
+        trigger's own body, so it can only run afterwards). The scheduler gates
+        it behind its creator, dispatches it, and it reaches COMPLETED.
+        """
+        del horus_context
+
+        def downstream_fn(marker: FileArtifact) -> None:
+            marker.path.write_text("ran")
+
+        def trigger_fn(task: BaseTask, out: FileArtifact) -> None:
+            out.path.write_text("hello")
+
+            wf = task.workflow
+            assert wf is not None
+
+            downstream = FunctionTask(
+                id="downstream",
+                name="downstream",
+                runtime=PythonFunctionRuntime(func=downstream_fn),
+                outputs=[FileArtifact(id="marker", path=Path("marker.txt"))],
+            )
+            # No add_edge: the task is edge-less and only reachable because it
+            # is gated behind the trigger that created it.
+            wf.add_task(downstream)
+
+        trigger = FunctionTask(
+            id="trigger",
+            name="trigger",
+            runtime=PythonFunctionRuntime(func=trigger_fn),
+            outputs=[FileArtifact(id="out", path=Path("trigger_out.txt"))],
+        )
+
+        wf = HorusWorkflow(
+            name="dynamic-edgeless",
+            tasks=[trigger],
+            orchestrator_target=LocalTarget(
+                working_directory=tmp_path.as_posix()
+            ),
+        )
+
+        await wf.run(trigger_id="trigger")
+
+        assert wf.status.value == "completed"
+        assert wf.implicit_task_dependencies == {"downstream": {"trigger"}}
+
+        downstream_task = next(t for t in wf.tasks if t.id == "downstream")
+        assert downstream_task.status == TaskStatus.COMPLETED
+        assert (tmp_path / "marker.txt").resolve().read_text() == "ran"


### PR DESCRIPTION
## Problem

A task added to a running workflow via `BaseWorkflow.add_task`/`expand` **with no incoming edge** was silently never executed. The scheduler's scope is `ancestors(trigger) | descendants(trigger)`, so a task disconnected from the trigger stays out of scope — even though it was created *during* another task's execution and therefore can only run afterwards.

This is the exact failure mode of the programmatic dynamic-DAG pattern (a `plan` step that reads data and generates one `process_<group>` task per group): the generated tasks were added but never ran, and the workflow reported "completed" after only the `plan` task.

## Fix

Gate a runtime-added, edge-less task behind the task that created it:

- **`context.py`** — a `running_task(task_id)` context manager + `current_task_id()` accessor backed by a `ContextVar` (naturally isolated per concurrent task).
- **`BaseTask.run`** — publishes the running task's id for the duration of its execution, so code it invokes (notably `add_task`) can discover its creator.
- **`BaseWorkflow.add_task`/`expand`** — record an implicit `new_task -> creator` ordering dependency for any new task that has **no incoming task edge**. Tasks already wired by their own edge (map/loop clones, fan-in joins) are left untouched; static construction-time `add_task` (no running task) is unchanged.
- **`scheduler.py`** — folds the implicit deps into the edge-derived dependency map each loop, *before* scope is computed, so the new task enters scope as a descendant of its in-scope creator and runs once the creator completes.

## Also

- **`JSONArtifact.write`** now creates parent directories, so a task can write an output into a not-yet-existing folder without a manual `mkdir`.

## Tests

Added to `tests/unit/workflow/test_dynamic_mutation.py`:
- `TestImplicitCreatorGating` — implicit dep is recorded for an edge-less `add_task` inside a running task; **not** recorded for static `add_task` or for a task wired by its own edge.
- `test_edgeless_injected_task_runs_after_its_creator` — end-to-end: a trigger injects a downstream task with no edge; it is dispatched and reaches `COMPLETED`.

Full unit suite (521 tests) passes; ruff and mypy clean. Verified end-to-end against the `w02-programmatic-dynamic-dag` showcase (edge-less `add_task` pattern now runs all generated tasks).