### PR TITLE
fix(tui): render dashboard on alternate screen to stop flicker

### DIFF
--- a/src/horus_builtin/event/tui_subscriber.py
+++ b/src/horus_builtin/event/tui_subscriber.py
@@ -139,6 +139,10 @@ _SECONDS_PER_MINUTE = 60
 _LOG_LINES = 8
 _TRANSFER_LINGER_S = 2.0
 
+# Live refresh rate. The spinner advances at this same rate so its animation
+# can't beat against the frame rate.
+_REFRESH_HZ = 8
+
 
 class _LogLine(NamedTuple):
     """One rendered entry in the log/event pane."""
@@ -161,7 +165,8 @@ def _make_console() -> Console:
 
 def _spinner_frame() -> str:
     """Pick a spinner glyph from the wall clock (animates via Live refresh)."""
-    return _SPINNER_FRAMES[int(time.monotonic() * 10) % len(_SPINNER_FRAMES)]
+    tick = int(time.monotonic() * _REFRESH_HZ)
+    return _SPINNER_FRAMES[tick % len(_SPINNER_FRAMES)]
 
 
 def _fmt_duration(seconds: float | None) -> str:
@@ -280,6 +285,11 @@ class WorkflowTUISubscriber(BaseEventSubscriber):
     def live(self) -> Iterator[None]:
         """Drive the Rich ``Live`` dashboard for the ``with`` body.
 
+        Runs on the terminal's alternate screen (``screen=True``) so Rich
+        diffs frames into a dedicated buffer instead of erasing and repainting
+        scrollback lines, which is what made the display flicker as the
+        dashboard's height changed between frames.
+
         Redirects loguru's terminal sink into the log pane for the duration so
         log lines never corrupt the display, restoring it on exit.
         """
@@ -290,8 +300,9 @@ class WorkflowTUISubscriber(BaseEventSubscriber):
             with Live(
                 view,
                 console=self._console,
-                refresh_per_second=8,
+                refresh_per_second=_REFRESH_HZ,
                 transient=False,
+                screen=True,
             ) as live:
                 self._live = live
                 try:
@@ -301,11 +312,12 @@ class WorkflowTUISubscriber(BaseEventSubscriber):
                     raise
                 finally:
                     self._live = None
-                    # Final repaint so terminating statuses (and any error
-                    # panel) are shown before Live tears down.
-                    live.update(view)
         finally:
             horus_logger.restore_terminal()
+            # The alternate screen is gone by now, so leave a receipt of the
+            # final state behind in normal scrollback. Runs on the failure
+            # path too, so a crash still reports what happened.
+            self._console.print(self._render_summary())
 
     def handle(self, event: BaseEvent) -> None:
         """React to bus events: pause for interactions, feed the log pane."""
@@ -563,6 +575,40 @@ class WorkflowTUISubscriber(BaseEventSubscriber):
         return Panel(
             body, title=_("Failed"), border_style="red", padding=(0, 1)
         )
+
+    def _render_summary(self) -> RenderableType:
+        """One-line receipt of the final state, for normal scrollback.
+
+        The dashboard lives on the alternate screen and disappears when Live
+        tears down, so this is all the user is left with after a run.
+        """
+        workflow = self._workflow
+        if workflow is None:
+            return Text(_("No workflow ran."), style="dim")
+
+        scope = self._scope or {t.id for t in workflow.tasks}
+        tasks = [t for t in workflow.tasks if t.id in scope]
+        done = sum(1 for t in tasks if t.status in _TERMINAL)
+        elapsed = (
+            None
+            if self._started_at is None
+            else time.monotonic() - self._started_at
+        )
+        line = Text.assemble(
+            (workflow.name, "bold"),
+            ("  ·  ", "dim"),
+            (
+                workflow.status.value.upper(),
+                _WF_STATUS_STYLE.get(workflow.status, "white"),
+            ),
+            ("  ·  ", "dim"),
+            (f"{done}/{len(tasks)} " + _("tasks"), "dim"),
+            ("  ·  ", "dim"),
+            (_fmt_duration(elapsed), "dim"),
+        )
+        if self._error is None:
+            return line
+        return Group(line, self._render_error())
 
 
 def render_workflow(workflow: BaseWorkflow, trigger_id: str) -> None:


### PR DESCRIPTION
## Summary

The live workflow dashboard flickers — the screen goes black for a split
millisecond on refresh. Everything functions correctly; it just looks bad.

`Live` ran in inline mode, so each frame Rich moves the cursor up, erases the
previous N lines and repaints. The dashboard's height changes constantly
between frames:

- `_render_header` grows a line for 2s on every artifact transfer
- `_render_log` grows from 1 line toward `_LOG_LINES` as events arrive
- `_render_tree` grows as the DAG renders
- the error panel is appended conditionally

On larger workflows the frame also exceeds terminal height. Both conditions
push Rich out of in-place overwrite into a full reprint — the black flash.

### Changes

- `Live(screen=True)` — frames are diffed into the alternate screen buffer, so
  scrollback lines are never erased and height changes are free.
- New `_render_summary()` — the alt-screen buffer vanishes on teardown, so a
  one-line receipt (name · status · counts · elapsed, plus the error panel on
  failure) is printed to normal scrollback. Called from the outer `finally`, so
  a crashed run still reports what happened.
- Dropped the `live.update(view)` teardown repaint — it painted a buffer that
  was about to be torn down.
- `_REFRESH_HZ = 8` now drives both the spinner and `refresh_per_second`. The
  spinner advanced at 10Hz against an 8Hz sample rate, so it stuttered.

`_pause`/`_resume` around interaction prompts get better with this: `stop()`
drops to the normal screen for the prompt, `start()` re-enters, so prompts land
in real scrollback instead of competing with the dashboard for lines.

### Testing

- 533 unit tests pass; ruff and mypy clean.
- Drove `_render_summary()` across all four branches (no workflow / partial /
  with error / exception mid-run) and confirmed the failure path still prints.

**Not verified:** the flicker itself is visual and was not checked in an
interactive terminal. The actual no-flash behavior needs a human check via
`horus run` on a multi-task workflow.

### Notes

- Deliberately skipped fixed-height panels and tree memoization — alt-screen
  makes height changes free, and the per-frame `build_dependencies()` walk
  isn't the flicker cause. Add either if they prove to matter.
- Unrelated pre-existing observation: the summary showed `1/1 tasks` for a
  2-task workflow, because `track()` scopes to the execution plan from the
  trigger and there are no edges. `_render_progress` has always counted the
  same way, so it was left alone.

## Documentation impact

If a user, plugin, or GUI can observe the difference, it requires documentation.

- [ ] No documentation update required
- [x] Documentation updated / will be updated

`horus run`'s on-screen behavior changes visibly: the dashboard now renders on
the alternate screen and **disappears when the run ends**, leaving a one-line
summary in scrollback instead of the final dashboard. Anyone who relied on
scrolling back through the finished dashboard is affected. Documented in temple-compute/horus-docs#44.

If documentation was updated, link the docs PR here:

**horus-docs PR:** ⬇️

https://github.com/temple-compute/horus-docs/pull/44

