### PR TITLE
feat(target): TargetCommandMiddleware hook

### DIFF
--- a/src/horus_runtime/core/target/base.py
+++ b/src/horus_runtime/core/target/base.py
@@ -43,6 +43,10 @@ from horus_runtime.middleware.target import (
     TargetMiddleware,
     TargetMiddlewareContext,
 )
+from horus_runtime.middleware.target_command import (
+    TargetCommandMiddleware,
+    TargetCommandMiddlewareContext,
+)
 from horus_runtime.registry.auto_registry import AutoRegistry
 
 if TYPE_CHECKING:
@@ -285,13 +289,40 @@ class BaseTarget(AutoRegistry, entry_point="target"):
     ) -> ChannelProcess:
         """
         Run *cmd* on the target and return a :class:`.ChannelProcess` handle.
+
+        The command is routed through the ``TargetCommandMiddleware`` chain
+        first, so middleware may rewrite it (e.g. wrap it in an instrumentation
+        tool) before it is dispatched.
         """
+        ctx = TargetCommandMiddlewareContext(
+            target=self,
+            command=cmd,
+            cwd=cwd,
+            env=env,
+            detach=detach,
+        )
+        return await TargetCommandMiddleware.call_with_middleware(
+            ctx,
+            lambda: self._run_command(ctx),
+        )
+
+    async def _run_command(
+        self, ctx: TargetCommandMiddlewareContext
+    ) -> ChannelProcess:
+        """
+        Dispatch the (possibly rewritten) command from *ctx* to the target.
+        """
+        detach = ctx.detach
         if detach is None:
             detach = self.detach_by_default
         if not detach:
-            return await self.run_command_sync(cmd, cwd=cwd, env=env)
-        job_dir = new_job_dir(cwd or self.resolved_working_directory)
-        handle = await self.launch(cmd, cwd=cwd, env=env, job_dir=job_dir)
+            return await self.run_command_sync(
+                ctx.command, cwd=ctx.cwd, env=ctx.env
+            )
+        job_dir = new_job_dir(ctx.cwd or self.resolved_working_directory)
+        handle = await self.launch(
+            ctx.command, cwd=ctx.cwd, env=ctx.env, job_dir=job_dir
+        )
         return PollingChannelProcess(self, handle)
 
     @abstractmethod

--- a/src/horus_runtime/middleware/target_command.py
+++ b/src/horus_runtime/middleware/target_command.py
@@ -1,0 +1,60 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Target command middleware system for the horus-runtime.
+
+Wraps :meth:`BaseTarget.run_command` so plugins can inspect or rewrite the
+command string before it is launched on the target host. The context is
+mutable: middleware set ``ctx.command`` in place and the rewritten value is
+what actually runs (locally or over a remote channel).
+"""
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from horus_runtime.middleware.auto_middleware import AutoMiddleware
+
+if TYPE_CHECKING:
+    from horus_runtime.core.target.base import BaseTarget
+
+
+@dataclass
+class TargetCommandMiddlewareContext:
+    """
+    Context passed to TargetCommandMiddleware.
+
+    ``command`` is mutable: middleware may rewrite it in place (e.g. to wrap
+    the command with an instrumentation tool) before it is dispatched.
+    """
+
+    target: "BaseTarget"
+    command: str
+    cwd: str | None
+    env: dict[str, str] | None
+    detach: bool | None
+
+
+class TargetCommandMiddleware(
+    AutoMiddleware[TargetCommandMiddlewareContext],
+    entry_point="target_command",
+):
+    """
+    Base class for target command middleware.
+    """
+
+    registry: list[type["TargetCommandMiddleware"]]

--- a/tests/unit/middleware/test_target_command.py
+++ b/tests/unit/middleware/test_target_command.py
@@ -1,0 +1,88 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Tests for the TargetCommandMiddleware domain: middleware may rewrite the
+command string before it is dispatched by ``BaseTarget.run_command``.
+"""
+
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+
+from horus_builtin.target.local import LocalTarget
+from horus_runtime.middleware.target_command import (
+    TargetCommandMiddleware,
+    TargetCommandMiddlewareContext,
+)
+
+
+@pytest.fixture
+def restore_target_command_registry() -> Generator[None]:
+    """
+    Restore the target-command middleware registry after each test.
+    """
+    original_registry = list(TargetCommandMiddleware.registry)
+    try:
+        yield
+    finally:
+        TargetCommandMiddleware.registry = original_registry
+
+
+@pytest.mark.unit
+class TestTargetCommandMiddleware:
+    """The command a target runs is the one middleware rewrote."""
+
+    async def test_middleware_rewrites_command(
+        self, tmp_path: Path, restore_target_command_registry: None
+    ) -> None:
+        """
+        A middleware that overwrites ``ctx.command`` changes what actually
+        runs on the target.
+        """
+        del restore_target_command_registry
+
+        class RewriteMiddleware(TargetCommandMiddleware):
+            """Replace whatever command is passed with a known marker."""
+
+            async def before(
+                self, context: TargetCommandMiddlewareContext
+            ) -> None:
+                context.command = "echo REWRITTEN"
+
+        # Defining the concrete subclass above auto-registers it into
+        # TargetCommandMiddleware.registry; the fixture restores it afterwards.
+
+        target = LocalTarget(working_directory=tmp_path.as_posix())
+        proc = await target.run_command("echo ORIGINAL")
+        stdout, _stderr = await proc.communicate()
+
+        assert b"REWRITTEN" in stdout
+        assert b"ORIGINAL" not in stdout
+
+    async def test_no_middleware_runs_command_unchanged(
+        self, tmp_path: Path
+    ) -> None:
+        """
+        With no command middleware registered the original command runs.
+        """
+        target = LocalTarget(working_directory=tmp_path.as_posix())
+        proc = await target.run_command("echo ORIGINAL")
+        stdout, _stderr = await proc.communicate()
+
+        assert b"ORIGINAL" in stdout


### PR DESCRIPTION
## Summary

- Adds `TargetCommandMiddlewareContext` (mutable dataclass holding `target`, `command`, `cwd`, `env`, `detach`) and `TargetCommandMiddleware` base class in `src/horus_runtime/middleware/target_command.py`
- Routes `BaseTarget.run_command` through the middleware chain before dispatch, splitting off `_run_command` as the inner implementation
- Adds unit tests in `tests/unit/middleware/test_target_command.py` covering command rewrite via middleware and passthrough with no middleware registered

Middleware may set `ctx.command` in place to rewrite the command before it runs on the target host. Required by horus-resource-monitor for transparent instrumentation.

## Test plan

- [ ] `uv run pytest tests/unit/middleware/test_target_command.py -v` — both tests pass
- [x] Full test suite passes
- [ ] Confirm a plugin subclassing `TargetCommandMiddleware` and registered under the `target_command` entry point is discovered and invoked by `run_command`

- [x] No documentation update required