### PR TITLE
feat(workflow): artifact-less ordering edges and auto-created output dirs

### DIFF
--- a/src/horus_runtime/core/executor/base.py
+++ b/src/horus_runtime/core/executor/base.py
@@ -104,6 +104,14 @@ class BaseExecutor(AutoRegistry, entry_point="executor"):
         # code works on both local and remote targets (M2.3).
         await task.target.mkdir(task.side_artifacts_dir)
 
+        # Declared outputs are written by the task itself (a shell command
+        # redirecting to ${artifact} never goes through Artifact.write), so
+        # their directory must exist beforehand. Only the *parent*: creating a
+        # FolderArtifact's own path would make it exist() and the task would
+        # skip itself forever.
+        for artifact in task.outputs:
+            await task.target.mkdir(str(artifact.path.parent))
+
         try:
             await ExecutorMiddleware.call_with_middleware(
                 ExecutorMiddlewareContext(executor=self, task=task),

--- a/src/horus_runtime/core/workflow/base.py
+++ b/src/horus_runtime/core/workflow/base.py
@@ -434,9 +434,14 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
         Raise :exc:`UnknownEdgeEndpointError` unless *edge* targets a real
         task and one of its declared input ids. Shared by
         :meth:`check_edges_resolve`, :meth:`add_edge`, and :meth:`expand`.
+
+        An edge naming no artifacts only has to target a real task: it exists
+        to order tasks that may declare no inputs at all.
         """
         if edge.target not in task_inputs:
             raise UnknownEdgeEndpointError("target task", edge.target)
+        if edge.target_input is None:
+            return
         if edge.target_input not in task_inputs[edge.target]:
             raise UnknownEdgeEndpointError("target input", edge.target_input)
 
@@ -451,16 +456,27 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
         task output, or a root artifact via the ``artifact-<rootId>``
         convention. Shared by :meth:`check_edges_resolve`, :meth:`add_edge`,
         and :meth:`expand`.
+
+        An edge naming no artifacts only has to source a real task: it exists
+        to order tasks that may declare no outputs at all. A root artifact is
+        not a task and so has nothing to order against, which leaves it
+        rejected by the final branch.
         """
         if edge.source in task_outputs:
-            if edge.source_output not in task_outputs[edge.source]:
+            if (
+                edge.source_output is not None
+                and edge.source_output not in task_outputs[edge.source]
+            ):
                 raise UnknownEdgeEndpointError(
                     "source output", edge.source_output
                 )
         elif edge.source.startswith("artifact-"):
-            if edge.source_output not in root_ids:
+            if (
+                edge.source_output is None
+                or edge.source_output not in root_ids
+            ):
                 raise UnknownEdgeEndpointError(
-                    "root artifact", edge.source_output
+                    "root artifact", str(edge.source_output)
                 )
         else:
             raise UnknownEdgeEndpointError("source task", edge.source)
@@ -493,7 +509,9 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
 
             # At most one transfer edge may feed a given consumer input.
             # Ordering-only edges (transfer=False) are exempt.
-            if edge.transfer:
+            # (`target_input is not None` is implied by `transfer`, and is
+            # spelled out to narrow the type.)
+            if edge.transfer and edge.target_input is not None:
                 key = (edge.target, edge.target_input)
                 if key in seen_targets:
                     raise DuplicateEdgeTargetError(
@@ -641,11 +659,21 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
         root_ids = {a.id for a in self.artifacts}
 
         self._assert_edge_target_resolves(edge, task_inputs)
-        if any(
-            e.target == edge.target and e.target_input == edge.target_input
-            for e in self.edges
-        ):
-            raise DuplicateEdgeTargetError(edge.target, edge.target_input)
+
+        # At most one transfer edge may feed a given consumer input, exactly
+        # as in check_edges_resolve and expand: ordering-only edges never
+        # contribute a transfer source, so any number of them may pile onto
+        # the same input. (`target_input is not None` is implied by
+        # `transfer`, and is spelled out to narrow the type.)
+        if edge.transfer and edge.target_input is not None:
+            if any(
+                e.transfer
+                and e.target == edge.target
+                and e.target_input == edge.target_input
+                for e in self.edges
+            ):
+                raise DuplicateEdgeTargetError(edge.target, edge.target_input)
+
         self._assert_edge_source_resolves(edge, task_outputs, root_ids)
 
         if would_create_cycle(self.edges, edge, self.tasks):
@@ -738,7 +766,9 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
         for edge in new_edges:
             self._assert_edge_target_resolves(edge, task_inputs)
 
-            if edge.transfer:
+            # (`target_input is not None` is implied by `transfer`, and is
+            # spelled out to narrow the type.)
+            if edge.transfer and edge.target_input is not None:
                 key = (edge.target, edge.target_input)
                 if key in seen_targets:
                     raise DuplicateEdgeTargetError(
@@ -827,7 +857,13 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
 
         source_map: dict[tuple[str, str], _EdgeSource] = {}
         for edge in self.edges:
-            if not edge.transfer:
+            # (The id checks are implied by `transfer`, and are spelled out to
+            # narrow the types for the key and lookups below.)
+            if (
+                not edge.transfer
+                or edge.target_input is None
+                or edge.source_output is None
+            ):
                 continue
             key = (edge.target, edge.target_input)
             producer_target = targets_by_task.get(edge.source)

--- a/src/horus_runtime/core/workflow/edge.py
+++ b/src/horus_runtime/core/workflow/edge.py
@@ -19,9 +19,16 @@
 Explicit connection between a producer's output artifact and a consumer's
 input artifact. Edges are the source of truth for the workflow DAG: a
 ``source`` task must complete before its ``target`` task.
+
+Omitting both artifact ids makes the edge purely ordering: it needs no
+artifact on either end, so it can order tasks that declare none.
 """
 
-from pydantic import BaseModel
+from typing import Self
+
+from pydantic import BaseModel, model_validator
+
+from horus_runtime.core.workflow.exceptions import IncompleteEdgeError
 
 
 class WorkflowEdge(BaseModel):
@@ -33,14 +40,20 @@ class WorkflowEdge(BaseModel):
     source: str
     """Producer task id, or ``artifact-<rootId>`` for a root source."""
 
-    source_output: str
-    """Output artifact id on the source (or the root artifact's id)."""
+    source_output: str | None = None
+    """
+    Output artifact id on the source (or the root artifact's id). ``None``
+    only on an artifact-less ordering edge (see ``transfer``).
+    """
 
     target: str
     """Consumer task id."""
 
-    target_input: str
-    """Input artifact id on the consumer task."""
+    target_input: str | None = None
+    """
+    Input artifact id on the consumer task. ``None`` only on an artifact-less
+    ordering edge (see ``transfer``).
+    """
 
     transfer: bool = True
     """
@@ -53,4 +66,26 @@ class WorkflowEdge(BaseModel):
     one ordering-only edge alongside a single ``transfer=True`` edge) may all
     feed the same input. This is what lets many producers order-gate one
     consumer whose actual data input is, say, a folder populated out of band.
+
+    Forced to ``False`` when the edge names no artifacts at all: there is
+    then nothing to carry. Such an edge orders two tasks that need declare no
+    inputs or outputs, which ``transfer=False`` alone cannot express (it still
+    requires both ids to name declared artifacts).
     """
+
+    @model_validator(mode="after")
+    def check_endpoints_agree(self) -> Self:
+        """
+        Both artifact ids or neither, and an edge naming none cannot transfer.
+
+        A half-specified edge is a typo: letting it through would silently
+        downgrade a data edge to an ordering one. Forcing ``transfer=False``
+        when both ids are absent keeps ``transfer`` the single question every
+        consumer already asks ("does this edge carry data?"), so nothing
+        downstream needs to re-derive it from the ids.
+        """
+        if (self.source_output is None) != (self.target_input is None):
+            raise IncompleteEdgeError(self.source, self.target)
+        if self.target_input is None:
+            self.transfer = False
+        return self

--- a/src/horus_runtime/core/workflow/exceptions.py
+++ b/src/horus_runtime/core/workflow/exceptions.py
@@ -95,6 +95,25 @@ class UnknownEdgeEndpointError(WorkflowError):
         )
 
 
+class IncompleteEdgeError(WorkflowError):
+    """
+    Raised when an edge names one endpoint artifact id but not the other. An
+    edge either names both (it may carry data) or neither (it only orders its
+    two tasks); anything in between is a typo that would silently drop a
+    transfer.
+    """
+
+    def __init__(self, source: str, target: str):
+        super().__init__(
+            _(
+                "Edge '%(source)s' -> '%(target)s' names only one of "
+                "'source_output' and 'target_input'. Name both to connect two "
+                "artifacts, or neither to only order the two tasks."
+            )
+            % {"source": source, "target": target}
+        )
+
+
 class DuplicateEdgeTargetError(WorkflowError):
     """
     Raised when two edges feed the same consumer input. A single input can be

--- a/tests/unit/executor/test_executor_base.py
+++ b/tests/unit/executor/test_executor_base.py
@@ -21,13 +21,22 @@ Unit tests for BaseExecutor class.
 
 import inspect
 from abc import ABC
+from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar, Union
 
 import pytest
 from pydantic import BaseModel, ValidationError
 
+from horus_builtin.artifact.file import FileArtifact
+from horus_builtin.artifact.folder import FolderArtifact
+from horus_builtin.executor.shell import ShellExecutor
+from horus_builtin.runtime.command import CommandRuntime
+from horus_builtin.target.local import LocalTarget
+from horus_builtin.task.horus_task import HorusTask
+from horus_runtime.core.artifact.base import BaseArtifact
 from horus_runtime.core.executor.base import BaseExecutor
 from horus_runtime.core.task.exceptions import TaskExecutionError
+from horus_runtime.core.task.status import TaskStatus
 from horus_runtime.registry.auto_registry import (
     AutoRegistry,
 )
@@ -221,3 +230,58 @@ class TestBaseExecutorValidation:
 
             # This should fail because execute method is not implemented
             IncompleteExecutor()  # type: ignore
+
+
+@pytest.mark.unit
+class TestOutputDirectoriesAreCreated:
+    """
+    ``BaseExecutor.execute`` creates each declared output's parent directory,
+    so tasks never need a mkdir step of their own.
+    """
+
+    def _task(
+        self, tmp_path: Path, cmd: str, outputs: list[BaseArtifact]
+    ) -> HorusTask:
+        return HorusTask(
+            id="writer",
+            name="writer",
+            outputs=outputs,
+            runtime=CommandRuntime(command=cmd),
+            executor=ShellExecutor(),
+            target=LocalTarget(working_directory=tmp_path.as_posix()),
+        )
+
+    @pytest.mark.usefixtures("horus_context")
+    async def test_missing_output_dir_is_created(self, tmp_path: Path) -> None:
+        """A task writing into a non-existent directory succeeds anyway."""
+        out = tmp_path / "results" / "nested" / "out.txt"
+        task = self._task(
+            tmp_path,
+            f"echo hi > {out}",
+            [FileArtifact(id="out", path=out)],
+        )
+
+        await task.run()
+
+        assert out.exists()
+        assert task.status is TaskStatus.COMPLETED
+
+    @pytest.mark.usefixtures("horus_context")
+    async def test_folder_output_path_itself_is_not_created(
+        self, tmp_path: Path
+    ) -> None:
+        """
+        Only the *parent* is created. A FolderArtifact reports exists() for any
+        directory, so pre-creating its own path would make the task look
+        complete and skip forever.
+        """
+        out = tmp_path / "results" / "bundle"
+        task = self._task(
+            tmp_path, "true", [FolderArtifact(id="out", path=out)]
+        )
+
+        await task.executor.execute(task)
+
+        assert out.parent.is_dir()
+        assert not out.exists()
+        assert not await task.is_complete()

--- a/tests/unit/workflow/test_edges.py
+++ b/tests/unit/workflow/test_edges.py
@@ -46,6 +46,7 @@ from horus_runtime.core.workflow.edge import WorkflowEdge
 from horus_runtime.core.workflow.exceptions import (
     ArtifactIdsAreNotUniqueError,
     DuplicateEdgeTargetError,
+    IncompleteEdgeError,
     UnknownEdgeEndpointError,
 )
 
@@ -582,3 +583,144 @@ class TestOrderingOnlyEdges:
                     _edge("p2", "o2", "c", "in", transfer=True),
                 ],
             )
+
+
+@pytest.mark.unit
+class TestArtifactLessOrderingEdges:
+    """
+    An edge naming no artifacts orders two tasks that need declare none.
+    ``transfer=False`` alone cannot express this: it still requires both ids
+    to name declared artifacts.
+    """
+
+    def _pair(self, tmp_path: Path) -> tuple[HorusTask, HorusTask]:
+        """A producer, and a task declaring no inputs and no outputs."""
+        producer = _task(
+            task_id="prep",
+            inputs=[],
+            outputs=[FileArtifact(id="out", path=tmp_path / "p.txt")],
+        )
+        bare = _task(task_id="cleanup", inputs=[], outputs=[])
+        return producer, bare
+
+    def test_orders_a_task_that_declares_no_artifacts(
+        self, tmp_path: Path
+    ) -> None:
+        """The case transfer=False cannot express: nothing to name."""
+        producer, bare = self._pair(tmp_path)
+        edges = [WorkflowEdge(source="prep", target="cleanup")]
+        wf = HorusWorkflow(
+            name="ordering", tasks=[bare, producer], edges=edges
+        )
+        plan = execution_plan(wf.tasks, trigger_id="prep", edges=wf.edges)
+        assert plan == ["prep", "cleanup"]
+
+    def test_naming_no_artifacts_forces_transfer_false(self) -> None:
+        """
+        An edge with nothing to carry cannot be a transfer edge, so every
+        downstream `if edge.transfer` check answers correctly without having
+        to re-derive it from the ids.
+        """
+        edge = WorkflowEdge(source="prep", target="cleanup")
+        assert edge.transfer is False
+        # Even when the default is overridden: there is still nothing to move.
+        assert (
+            WorkflowEdge(
+                source="prep", target="cleanup", transfer=True
+            ).transfer
+            is False
+        )
+
+    def test_contributes_no_transfer_source(self, tmp_path: Path) -> None:
+        """It feeds no input, so it adds no entry to the source map."""
+        producer, bare = self._pair(tmp_path)
+        wf = HorusWorkflow(
+            name="ordering",
+            tasks=[producer, bare],
+            edges=[WorkflowEdge(source="prep", target="cleanup")],
+        )
+        assert wf._build_source_map() == {}
+
+    def test_many_into_one_task_allowed(self, tmp_path: Path) -> None:
+        """
+        Several may gate one task: the one-edge-per-input rule is about
+        inputs, and these have none.
+        """
+        a = _task(
+            task_id="a",
+            inputs=[],
+            outputs=[FileArtifact(id="o", path=tmp_path / "a.txt")],
+        )
+        b = _task(
+            task_id="b",
+            inputs=[],
+            outputs=[FileArtifact(id="o", path=tmp_path / "b.txt")],
+        )
+        last = _task(task_id="last", inputs=[], outputs=[])
+        wf = HorusWorkflow(
+            name="fan_in",
+            tasks=[last, a, b],
+            edges=[
+                WorkflowEdge(source="a", target="last"),
+                WorkflowEdge(source="b", target="last"),
+            ],
+        )
+        # Triggered from "last" so both predecessors are in scope as ancestors.
+        plan = execution_plan(wf.tasks, trigger_id="last", edges=wf.edges)
+        assert plan.index("last") > plan.index("a")
+        assert plan.index("last") > plan.index("b")
+
+    def test_add_edge_accepts_many_into_one_task(self, tmp_path: Path) -> None:
+        """
+        add_edge must agree with the constructor: it applies the duplicate
+        rule only to transfer edges.
+        """
+        a = _task(
+            task_id="a",
+            inputs=[],
+            outputs=[FileArtifact(id="o", path=tmp_path / "a.txt")],
+        )
+        b = _task(
+            task_id="b",
+            inputs=[],
+            outputs=[FileArtifact(id="o", path=tmp_path / "b.txt")],
+        )
+        last = _task(task_id="last", inputs=[], outputs=[])
+        wf = HorusWorkflow(
+            name="fan_in",
+            tasks=[a, b, last],
+            edges=[WorkflowEdge(source="a", target="last")],
+        )
+        wf.add_edge(WorkflowEdge(source="b", target="last"))
+        assert len(wf.edges) == 2
+
+    def test_unknown_task_still_rejected(self, tmp_path: Path) -> None:
+        """Dropping the ids does not drop endpoint validation."""
+        producer, bare = self._pair(tmp_path)
+        with pytest.raises(UnknownEdgeEndpointError):
+            HorusWorkflow(
+                name="bad",
+                tasks=[producer, bare],
+                edges=[WorkflowEdge(source="prep", target="ghost")],
+            )
+
+    def test_root_artifact_source_rejected(self, tmp_path: Path) -> None:
+        """A root artifact is not a task: nothing to order against."""
+        _, bare = self._pair(tmp_path)
+        with pytest.raises(UnknownEdgeEndpointError):
+            HorusWorkflow(
+                name="bad",
+                tasks=[bare],
+                artifacts=[FileArtifact(id="root", path=tmp_path / "r.txt")],
+                edges=[WorkflowEdge(source="artifact-root", target="cleanup")],
+            )
+
+    def test_half_named_edge_raises(self) -> None:
+        """
+        One id without the other is a typo, not an ordering edge: it must not
+        silently stop transferring.
+        """
+        with pytest.raises(IncompleteEdgeError):
+            WorkflowEdge(source="a", source_output="o", target="b")
+        with pytest.raises(IncompleteEdgeError):
+            WorkflowEdge(source="a", target="b", target_input="in")


### PR DESCRIPTION
Rebased onto current `main`. The original version of this PR was cut from a stale
checkout and reimplemented ordering-only edges from scratch, unaware of #117. It now
builds on #117's `transfer` flag instead of competing with it.

## 1. Output directories are created automatically

Nothing pre-creates the parent directory of a declared output. `FileArtifact.write` and
`JSONArtifact.write` (#125) mkdir their own parent, but a shell/command task writing to
`${artifact}` never goes through `write()` — so a workflow declaring
`path: results/out.tar.gz` fails until a task makes `results/` itself. Verified still
broken on `main` today:

```
RESULT: task FAILED -> TaskExecutionError  Shell command exited with return code 1
```

`BaseExecutor.execute` now creates each output's parent via `task.target.mkdir`, next to
the existing side-artifacts mkdir, so it works on local and remote targets alike.
`ArtifactStore` has no mkdir-for-artifact operation and `execute()` still calls
`task.target.mkdir` directly for side artifacts, so this stays consistent with its
neighbour.

Parent only, deliberately: `FolderArtifact.exists()` is true for any directory and
`is_complete()` treats output existence as completion, so creating a folder output's own
path would make that task skip itself forever. A test pins that.

## 2. Ordering edges that name no artifacts

`transfer=False` (#117) stops the data moving but still requires `source_output` and
`target_input` to resolve to declared artifacts. So it cannot order a task that declares
none — the "just run cleanup last" case. On current `main`:

```
ordering edge into input-less task: REJECTED -> UnknownEdgeEndpointError
    Workflow edge references unknown target input '???'
```

Both ids are now optional. Name both to connect two artifacts, or neither to only order
the two tasks:

```yaml
edges:
  - source: prep
    target: cleanup     # cleanup declares no inputs and no outputs
```

Naming neither **forces `transfer=False`** — there is nothing to carry — so every
existing `if edge.transfer` check keeps answering correctly and neither
`_build_source_map` nor the duplicate-target rule needed new logic. Naming exactly one
raises the new `IncompleteEdgeError`, so a typo cannot silently downgrade a data edge
into an ordering one. `build_dependencies` was already keyed only off `source`/`target`
and is untouched.

## 3. Drive-by fix: `add_edge` disagreed with the constructor

`add_edge` applied the one-edge-per-input rule to *every* edge, while
`check_edges_resolve` and `expand` both exempt ordering-only ones. So this was rejected
imperatively but allowed declaratively:

```
constructor : ALLOWED (as documented)
add_edge    : REJECTED -> DuplicateEdgeTargetError  <-- inconsistent
```

Pre-existing on `main` and independent of this PR, but directly in the path — my
artifact-less edges hit it too, since `None == None`. `add_edge` now filters on
`e.transfer` like the other two.

## Testing

- 531 unit tests pass. New cases live in #117's own `TestOrderingOnlyEdges` neighbourhood
  and in `test_executor_base.py`.
- Both output-dir tests confirmed to fail with the fix reverted.
- End-to-end through `horus run` against this branch: a task writing to a non-existent
  `results/deep/nested/` succeeds with the chain created under the run directory, and an
  artifact-less edge orders a no-artifact `cleanup` task after `prep`.

## Documentation impact

If a user, plugin, or GUI can observe the difference, it requires documentation.

- [ ] No documentation update required
- [x] Documentation updated / will be updated

The docs already cover `transfer=false`. Still needed: the optional-id form, the
auto-created output dirs, and removing the `mkdir -p "$$(dirname $raw)"` workaround from
the `pipeline.yaml` example in `writing-workflows-yaml.mdx` — it currently teaches the
workaround this PR removes.

**horus-docs PR:** ⬇️

https://github.com/temple-compute/horus-docs/pull/43
