### PR TITLE
feat(workflow): package a workflow and its input files into a zip

### DIFF
--- a/src/horus_builtin/runtime/python_script.py
+++ b/src/horus_builtin/runtime/python_script.py
@@ -25,6 +25,9 @@ from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar
 
 from horus_builtin.runtime.command import CommandRuntime
+from horus_builtin.runtime.substitution import (
+    is_template as _is_template,
+)
 from horus_builtin.runtime.substitution import substitute
 from horus_runtime.context import HorusContext
 from horus_runtime.core.runtime.events import RuntimeEvent
@@ -67,16 +70,32 @@ class PythonScriptRuntime(CommandRuntime):
     command: str = ""
 
     def anchor_local_paths(self, base: Path) -> None:
-        """Resolve ``script`` against ``base`` if it is a relative path."""
+        """
+        Resolve ``script`` against ``base`` if it is a relative path.
+
+        A templated script (see :meth:`_setup_runtime`) names an artifact
+        rather than a file on this machine, so it is left untouched.
+        """
+        if _is_template(self.script):
+            return
         if not self.script.is_absolute():
             self.script = (base / self.script).resolve()
 
     async def _setup_runtime(self, task: "BaseTask") -> str:
-        remote_path = f"{task.working_dir}/{self.script.name}"
+        if _is_template(self.script):
+            # ``script: ${my_script}`` names an input artifact instead of a
+            # file on the orchestrator. The transfer layer has already placed
+            # it on the target, so resolve its on-target path and skip the
+            # upload -- the orchestrator may not have the file at all (this is
+            # how tc-os runs an imported workflow).
+            remote_path = substitute(str(self.script), task)
+            await task.target.mkdir(task.working_dir)
+        else:
+            remote_path = f"{task.working_dir}/{self.script.name}"
 
-        # Placing the file also creates task.working_dir on the target, which
-        # the executor uses as cwd and where the script's outputs land.
-        await task.target.put_file(self.script, remote_path)
+            # Placing the file also creates task.working_dir on the target,
+            # which the executor uses as cwd and where the outputs land.
+            await task.target.put_file(self.script, remote_path)
 
         args = substitute(self.args, task) if self.args else ""
         cmd = f"{self.python} {shlex.quote(remote_path)} {args}".rstrip()

--- a/src/horus_builtin/runtime/substitution.py
+++ b/src/horus_builtin/runtime/substitution.py
@@ -42,6 +42,8 @@ from typing import TYPE_CHECKING
 from horus_runtime.i18n import tr as _
 
 if TYPE_CHECKING:
+    from pathlib import PurePath
+
     from horus_runtime.core.artifact.base import BaseArtifact
     from horus_runtime.core.target.base import BaseTarget
     from horus_runtime.core.task.base import BaseTask
@@ -120,6 +122,21 @@ class _Resolver(Mapping[str, str]):
 
     def __len__(self) -> int:
         return len(self._roots)
+
+
+def is_template(value: "str | PurePath") -> bool:
+    """
+    True if *value* carries a ``$`` placeholder and so must be rendered by
+    :func:`substitute` against a task rather than used verbatim.
+
+    Fields that normally hold a path on the orchestrator (a script, a conda
+    environment file) accept ``${artifact_id}`` instead, naming an input
+    artifact that the transfer layer has already placed on the target. That
+    lets a workflow run on a machine that never had the original file.
+
+    ``$$`` is the escape for a literal ``$`` and does not make a template.
+    """
+    return "$" in str(value).replace("$$", "")
 
 
 def substitute(template: str, task: "BaseTask") -> str:

--- a/src/horus_runtime/cli.py
+++ b/src/horus_runtime/cli.py
@@ -30,6 +30,7 @@ from horus_runtime.context import HorusContext
 from horus_runtime.core.workflow.base import BaseWorkflow
 from horus_runtime.i18n import tr as _
 from horus_runtime.logging import horus_logger
+from horus_runtime.packaging import package_workflow
 from horus_runtime.version import __version__ as horus_version
 
 
@@ -136,6 +137,49 @@ def run(
         raise click.ClickException(str(exc)) from exc
     finally:
         ctx.shutdown()
+
+
+@main.command()
+@click.argument(
+    "workflow_yaml",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+)
+@click.option(
+    "--output",
+    "-o",
+    default=None,
+    type=click.Path(dir_okay=False, path_type=Path),
+    help="Zip to write. Defaults to <workflow-dir-name>.zip beside it.",
+)
+def package(workflow_yaml: Path, output: Path | None) -> None:
+    """
+    Bundle WORKFLOW_YAML and the files it references into a zip.
+
+    Collects every external input artifact, script, and executor environment
+    file, so the workflow can run on a machine that never had this directory.
+    Run output is excluded. Exits non-zero if a referenced file is missing.
+    """
+    ctx = HorusContext.boot()
+    try:
+        archive, members, skipped = package_workflow(workflow_yaml, output)
+    except click.ClickException:
+        raise
+    except Exception as exc:
+        raise click.ClickException(str(exc)) from exc
+    finally:
+        ctx.shutdown()
+
+    click.echo("  + workflow.yaml")
+    for rel in members:
+        click.echo(f"  + {rel}")
+    for rel in skipped:
+        # Usually a path a plugin pins into the run root when it expands
+        # (``map:`` does this), but it can also be a genuinely missing input.
+        click.echo(f"  - {rel} " + _("(not found; assumed generated)"))
+    click.echo(
+        _("Wrote %(archive)s (%(count)d file(s))")
+        % {"archive": archive, "count": len(members) + 1}
+    )
 
 
 if __name__ == "__main__":

--- a/src/horus_runtime/core/executor/base.py
+++ b/src/horus_runtime/core/executor/base.py
@@ -92,6 +92,17 @@ class BaseExecutor(AutoRegistry, entry_point="executor"):
     handle any runtime type.
     """
 
+    def anchor_local_paths(self, base: Path) -> None:
+        """
+        Resolve any relative local file paths this executor owns against
+        `base`. Called by the workflow before execution. No-op by default.
+
+        Mirrors :meth:`BaseRuntime.anchor_local_paths`; an executor that
+        references a file next to the workflow (a conda ``environment_file``,
+        say) needs the same anchoring or it would resolve against the process
+        working directory instead.
+        """
+
     @final
     async def execute(self, task: "BaseTask") -> None:
         """

--- a/src/horus_runtime/core/workflow/base.py
+++ b/src/horus_runtime/core/workflow/base.py
@@ -121,9 +121,17 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
     Unique identifier for this workflow instance.
     """
 
-    name: str = Field(min_length=1, pattern=r"^[a-zA-Z0-9 _-]+$")
+    name: str = Field(min_length=1, pattern=r"^[^\x00-\x1f\x7f]+$")
     """
     Human-readable name for this workflow.
+
+    Only used for display and log messages, never as a path, so the pattern
+    only excludes control characters. Real names carry punctuation --
+    "MD Setup - Protein-Ligand Complex (3HTB + JZ4)", "p38a / Imatinib" --
+    and an alphanumeric-only rule rejected most of the Pantheon library.
+
+    Anything deriving a filename from this must sanitise it itself; a name is
+    free text and may contain path separators.
     """
 
     tasks: list[BaseTask] = Field(
@@ -1056,8 +1064,9 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
         - Declared input/output artifact paths become absolute, rooted under
           :attr:`run_directory` for paths some task produces, or the base
           directory for external paths (see :meth:`_anchor_artifact`).
-        - ``task.runtime.anchor_local_paths(base)`` resolves any relative
-          local files the runtime owns (e.g. a script path).
+        - ``task.runtime.anchor_local_paths(base)`` and the executor's
+          equivalent resolve any relative local files those own (e.g. a
+          script path, or a conda ``environment_file``).
         - A co-located task target (same ``location_id`` as the orchestrator
           target) that has not set its own ``working_directory`` inherits the
           orchestrator target's working directory, mirroring what
@@ -1076,6 +1085,7 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
                 artifact, base=base, run_root=run_root, produced=produced
             )
         task.runtime.anchor_local_paths(base)
+        task.executor.anchor_local_paths(base)
 
         if self.orchestrator_target is not None:
             orchestrator_wd = self.orchestrator_target.working_directory

--- a/src/horus_runtime/locale/es/LC_MESSAGES/horus_runtime.po
+++ b/src/horus_runtime/locale/es/LC_MESSAGES/horus_runtime.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: horus-runtime 0.0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-02-15 19:05+0100\n"
-"PO-Revision-Date: 2026-01-28 16:50+0100\n"
+"POT-Creation-Date: 2026-07-20 13:50+0200\n"
+"PO-Revision-Date: 2026-07-20 13:50+0200\n"
 "Last-Translator: Christian Domínguez "
 "<christian.dominguez@templecompute.com>\n"
 "Language: es\n"
@@ -20,11 +20,498 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.18.0\n"
 
-#: src/horus_runtime/cli.py:30
+#: src/horus_runtime/cli.py:106
+msgid "Workflow has no tasks to run."
+msgstr "El flujo de trabajo no tiene tareas que ejecutar."
+
+#: src/horus_runtime/cli.py:115
+#, python-format
+msgid "Unknown task id(s) for --no-skip: %(unknown)s. Valid task ids: %(valid)s"
+msgstr ""
+"ID(s) de tarea desconocido(s) para --no-skip: %(unknown)s. IDs de tarea "
+"válidos: %(valid)s"
+
+#: src/horus_runtime/cli.py:178
+msgid "(not found; assumed generated)"
+msgstr "(no encontrado; se asume generado)"
+
+#: src/horus_runtime/cli.py:180
+#, python-format
+msgid "Wrote %(archive)s (%(count)d file(s))"
+msgstr "Se escribió %(archive)s (%(count)d archivo(s))"
+
+#: src/horus_runtime/context.py:130
+msgid "HorusContext is not set. Did you forget to call HorusContext.boot()?"
+msgstr "HorusContext no está definido. ¿Olvidó llamar a HorusContext.boot()?"
+
+#: src/horus_runtime/context.py:141
 msgid "Horus Runtime is starting..."
 msgstr "El entorno de ejecución de Horus se está iniciando..."
 
-#: src/horus_runtime/core/registry/auto_registry.py:115
+#: src/horus_runtime/context.py:158
+msgid "Horus Runtime ready!"
+msgstr "¡El entorno de ejecución de Horus está listo!"
+
+#: src/horus_runtime/context.py:173
+msgid "Horus Runtime is shutting down..."
+msgstr "El entorno de ejecución de Horus se está deteniendo..."
+
+#: src/horus_runtime/packaging.py:139
+#, python-format
+msgid ""
+"Workflow references %(count)d missing file(s):\n"
+"%(files)s"
+msgstr ""
+"El flujo de trabajo referencia %(count)d archivo(s) inexistente(s):\n"
+"%(files)s"
+
+#: src/horus_runtime/core/placement.py:92
+#, python-format
+msgid ""
+"Task '%(task_name)s' requests %(requested)s %(dimension)s at location "
+"'%(location_id)s', which only ever has %(total)s available. This request "
+"can never be satisfied."
+msgstr ""
+"La tarea '%(task_name)s' solicita %(requested)s %(dimension)s en la "
+"ubicación '%(location_id)s', que como máximo dispone de %(total)s. Esta "
+"solicitud nunca podrá satisfacerse."
+
+#: src/horus_runtime/core/artifact/base.py:194
+#, python-format
+msgid "Artifact at %(path)s. %(event)s"
+msgstr "Artefacto en %(path)s. %(event)s"
+
+#: src/horus_runtime/core/artifact/store.py:131
+#, python-format
+msgid "Failed to %(op)s artifact '%(id)s' on target (exit code %(rc)s)"
+msgstr ""
+"No se pudo %(op)s el artefacto '%(id)s' en el destino (código de salida "
+"%(rc)s)"
+
+#: src/horus_runtime/core/executor/base.py:84
+msgid "Horus base executor"
+msgstr "Ejecutor base de Horus"
+
+#: src/horus_runtime/core/executor/base.py:138
+#, python-format
+msgid "Failed to collect side artifacts for task %(task_id)s: %(err)s"
+msgstr ""
+"No se pudieron recopilar los artefactos secundarios de la tarea "
+"%(task_id)s: %(err)s"
+
+#: src/horus_runtime/core/executor/base.py:181
+#, python-format
+msgid "Failed to list side artifacts for task %(task_id)s: %(err)s"
+msgstr ""
+"No se pudieron listar los artefactos secundarios de la tarea %(task_id)s: "
+"%(err)s"
+
+#: src/horus_runtime/core/executor/base.py:201
+#: src/horus_runtime/core/executor/base.py:261
+#, python-format
+msgid "Skipping side artifact with unsafe name %(name)s"
+msgstr "Se omite el artefacto secundario con nombre no seguro %(name)s"
+
+#: src/horus_runtime/core/executor/base.py:218
+#: src/horus_runtime/core/executor/base.py:271
+#, python-format
+msgid "Skipping large side artifact %(name)s (%(size)d bytes)"
+msgstr ""
+"Se omite el artefacto secundario de gran tamaño %(name)s (%(size)d bytes)"
+
+#: src/horus_runtime/core/executor/base.py:235
+#, python-format
+msgid "Failed to collect side artifact %(name)s: %(err)s"
+msgstr "No se pudo recopilar el artefacto secundario %(name)s: %(err)s"
+
+#: src/horus_runtime/core/interaction/exceptions.py:41
+#: src/horus_runtime/core/interaction/transport.py:217
+#, python-format
+msgid "No renderer registered for %(transport)s:%(interaction)s"
+msgstr ""
+"No hay ningún renderizador registrado para %(transport)s:%(interaction)s"
+
+#: src/horus_runtime/core/interaction/exceptions.py:56
+msgid "No interaction transport configured for this task."
+msgstr "No hay ningún transporte de interacción configurado para esta tarea."
+
+#: src/horus_runtime/core/interaction/exceptions.py:71
+#, python-format
+msgid "Failed to parse interaction '%(kind)s' after %(retries)d retries."
+msgstr ""
+"No se pudo analizar la interacción '%(kind)s' tras %(retries)d reintentos."
+
+#: src/horus_runtime/core/interaction/exceptions.py:88
+#, python-format
+msgid "Missing required batch key '%(key)s'."
+msgstr "Falta la clave de lote obligatoria '%(key)s'."
+
+#: src/horus_runtime/core/interaction/exceptions.py:102
+#, python-format
+msgid "Batch value for key '%(key)s' is invalid: %(reason)s"
+msgstr "El valor de lote para la clave '%(key)s' no es válido: %(reason)s"
+
+#: src/horus_runtime/core/interaction/exceptions.py:117
+#, python-format
+msgid "Missing required input '%(input)s'."
+msgstr "Falta la entrada obligatoria '%(input)s'."
+
+#: src/horus_runtime/core/interaction/exceptions.py:131
+#, python-format
+msgid "YAML value for key '%(key)s' is invalid: %(reason)s"
+msgstr "El valor YAML para la clave '%(key)s' no es válido: %(reason)s"
+
+#: src/horus_runtime/core/interaction/transport.py:73
+#, python-format
+msgid ""
+"Interaction '%(interaction)s' asked via transport '%(transport)s' using "
+"renderer '%(renderer)s'."
+msgstr ""
+"Se solicitó la interacción '%(interaction)s' mediante el transporte "
+"'%(transport)s' usando el renderizador '%(renderer)s'."
+
+#: src/horus_runtime/core/interaction/transport.py:103
+#, python-format
+msgid "Interaction '%(interaction)s' answered successfully."
+msgstr "La interacción '%(interaction)s' se respondió correctamente."
+
+#: src/horus_runtime/core/interaction/transport.py:132
+#, python-format
+msgid ""
+"Interaction '%(interaction)s' parse failed. Retry %(attempt)d of "
+"%(max_retries)d."
+msgstr ""
+"Falló el análisis de la interacción '%(interaction)s'. Reintento "
+"%(attempt)d de %(max_retries)d."
+
+#: src/horus_runtime/core/interaction/transport.py:164
+#, python-format
+msgid "Interaction '%(interaction)s' failed: %(reason)s"
+msgstr "La interacción '%(interaction)s' falló: %(reason)s"
+
+#: src/horus_runtime/core/interaction/transport.py:196
+msgid "max_retries must be at least 1."
+msgstr "max_retries debe ser al menos 1."
+
+#: src/horus_runtime/core/interaction/transport.py:289
+#, python-format
+msgid "All %(retries)d retries exhausted."
+msgstr "Se agotaron los %(retries)d reintentos."
+
+#: src/horus_runtime/core/runtime/base.py:57
+msgid "Horus base runtime"
+msgstr "Entorno de ejecución base de Horus"
+
+#: src/horus_runtime/core/target/base.py:133
+msgid "No task is currently running on this target."
+msgstr "No hay ninguna tarea en ejecución en este destino."
+
+#: src/horus_runtime/core/target/base.py:146
+#, python-format
+msgid "Task '%(task_name)s' is already running on this target."
+msgstr "La tarea '%(task_name)s' ya se está ejecutando en este destino."
+
+#: src/horus_runtime/core/target/base.py:182
+#, python-format
+msgid "Dispatched task '%(task_name)s' to %(kind)s target"
+msgstr "Se despachó la tarea '%(task_name)s' al destino %(kind)s"
+
+#: src/horus_runtime/core/target/base.py:194
+#: src/horus_runtime/core/target/base.py:246
+msgid "Task has not been dispatched yet."
+msgstr "La tarea aún no se ha despachado."
+
+#: src/horus_runtime/core/target/base.py:198
+#, python-format
+msgid "Waiting for task '%(task_name)s' to complete on %(kind)s target"
+msgstr ""
+"Esperando a que la tarea '%(task_name)s' finalice en el destino %(kind)s"
+
+#: src/horus_runtime/core/target/base.py:221
+#, python-format
+msgid "Cancelling task '%(task_name)s' on %(kind)s target"
+msgstr "Cancelando la tarea '%(task_name)s' en el destino %(kind)s"
+
+#: src/horus_runtime/core/target/exceptions.py:44
+#, python-format
+msgid ""
+"Target '%(kind)s' has no working_directory set. Provide one explicitly or"
+" use a target that derives it automatically."
+msgstr ""
+"El destino '%(kind)s' no tiene working_directory definido. Proporcione uno"
+" explícitamente o use un destino que lo derive automáticamente."
+
+#: src/horus_runtime/core/task/base.py:71
+msgid "Horus base task"
+msgstr "Tarea base de Horus"
+
+#: src/horus_runtime/core/task/base.py:213
+#, python-format
+msgid ""
+"Runtime '%(runtime)s' is not compatible with executor '%(executor)s'. "
+"Expected one of: %(expected)s"
+msgstr ""
+"El entorno de ejecución '%(runtime)s' no es compatible con el ejecutor "
+"'%(executor)s'. Se esperaba uno de: %(expected)s"
+
+#: src/horus_runtime/core/task/base.py:248
+#, python-format
+msgid "Skipping task %(task_name)s. Already complete."
+msgstr "Se omite la tarea %(task_name)s. Ya está completada."
+
+#: src/horus_runtime/core/task/base.py:257
+#, python-format
+msgid "Task %(task_name)s status → SKIPPED"
+msgstr "Estado de la tarea %(task_name)s → SKIPPED"
+
+#: src/horus_runtime/core/task/base.py:263
+#, python-format
+msgid "Task %(task_name)s status → RUNNING"
+msgstr "Estado de la tarea %(task_name)s → RUNNING"
+
+#: src/horus_runtime/core/task/base.py:274
+#, python-format
+msgid "Task %(task_name)s status → CANCELED"
+msgstr "Estado de la tarea %(task_name)s → CANCELED"
+
+#: src/horus_runtime/core/task/base.py:281
+#, python-format
+msgid "Task %(task_name)s status → FAILED"
+msgstr "Estado de la tarea %(task_name)s → FAILED"
+
+#: src/horus_runtime/core/task/base.py:288
+#, python-format
+msgid "Task %(task_name)s status → COMPLETED"
+msgstr "Estado de la tarea %(task_name)s → COMPLETED"
+
+#: src/horus_runtime/core/task/base.py:330
+#, python-format
+msgid "Task %(task_name)s reset → IDLE"
+msgstr "Reinicio de la tarea %(task_name)s → IDLE"
+
+#: src/horus_runtime/core/transfer/exceptions.py:41
+#, python-format
+msgid ""
+"No transfer strategy registered for '%(source_kind)s' → "
+"'%(destination_kind)s'. Register a BaseTransferStrategy subclass that "
+"declares handles_source and handles_destination for these target kinds."
+msgstr ""
+"No hay ninguna estrategia de transferencia registrada para "
+"'%(source_kind)s' → '%(destination_kind)s'. Registre una subclase de "
+"BaseTransferStrategy que declare handles_source y handles_destination para"
+" estos tipos de destino."
+
+#: src/horus_runtime/core/transfer/exceptions.py:65
+#, python-format
+msgid ""
+"Artifact '%(artifact_id)s' is not accessible by target "
+"'%(destination_target_kind)s' and no orchestrator_target is set on the "
+"workflow. Set workflow.orchestrator_target to the target that holds user-"
+"provided root artifacts."
+msgstr ""
+"El artefacto '%(artifact_id)s' no es accesible por el destino "
+"'%(destination_target_kind)s' y no se ha definido orchestrator_target en "
+"el flujo de trabajo. Defina workflow.orchestrator_target como el destino "
+"que contiene los artefactos raíz proporcionados por el usuario."
+
+#: src/horus_runtime/core/workflow/base.py:114
+msgid "Horus base workflow"
+msgstr "Flujo de trabajo base de Horus"
+
+#: src/horus_runtime/core/workflow/base.py:690
+#, python-format
+msgid ""
+"Adding edge from '%(source)s.%(source_output)s' to "
+"'%(target)s.%(target_input)s' would create a cycle."
+msgstr ""
+"Añadir una arista de '%(source)s.%(source_output)s' a "
+"'%(target)s.%(target_input)s' crearía un ciclo."
+
+#: src/horus_runtime/core/workflow/base.py:976
+#, python-format
+msgid ""
+"Transferring artifact '%(id)s' from '%(src)s' to '%(dst)s' via "
+"%(strategy)s."
+msgstr ""
+"Transfiriendo el artefacto '%(id)s' de '%(src)s' a '%(dst)s' mediante "
+"%(strategy)s."
+
+#: src/horus_runtime/core/workflow/base.py:1184
+#, python-format
+msgid "Workflow %(workflow_name)s status → RUNNING"
+msgstr "Estado del flujo de trabajo %(workflow_name)s → RUNNING"
+
+#: src/horus_runtime/core/workflow/base.py:1204
+#, python-format
+msgid "Workflow %(workflow_name)s status → CANCELED"
+msgstr "Estado del flujo de trabajo %(workflow_name)s → CANCELED"
+
+#: src/horus_runtime/core/workflow/base.py:1211
+#, python-format
+msgid "Workflow %(workflow_name)s status → FAILED"
+msgstr "Estado del flujo de trabajo %(workflow_name)s → FAILED"
+
+#: src/horus_runtime/core/workflow/base.py:1218
+#, python-format
+msgid "Workflow %(workflow_name)s status → COMPLETED"
+msgstr "Estado del flujo de trabajo %(workflow_name)s → COMPLETED"
+
+#: src/horus_runtime/core/workflow/base.py:1240
+#, python-format
+msgid "Resetting workflow %(workflow_name)s."
+msgstr "Reiniciando el flujo de trabajo %(workflow_name)s."
+
+#: src/horus_runtime/core/workflow/exceptions.py:43
+#, python-format
+msgid ""
+"Another workflow with ID %(id)s is already running in this context. Only "
+"one workflow can run at a time per context."
+msgstr ""
+"Ya se está ejecutando otro flujo de trabajo con el ID %(id)s en este "
+"contexto. Solo puede ejecutarse un flujo de trabajo a la vez por contexto."
+
+#: src/horus_runtime/core/workflow/exceptions.py:59
+#, python-format
+msgid ""
+"Multiple tasks share the same ID '%(id)s'. Task IDs must be unique within"
+" a workflow."
+msgstr ""
+"Varias tareas comparten el mismo ID '%(id)s'. Los IDs de tarea deben ser "
+"únicos dentro de un flujo de trabajo."
+
+#: src/horus_runtime/core/workflow/exceptions.py:75
+#, python-format
+msgid ""
+"Multiple tasks declare the same output artifact ID '%(id)s'. Output "
+"artifact IDs must be unique across all tasks in a workflow."
+msgstr ""
+"Varias tareas declaran el mismo ID de artefacto de salida '%(id)s'. Los "
+"IDs de artefacto de salida deben ser únicos entre todas las tareas de un "
+"flujo de trabajo."
+
+#: src/horus_runtime/core/workflow/exceptions.py:93
+#, python-format
+msgid "Workflow edge references unknown %(endpoint)s '%(value)s'."
+msgstr ""
+"Una arista del flujo de trabajo referencia un %(endpoint)s desconocido: "
+"'%(value)s'."
+
+#: src/horus_runtime/core/workflow/exceptions.py:109
+#, python-format
+msgid ""
+"Edge '%(source)s' -> '%(target)s' names only one of 'source_output' and "
+"'target_input'. Name both to connect two artifacts, or neither to only "
+"order the two tasks."
+msgstr ""
+"La arista '%(source)s' -> '%(target)s' indica solo uno de 'source_output' "
+"y 'target_input'. Indique ambos para conectar dos artefactos, o ninguno "
+"para únicamente ordenar las dos tareas."
+
+#: src/horus_runtime/core/workflow/exceptions.py:127
+#, python-format
+msgid ""
+"Multiple edges feed input '%(input)s' of task '%(target)s'. Each consumer"
+" input may be fed by at most one edge."
+msgstr ""
+"Varias aristas alimentan la entrada '%(input)s' de la tarea '%(target)s'. "
+"Cada entrada consumidora puede ser alimentada por una arista como máximo."
+
+#: src/horus_runtime/core/workflow/exceptions.py:150
+#, python-format
+msgid "Workflow finished with failed task(s): %(tasks)s."
+msgstr "El flujo de trabajo finalizó con tarea(s) fallida(s): %(tasks)s."
+
+#: src/horus_runtime/event/bus.py:79
+#, python-format
+msgid "Subscribing handler %(subscriber)s to event type %(event_type)s"
+msgstr ""
+"Suscribiendo el manejador %(subscriber)s al tipo de evento %(event_type)s"
+
+#: src/horus_runtime/event/bus.py:103
+#, python-format
+msgid "Error publishing event %(event)s: %(error)s"
+msgstr "Error al publicar el evento %(event)s: %(error)s"
+
+#: src/horus_runtime/event/bus.py:124
+msgid "Event bus is already started."
+msgstr "El bus de eventos ya está iniciado."
+
+#: src/horus_runtime/event/bus.py:128
+msgid "Initializing transport and subscribers from the registry."
+msgstr "Inicializando el transporte y los suscriptores desde el registro."
+
+#: src/horus_runtime/event/bus.py:138
+#, python-format
+msgid "Starting transport: %(transport_type)s"
+msgstr "Iniciando el transporte: %(transport_type)s"
+
+#: src/horus_runtime/event/bus.py:154
+#, python-format
+msgid "Subscribing handler: %(subscriber_cls)s"
+msgstr "Suscribiendo el manejador: %(subscriber_cls)s"
+
+#: src/horus_runtime/event/bus.py:171
+#, python-format
+msgid "Stopping transport: %(transport_type)s"
+msgstr "Deteniendo el transporte: %(transport_type)s"
+
+#: src/horus_runtime/event/bus.py:180
+#, python-format
+msgid "Error stopping transport %(transport_type)s: %(error)s"
+msgstr "Error al detener el transporte %(transport_type)s: %(error)s"
+
+#: src/horus_runtime/middleware/auto_middleware.py:67
+#, python-format
+msgid ""
+"%(cls_name)s is abstract or opted-out, skipping registration. Concrete "
+"subclasses will still be registered if they inherit from AutoMiddleware."
+msgstr ""
+"%(cls_name)s es abstracta o está excluida; se omite su registro. Las "
+"subclases concretas se seguirán registrando si heredan de AutoMiddleware."
+
+#: src/horus_runtime/middleware/auto_middleware.py:83
+#, python-format
+msgid ""
+"%(cls_name)s inherits from AutoMiddleware but no domain root "
+"(entry_point=...) was found in its MRO."
+msgstr ""
+"%(cls_name)s hereda de AutoMiddleware pero no se encontró ninguna raíz de "
+"dominio (entry_point=...) en su MRO."
+
+#: src/horus_runtime/middleware/auto_middleware.py:107
+#, python-format
+msgid "Error loading middleware: %(error)s"
+msgstr "Error al cargar el middleware: %(error)s"
+
+#: src/horus_runtime/registry/auto_registry.py:158
+#, python-format
+msgid ""
+"%(entry_point)s already exists in the registry. Entry points must be "
+"unique."
+msgstr ""
+"%(entry_point)s ya existe en el registro. Los puntos de entrada deben ser "
+"únicos."
+
+#: src/horus_runtime/registry/auto_registry.py:176
+#, python-format
+msgid ""
+"%(cls)s tried to register without specifying a 'entry_point'. Make sure "
+"all base classes that inherit from AutoRegistry define an entry_point."
+msgstr ""
+"%(cls)s intentó registrarse sin especificar un 'entry_point'. Asegúrese de"
+" que todas las clases base que heredan de AutoRegistry definan un "
+"entry_point."
+
+#: src/horus_runtime/registry/auto_registry.py:190
+#, python-format
+msgid ""
+"%(cls_name)s is abstract or opted-out, skipping registration. Concrete "
+"subclasses will still be registered if they inherit from AutoRegistry."
+msgstr ""
+"%(cls_name)s es abstracta o está excluida; se omite su registro. Las "
+"subclases concretas se seguirán registrando si heredan de AutoRegistry."
+
+#: src/horus_runtime/registry/auto_registry.py:204
 #, python-format
 msgid ""
 "%(cls)s must define a class property named 'registry_key' with a non-"
@@ -35,7 +522,7 @@ msgstr ""
 " valor no vacío para permitir que el mecanismo de auto-registro registre "
 "las subclases en el registro correspondiente."
 
-#: src/horus_runtime/core/registry/auto_registry.py:129
+#: src/horus_runtime/registry/auto_registry.py:218
 #, python-format
 msgid ""
 "%(cls)s must define a class property named '%(key)s' with a non-empty "
@@ -44,16 +531,91 @@ msgstr ""
 "%(cls)s debe definir una propiedad de clase llamada '%(key)s' con un "
 "valor no vacío para ser registrada en el registro correspondiente."
 
-#: src/horus_runtime/core/registry/auto_registry.py:154
+#: src/horus_runtime/registry/auto_registry.py:230
 #, python-format
-msgid "Initializing %(group)s registry for %(cls)s"
-msgstr "Inicializando el registro %(group)s para %(cls)s"
+msgid "Duplicate registry key '%(key_value)s' for %(cls)s and %(cls_key)s"
+msgstr "Clave de registro duplicada '%(key_value)s' para %(cls)s y %(cls_key)s"
 
-#: src/horus_runtime/core/registry/auto_registry.py:169
+#: src/horus_runtime/registry/auto_registry.py:269
+#, python-format
+msgid "Expected dict or %(origin)s, got %(type)s"
+msgstr "Se esperaba un dict o %(origin)s, pero se obtuvo %(type)s"
+
+#: src/horus_runtime/registry/auto_registry.py:275
+#, python-format
+msgid "Missing '%(registry_key)s' discriminator in data"
+msgstr "Falta el discriminador '%(registry_key)s' en los datos"
+
+#: src/horus_runtime/registry/auto_registry.py:282
 #, python-format
 msgid ""
-"No subclasses registered for %(cls)s. Ensure that there are subclasses of"
-" this base class with add_to_registry=True."
+"Unknown %(registry_key)s='%(discriminator)s' for %(origin)s. Registered: "
+"%(registered)s"
 msgstr ""
-"No hay subclases registradas para %(cls)s. Asegúrese de que existan "
-"subclases de esta clase base con add_to_registry=True."
+"%(registry_key)s='%(discriminator)s' desconocido para %(origin)s. "
+"Registrados: %(registered)s"
+
+#: src/horus_runtime/registry/auto_registry.py:422
+#, python-format
+msgid "Initializing %(group)s registry."
+msgstr "Inicializando el registro %(group)s."
+
+#: src/horus_runtime/registry/auto_registry.py:427
+#, python-format
+msgid "- %(entry_point)s"
+msgstr "- %(entry_point)s"
+
+#: src/horus_runtime/registry/auto_registry.py:438
+#, python-format
+msgid "Failed to load plugin %(entry_point)s: %(error)s"
+msgstr "No se pudo cargar el complemento %(entry_point)s: %(error)s"
+
+#: src/horus_runtime/registry/auto_registry_product.py:70
+#, python-format
+msgid ""
+"%(cls_name)s uses AutoRegistryProduct but does not inherit from "
+"AutoRegistry."
+msgstr ""
+"%(cls_name)s usa AutoRegistryProduct pero no hereda de AutoRegistry."
+
+#: src/horus_runtime/registry/auto_registry_product.py:103
+#, python-format
+msgid ""
+"%(cls_name)s uses AutoRegistryProduct but no composite registry_key "
+"template was found. Make sure a base class defines registry_key in "
+"'field_name:attr1.attr2' format."
+msgstr ""
+"%(cls_name)s usa AutoRegistryProduct pero no se encontró ninguna plantilla"
+" compuesta de registry_key. Asegúrese de que una clase base defina "
+"registry_key con el formato 'field_name:attr1.attr2'."
+
+#: src/horus_runtime/registry/auto_registry_product.py:121
+#, python-format
+msgid ""
+"%(cls_name)s registry_key references attribute '%(attr)s' which does not "
+"exist."
+msgstr ""
+"El registry_key de %(cls_name)s referencia el atributo '%(attr)s', que no "
+"existe."
+
+#: src/horus_runtime/registry/auto_registry_product.py:134
+#, python-format
+msgid ""
+"%(cls_name)s registry_key references attribute '%(attr)s' whose registry "
+"key is not a non-empty string."
+msgstr ""
+"El registry_key de %(cls_name)s referencia el atributo '%(attr)s' cuya "
+"clave de registro no es una cadena no vacía."
+
+#~ msgid "Initializing %(group)s registry for %(cls)s"
+#~ msgstr "Inicializando el registro %(group)s para %(cls)s"
+
+#~ msgid ""
+#~ "No subclasses registered for %(cls)s. "
+#~ "Ensure that there are subclasses of "
+#~ "this base class with add_to_registry=True."
+#~ msgstr ""
+#~ "No hay subclases registradas para "
+#~ "%(cls)s. Asegúrese de que existan "
+#~ "subclases de esta clase base con "
+#~ "add_to_registry=True."

--- a/src/horus_runtime/locale/messages.pot
+++ b/src/horus_runtime/locale/messages.pot
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: horus-runtime VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-02-15 19:05+0100\n"
+"POT-Creation-Date: 2026-07-20 13:50+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,11 +18,435 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.18.0\n"
 
-#: src/horus_runtime/cli.py:30
+#: src/horus_runtime/cli.py:106
+msgid "Workflow has no tasks to run."
+msgstr ""
+
+#: src/horus_runtime/cli.py:115
+#, python-format
+msgid "Unknown task id(s) for --no-skip: %(unknown)s. Valid task ids: %(valid)s"
+msgstr ""
+
+#: src/horus_runtime/cli.py:178
+msgid "(not found; assumed generated)"
+msgstr ""
+
+#: src/horus_runtime/cli.py:180
+#, python-format
+msgid "Wrote %(archive)s (%(count)d file(s))"
+msgstr ""
+
+#: src/horus_runtime/context.py:130
+msgid "HorusContext is not set. Did you forget to call HorusContext.boot()?"
+msgstr ""
+
+#: src/horus_runtime/context.py:141
 msgid "Horus Runtime is starting..."
 msgstr ""
 
-#: src/horus_runtime/core/registry/auto_registry.py:115
+#: src/horus_runtime/context.py:158
+msgid "Horus Runtime ready!"
+msgstr ""
+
+#: src/horus_runtime/context.py:173
+msgid "Horus Runtime is shutting down..."
+msgstr ""
+
+#: src/horus_runtime/packaging.py:139
+#, python-format
+msgid ""
+"Workflow references %(count)d missing file(s):\n"
+"%(files)s"
+msgstr ""
+
+#: src/horus_runtime/core/placement.py:92
+#, python-format
+msgid ""
+"Task '%(task_name)s' requests %(requested)s %(dimension)s at location "
+"'%(location_id)s', which only ever has %(total)s available. This request "
+"can never be satisfied."
+msgstr ""
+
+#: src/horus_runtime/core/artifact/base.py:194
+#, python-format
+msgid "Artifact at %(path)s. %(event)s"
+msgstr ""
+
+#: src/horus_runtime/core/artifact/store.py:131
+#, python-format
+msgid "Failed to %(op)s artifact '%(id)s' on target (exit code %(rc)s)"
+msgstr ""
+
+#: src/horus_runtime/core/executor/base.py:84
+msgid "Horus base executor"
+msgstr ""
+
+#: src/horus_runtime/core/executor/base.py:138
+#, python-format
+msgid "Failed to collect side artifacts for task %(task_id)s: %(err)s"
+msgstr ""
+
+#: src/horus_runtime/core/executor/base.py:181
+#, python-format
+msgid "Failed to list side artifacts for task %(task_id)s: %(err)s"
+msgstr ""
+
+#: src/horus_runtime/core/executor/base.py:201
+#: src/horus_runtime/core/executor/base.py:261
+#, python-format
+msgid "Skipping side artifact with unsafe name %(name)s"
+msgstr ""
+
+#: src/horus_runtime/core/executor/base.py:218
+#: src/horus_runtime/core/executor/base.py:271
+#, python-format
+msgid "Skipping large side artifact %(name)s (%(size)d bytes)"
+msgstr ""
+
+#: src/horus_runtime/core/executor/base.py:235
+#, python-format
+msgid "Failed to collect side artifact %(name)s: %(err)s"
+msgstr ""
+
+#: src/horus_runtime/core/interaction/exceptions.py:41
+#: src/horus_runtime/core/interaction/transport.py:217
+#, python-format
+msgid "No renderer registered for %(transport)s:%(interaction)s"
+msgstr ""
+
+#: src/horus_runtime/core/interaction/exceptions.py:56
+msgid "No interaction transport configured for this task."
+msgstr ""
+
+#: src/horus_runtime/core/interaction/exceptions.py:71
+#, python-format
+msgid "Failed to parse interaction '%(kind)s' after %(retries)d retries."
+msgstr ""
+
+#: src/horus_runtime/core/interaction/exceptions.py:88
+#, python-format
+msgid "Missing required batch key '%(key)s'."
+msgstr ""
+
+#: src/horus_runtime/core/interaction/exceptions.py:102
+#, python-format
+msgid "Batch value for key '%(key)s' is invalid: %(reason)s"
+msgstr ""
+
+#: src/horus_runtime/core/interaction/exceptions.py:117
+#, python-format
+msgid "Missing required input '%(input)s'."
+msgstr ""
+
+#: src/horus_runtime/core/interaction/exceptions.py:131
+#, python-format
+msgid "YAML value for key '%(key)s' is invalid: %(reason)s"
+msgstr ""
+
+#: src/horus_runtime/core/interaction/transport.py:73
+#, python-format
+msgid ""
+"Interaction '%(interaction)s' asked via transport '%(transport)s' using "
+"renderer '%(renderer)s'."
+msgstr ""
+
+#: src/horus_runtime/core/interaction/transport.py:103
+#, python-format
+msgid "Interaction '%(interaction)s' answered successfully."
+msgstr ""
+
+#: src/horus_runtime/core/interaction/transport.py:132
+#, python-format
+msgid ""
+"Interaction '%(interaction)s' parse failed. Retry %(attempt)d of "
+"%(max_retries)d."
+msgstr ""
+
+#: src/horus_runtime/core/interaction/transport.py:164
+#, python-format
+msgid "Interaction '%(interaction)s' failed: %(reason)s"
+msgstr ""
+
+#: src/horus_runtime/core/interaction/transport.py:196
+msgid "max_retries must be at least 1."
+msgstr ""
+
+#: src/horus_runtime/core/interaction/transport.py:289
+#, python-format
+msgid "All %(retries)d retries exhausted."
+msgstr ""
+
+#: src/horus_runtime/core/runtime/base.py:57
+msgid "Horus base runtime"
+msgstr ""
+
+#: src/horus_runtime/core/target/base.py:133
+msgid "No task is currently running on this target."
+msgstr ""
+
+#: src/horus_runtime/core/target/base.py:146
+#, python-format
+msgid "Task '%(task_name)s' is already running on this target."
+msgstr ""
+
+#: src/horus_runtime/core/target/base.py:182
+#, python-format
+msgid "Dispatched task '%(task_name)s' to %(kind)s target"
+msgstr ""
+
+#: src/horus_runtime/core/target/base.py:194
+#: src/horus_runtime/core/target/base.py:246
+msgid "Task has not been dispatched yet."
+msgstr ""
+
+#: src/horus_runtime/core/target/base.py:198
+#, python-format
+msgid "Waiting for task '%(task_name)s' to complete on %(kind)s target"
+msgstr ""
+
+#: src/horus_runtime/core/target/base.py:221
+#, python-format
+msgid "Cancelling task '%(task_name)s' on %(kind)s target"
+msgstr ""
+
+#: src/horus_runtime/core/target/exceptions.py:44
+#, python-format
+msgid ""
+"Target '%(kind)s' has no working_directory set. Provide one explicitly or"
+" use a target that derives it automatically."
+msgstr ""
+
+#: src/horus_runtime/core/task/base.py:71
+msgid "Horus base task"
+msgstr ""
+
+#: src/horus_runtime/core/task/base.py:213
+#, python-format
+msgid ""
+"Runtime '%(runtime)s' is not compatible with executor '%(executor)s'. "
+"Expected one of: %(expected)s"
+msgstr ""
+
+#: src/horus_runtime/core/task/base.py:248
+#, python-format
+msgid "Skipping task %(task_name)s. Already complete."
+msgstr ""
+
+#: src/horus_runtime/core/task/base.py:257
+#, python-format
+msgid "Task %(task_name)s status → SKIPPED"
+msgstr ""
+
+#: src/horus_runtime/core/task/base.py:263
+#, python-format
+msgid "Task %(task_name)s status → RUNNING"
+msgstr ""
+
+#: src/horus_runtime/core/task/base.py:274
+#, python-format
+msgid "Task %(task_name)s status → CANCELED"
+msgstr ""
+
+#: src/horus_runtime/core/task/base.py:281
+#, python-format
+msgid "Task %(task_name)s status → FAILED"
+msgstr ""
+
+#: src/horus_runtime/core/task/base.py:288
+#, python-format
+msgid "Task %(task_name)s status → COMPLETED"
+msgstr ""
+
+#: src/horus_runtime/core/task/base.py:330
+#, python-format
+msgid "Task %(task_name)s reset → IDLE"
+msgstr ""
+
+#: src/horus_runtime/core/transfer/exceptions.py:41
+#, python-format
+msgid ""
+"No transfer strategy registered for '%(source_kind)s' → "
+"'%(destination_kind)s'. Register a BaseTransferStrategy subclass that "
+"declares handles_source and handles_destination for these target kinds."
+msgstr ""
+
+#: src/horus_runtime/core/transfer/exceptions.py:65
+#, python-format
+msgid ""
+"Artifact '%(artifact_id)s' is not accessible by target "
+"'%(destination_target_kind)s' and no orchestrator_target is set on the "
+"workflow. Set workflow.orchestrator_target to the target that holds user-"
+"provided root artifacts."
+msgstr ""
+
+#: src/horus_runtime/core/workflow/base.py:114
+msgid "Horus base workflow"
+msgstr ""
+
+#: src/horus_runtime/core/workflow/base.py:690
+#, python-format
+msgid ""
+"Adding edge from '%(source)s.%(source_output)s' to "
+"'%(target)s.%(target_input)s' would create a cycle."
+msgstr ""
+
+#: src/horus_runtime/core/workflow/base.py:976
+#, python-format
+msgid ""
+"Transferring artifact '%(id)s' from '%(src)s' to '%(dst)s' via "
+"%(strategy)s."
+msgstr ""
+
+#: src/horus_runtime/core/workflow/base.py:1184
+#, python-format
+msgid "Workflow %(workflow_name)s status → RUNNING"
+msgstr ""
+
+#: src/horus_runtime/core/workflow/base.py:1204
+#, python-format
+msgid "Workflow %(workflow_name)s status → CANCELED"
+msgstr ""
+
+#: src/horus_runtime/core/workflow/base.py:1211
+#, python-format
+msgid "Workflow %(workflow_name)s status → FAILED"
+msgstr ""
+
+#: src/horus_runtime/core/workflow/base.py:1218
+#, python-format
+msgid "Workflow %(workflow_name)s status → COMPLETED"
+msgstr ""
+
+#: src/horus_runtime/core/workflow/base.py:1240
+#, python-format
+msgid "Resetting workflow %(workflow_name)s."
+msgstr ""
+
+#: src/horus_runtime/core/workflow/exceptions.py:43
+#, python-format
+msgid ""
+"Another workflow with ID %(id)s is already running in this context. Only "
+"one workflow can run at a time per context."
+msgstr ""
+
+#: src/horus_runtime/core/workflow/exceptions.py:59
+#, python-format
+msgid ""
+"Multiple tasks share the same ID '%(id)s'. Task IDs must be unique within"
+" a workflow."
+msgstr ""
+
+#: src/horus_runtime/core/workflow/exceptions.py:75
+#, python-format
+msgid ""
+"Multiple tasks declare the same output artifact ID '%(id)s'. Output "
+"artifact IDs must be unique across all tasks in a workflow."
+msgstr ""
+
+#: src/horus_runtime/core/workflow/exceptions.py:93
+#, python-format
+msgid "Workflow edge references unknown %(endpoint)s '%(value)s'."
+msgstr ""
+
+#: src/horus_runtime/core/workflow/exceptions.py:109
+#, python-format
+msgid ""
+"Edge '%(source)s' -> '%(target)s' names only one of 'source_output' and "
+"'target_input'. Name both to connect two artifacts, or neither to only "
+"order the two tasks."
+msgstr ""
+
+#: src/horus_runtime/core/workflow/exceptions.py:127
+#, python-format
+msgid ""
+"Multiple edges feed input '%(input)s' of task '%(target)s'. Each consumer"
+" input may be fed by at most one edge."
+msgstr ""
+
+#: src/horus_runtime/core/workflow/exceptions.py:150
+#, python-format
+msgid "Workflow finished with failed task(s): %(tasks)s."
+msgstr ""
+
+#: src/horus_runtime/event/bus.py:79
+#, python-format
+msgid "Subscribing handler %(subscriber)s to event type %(event_type)s"
+msgstr ""
+
+#: src/horus_runtime/event/bus.py:103
+#, python-format
+msgid "Error publishing event %(event)s: %(error)s"
+msgstr ""
+
+#: src/horus_runtime/event/bus.py:124
+msgid "Event bus is already started."
+msgstr ""
+
+#: src/horus_runtime/event/bus.py:128
+msgid "Initializing transport and subscribers from the registry."
+msgstr ""
+
+#: src/horus_runtime/event/bus.py:138
+#, python-format
+msgid "Starting transport: %(transport_type)s"
+msgstr ""
+
+#: src/horus_runtime/event/bus.py:154
+#, python-format
+msgid "Subscribing handler: %(subscriber_cls)s"
+msgstr ""
+
+#: src/horus_runtime/event/bus.py:171
+#, python-format
+msgid "Stopping transport: %(transport_type)s"
+msgstr ""
+
+#: src/horus_runtime/event/bus.py:180
+#, python-format
+msgid "Error stopping transport %(transport_type)s: %(error)s"
+msgstr ""
+
+#: src/horus_runtime/middleware/auto_middleware.py:67
+#, python-format
+msgid ""
+"%(cls_name)s is abstract or opted-out, skipping registration. Concrete "
+"subclasses will still be registered if they inherit from AutoMiddleware."
+msgstr ""
+
+#: src/horus_runtime/middleware/auto_middleware.py:83
+#, python-format
+msgid ""
+"%(cls_name)s inherits from AutoMiddleware but no domain root "
+"(entry_point=...) was found in its MRO."
+msgstr ""
+
+#: src/horus_runtime/middleware/auto_middleware.py:107
+#, python-format
+msgid "Error loading middleware: %(error)s"
+msgstr ""
+
+#: src/horus_runtime/registry/auto_registry.py:158
+#, python-format
+msgid ""
+"%(entry_point)s already exists in the registry. Entry points must be "
+"unique."
+msgstr ""
+
+#: src/horus_runtime/registry/auto_registry.py:176
+#, python-format
+msgid ""
+"%(cls)s tried to register without specifying a 'entry_point'. Make sure "
+"all base classes that inherit from AutoRegistry define an entry_point."
+msgstr ""
+
+#: src/horus_runtime/registry/auto_registry.py:190
+#, python-format
+msgid ""
+"%(cls_name)s is abstract or opted-out, skipping registration. Concrete "
+"subclasses will still be registered if they inherit from AutoRegistry."
+msgstr ""
+
+#: src/horus_runtime/registry/auto_registry.py:204
 #, python-format
 msgid ""
 "%(cls)s must define a class property named 'registry_key' with a non-"
@@ -30,21 +454,75 @@ msgid ""
 "subclasses in the corresponding registry."
 msgstr ""
 
-#: src/horus_runtime/core/registry/auto_registry.py:129
+#: src/horus_runtime/registry/auto_registry.py:218
 #, python-format
 msgid ""
 "%(cls)s must define a class property named '%(key)s' with a non-empty "
 "value to be registered in the corresponding registry."
 msgstr ""
 
-#: src/horus_runtime/core/registry/auto_registry.py:154
+#: src/horus_runtime/registry/auto_registry.py:230
 #, python-format
-msgid "Initializing %(group)s registry for %(cls)s"
+msgid "Duplicate registry key '%(key_value)s' for %(cls)s and %(cls_key)s"
 msgstr ""
 
-#: src/horus_runtime/core/registry/auto_registry.py:169
+#: src/horus_runtime/registry/auto_registry.py:269
+#, python-format
+msgid "Expected dict or %(origin)s, got %(type)s"
+msgstr ""
+
+#: src/horus_runtime/registry/auto_registry.py:275
+#, python-format
+msgid "Missing '%(registry_key)s' discriminator in data"
+msgstr ""
+
+#: src/horus_runtime/registry/auto_registry.py:282
 #, python-format
 msgid ""
-"No subclasses registered for %(cls)s. Ensure that there are subclasses of"
-" this base class with add_to_registry=True."
+"Unknown %(registry_key)s='%(discriminator)s' for %(origin)s. Registered: "
+"%(registered)s"
+msgstr ""
+
+#: src/horus_runtime/registry/auto_registry.py:422
+#, python-format
+msgid "Initializing %(group)s registry."
+msgstr ""
+
+#: src/horus_runtime/registry/auto_registry.py:427
+#, python-format
+msgid "- %(entry_point)s"
+msgstr ""
+
+#: src/horus_runtime/registry/auto_registry.py:438
+#, python-format
+msgid "Failed to load plugin %(entry_point)s: %(error)s"
+msgstr ""
+
+#: src/horus_runtime/registry/auto_registry_product.py:70
+#, python-format
+msgid ""
+"%(cls_name)s uses AutoRegistryProduct but does not inherit from "
+"AutoRegistry."
+msgstr ""
+
+#: src/horus_runtime/registry/auto_registry_product.py:103
+#, python-format
+msgid ""
+"%(cls_name)s uses AutoRegistryProduct but no composite registry_key "
+"template was found. Make sure a base class defines registry_key in "
+"'field_name:attr1.attr2' format."
+msgstr ""
+
+#: src/horus_runtime/registry/auto_registry_product.py:121
+#, python-format
+msgid ""
+"%(cls_name)s registry_key references attribute '%(attr)s' which does not "
+"exist."
+msgstr ""
+
+#: src/horus_runtime/registry/auto_registry_product.py:134
+#, python-format
+msgid ""
+"%(cls_name)s registry_key references attribute '%(attr)s' whose registry "
+"key is not a non-empty string."
 msgstr ""

--- a/src/horus_runtime/packaging.py
+++ b/src/horus_runtime/packaging.py
@@ -1,0 +1,164 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+"""
+Bundle a workflow and the files it needs into a single zip.
+
+A workflow directory is already self-contained: paths in the YAML resolve
+against the directory holding it (see
+:meth:`horus_runtime.core.workflow.base.BaseWorkflow._anchor_artifact`). This
+module turns that directory into a zip carrying *only* the files the workflow
+actually references, so it can be moved to a machine that never had the repo --
+for example uploaded to a web UI that then runs it.
+
+What travels: the workflow YAML, every external input artifact (one not
+produced by any task), every ``python_script`` script, and every executor
+``environment_file``. Run output is referenced only as task *outputs*, so it is
+excluded by construction rather than by a filename blocklist.
+"""
+
+import zipfile
+from pathlib import Path
+
+from horus_builtin.runtime.substitution import is_template
+from horus_runtime.core.workflow.base import BaseWorkflow
+from horus_runtime.i18n import tr as _
+
+# Junk that can sit inside a referenced folder artifact but is never input.
+_EXCLUDED_DIRS = frozenset(
+    {".venv", "__pycache__", ".git", ".mypy_cache", ".ruff_cache"}
+)
+
+
+class BundleError(Exception):
+    """A workflow could not be packaged."""
+
+
+def collect_bundle_paths(
+    workflow: "BaseWorkflow",
+) -> tuple[list[Path], list[Path]]:
+    """
+    Return ``(required, artifacts)`` workflow-relative paths, sorted+deduped.
+
+    *required* are files the author named directly -- scripts and executor
+    environment files. They are never generated, so one that is absent is a
+    broken workflow.
+
+    *artifacts* are external input artifacts (not produced by any task). These
+    are only *probably* input files: a plugin may re-pin a path into the run
+    root when it expands (``map:`` does exactly this for its ``.gathered``
+    folder and ``.over.marker``), which is not knowable before a run. A
+    missing one is therefore reported as a warning, not an error.
+
+    Absolute paths are skipped throughout: they name a location on this
+    machine, cannot travel, and are the author's responsibility.
+    """
+    # Reuses the runtime's own produced-vs-external rule rather than
+    # restating it here, so packaging can never drift from anchoring.
+    produced = workflow._produced_declared_paths()  # noqa: SLF001
+    artifact_paths: set[Path] = set()
+    required: set[Path] = set()
+
+    artifacts = [
+        *workflow.artifacts,
+        *(a for t in workflow.tasks for a in (*t.inputs, *t.outputs)),
+    ]
+    for artifact in artifacts:
+        declared = artifact.declared_path
+        # A produced path is run output; it is regenerated, never shipped.
+        if declared is None or declared.is_absolute() or declared in produced:
+            continue
+        artifact_paths.add(declared)
+
+    for task in workflow.tasks:
+        for value in (
+            getattr(task.runtime, "script", None),
+            getattr(task.executor, "environment_file", None),
+        ):
+            if value is None or is_template(value):
+                continue
+            path = Path(value)
+            if not path.is_absolute():
+                required.add(path)
+
+    # A file named as both a script and an artifact only travels once.
+    artifact_paths -= required
+    return sorted(required), sorted(artifact_paths)
+
+
+def _expand(base: Path, rel: Path) -> list[Path]:
+    """Expand a folder reference into its files; a file yields itself."""
+    src = base / rel
+    if not src.is_dir():
+        return [rel]
+    return [
+        rel / child.relative_to(src)
+        for child in sorted(src.rglob("*"))
+        if child.is_file()
+        and not _EXCLUDED_DIRS.intersection(child.relative_to(src).parts)
+    ]
+
+
+def package_workflow(
+    workflow_yaml: Path, output: Path | None = None
+) -> tuple[Path, list[Path], list[Path]]:
+    """
+    Write a zip bundling *workflow_yaml* and its referenced files.
+
+    Returns ``(archive, members, skipped)`` -- the zip path, the
+    workflow-relative paths written (excluding the YAML itself), and the
+    artifact paths that did not exist and so were left out.
+
+    Raises :class:`BundleError` if a script or environment file is missing, so
+    a broken workflow fails here rather than halfway through a run.
+    """
+    workflow_yaml = workflow_yaml.resolve()
+    base = workflow_yaml.parent
+    workflow = BaseWorkflow.from_yaml(workflow_yaml)
+
+    required, artifacts = collect_bundle_paths(workflow)
+
+    missing = [rel for rel in required if not (base / rel).exists()]
+    if missing:
+        raise BundleError(
+            _("Workflow references %(count)d missing file(s):\n%(files)s")
+            % {
+                "count": len(missing),
+                "files": "\n".join(f"  {rel}" for rel in missing),
+            }
+        )
+
+    present = [rel for rel in artifacts if (base / rel).exists()]
+    skipped = [rel for rel in artifacts if not (base / rel).exists()]
+
+    members = sorted(
+        {m for rel in (*required, *present) for m in _expand(base, rel)}
+    )
+    output = output or base / f"{base.name}.zip"
+    output = output.resolve()
+
+    with zipfile.ZipFile(
+        output, "w", compression=zipfile.ZIP_DEFLATED
+    ) as bundle:
+        # Always at the archive root under a fixed name, so an importer can
+        # find the definition without guessing the original filename.
+        bundle.write(workflow_yaml, "workflow.yaml")
+        for rel in members:
+            bundle.write(base / rel, rel.as_posix())
+
+    return output, members, skipped

--- a/tests/unit/runtime/test_python_script.py
+++ b/tests/unit/runtime/test_python_script.py
@@ -25,6 +25,7 @@ from typing import cast
 
 import pytest
 
+from horus_builtin.artifact.file import FileArtifact
 from horus_builtin.artifact.json import JSONArtifact
 from horus_builtin.executor.shell import ShellExecutor
 from horus_builtin.runtime.command import CommandRuntime
@@ -102,6 +103,57 @@ async def test_python_script_quotes_remote_path_with_spaces(
     placed = Path(task.working_dir) / "job.py"
     assert cmd == f"python {shlex.quote(str(placed))}"
     assert "'" in cmd  # the space forced quoting, so the path is one arg
+
+
+@pytest.mark.usefixtures("horus_context")
+async def test_python_script_templated_script_uses_input_artifact(
+    tmp_path: Path,
+) -> None:
+    """
+    ``script: ${id}`` runs the input artifact already on the target, without
+    reading the file from this machine.
+
+    This is how an imported workflow runs on a host that never had the repo:
+    the transfer layer materialises the script, so there is nothing to upload.
+    """
+    work = tmp_path / "work"
+    work.mkdir()
+    # Deliberately never created on the orchestrator side beyond the target
+    # dir: the point is that _setup_runtime does not read it from here.
+    staged = work / "job.py"
+    staged.write_text("print('hi')\n")
+
+    script_in = FileArtifact(id="job_script", path=staged)
+    result = JSONArtifact(id="result", path=tmp_path / "result.json")
+    task = HorusTask(
+        id="run",
+        name="run",
+        runtime=PythonScriptRuntime(
+            script=Path("${job_script}"), args="$result"
+        ),
+        executor=ShellExecutor(),
+        target=LocalTarget(working_directory=work.as_posix()),
+        inputs=[script_in],
+        outputs=[result],
+    )
+
+    cmd = await task.runtime.setup_runtime(task)
+
+    assert cmd == f"python {staged} {result.path}"
+
+
+def test_python_script_templated_script_is_not_anchored(
+    tmp_path: Path,
+) -> None:
+    """A templated script names an artifact, so anchoring must leave it be."""
+    runtime = PythonScriptRuntime(script=Path("${job_script}"))
+    runtime.anchor_local_paths(tmp_path)
+    assert str(runtime.script) == "${job_script}"
+
+    # A plain relative path still anchors to the workflow directory.
+    plain = PythonScriptRuntime(script=Path("scripts/job.py"))
+    plain.anchor_local_paths(tmp_path)
+    assert plain.script == (tmp_path / "scripts" / "job.py").resolve()
 
 
 def test_artifact_ref_resolves_on_target_path(tmp_path: Path) -> None:

--- a/tests/unit/test_packaging.py
+++ b/tests/unit/test_packaging.py
@@ -1,0 +1,206 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Tests for bundling a workflow and its input files into a zip.
+"""
+
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from horus_runtime.packaging import BundleError, package_workflow
+
+# A producer -> consumer pair where the consumer also reads a committed input
+# file. ``results/data.txt`` is a task output, so it must never be bundled.
+WORKFLOW = """
+kind: horus_workflow
+name: Bundle Me (v1)
+tasks:
+  - kind: horus_task
+    id: produce
+    name: Produce
+    inputs:
+      - id: seed
+        kind: file
+        path: examples/seed.txt
+    outputs:
+      - id: data
+        kind: file
+        path: results/data.txt
+    executor:
+      kind: shell
+    runtime:
+      kind: python_script
+      script: scripts/produce.py
+      args: --seed ${seed} --out ${data}
+    target:
+      kind: local
+  - kind: horus_task
+    id: consume
+    name: Consume
+    inputs:
+      - id: data
+        kind: file
+        path: results/data.txt
+      - id: config
+        kind: file
+        path: configs/run.yaml
+    outputs:
+      - id: report
+        kind: file
+        path: results/report.txt
+    executor:
+      kind: shell
+    runtime:
+      kind: command
+      command: cat ${data} ${config} > ${report}
+    target:
+      kind: local
+edges:
+  - source: produce
+    source_output: data
+    target: consume
+    target_input: data
+"""
+
+
+@pytest.fixture
+def workflow_dir(tmp_path: Path) -> Path:
+    """A workflow directory laid out the way Pantheon workflows are."""
+    (tmp_path / "examples").mkdir()
+    (tmp_path / "examples" / "seed.txt").write_text("seed\n")
+    (tmp_path / "configs").mkdir()
+    (tmp_path / "configs" / "run.yaml").write_text("k: v\n")
+    (tmp_path / "scripts").mkdir()
+    (tmp_path / "scripts" / "produce.py").write_text("pass\n")
+
+    # Output from a previous run: present on disk, must not be bundled.
+    (tmp_path / "results").mkdir()
+    (tmp_path / "results" / "data.txt").write_text("stale\n")
+
+    (tmp_path / "workflow.yaml").write_text(WORKFLOW)
+    return tmp_path
+
+
+def _members(archive: Path) -> set[str]:
+    with zipfile.ZipFile(archive) as bundle:
+        return set(bundle.namelist())
+
+
+@pytest.mark.usefixtures("horus_context")
+def test_bundles_inputs_and_scripts_but_not_outputs(
+    workflow_dir: Path,
+) -> None:
+    """Committed inputs and scripts travel; run output does not."""
+    archive, members, skipped = package_workflow(
+        workflow_dir / "workflow.yaml"
+    )
+
+    assert _members(archive) == {
+        "workflow.yaml",
+        "examples/seed.txt",
+        "configs/run.yaml",
+        "scripts/produce.py",
+    }
+    # results/data.txt exists on disk but is produced by `produce`, so it is
+    # regenerated rather than shipped -- and it is not a missing input either.
+    assert Path("results/data.txt") not in members
+    assert skipped == []
+
+
+@pytest.mark.usefixtures("horus_context")
+def test_missing_script_is_an_error(workflow_dir: Path) -> None:
+    """A script is authored, never generated, so its absence is fatal."""
+    (workflow_dir / "scripts" / "produce.py").unlink()
+
+    with pytest.raises(BundleError, match=r"scripts/produce\.py"):
+        package_workflow(workflow_dir / "workflow.yaml")
+
+
+@pytest.mark.usefixtures("horus_context")
+def test_missing_input_artifact_is_skipped_not_fatal(
+    workflow_dir: Path,
+) -> None:
+    """
+    A plugin may pin an input path into the run root when it expands (``map:``
+    does this), so an absent input artifact is reported, not fatal.
+    """
+    (workflow_dir / "configs" / "run.yaml").unlink()
+
+    archive, _members_out, skipped = package_workflow(
+        workflow_dir / "workflow.yaml"
+    )
+
+    assert skipped == [Path("configs/run.yaml")]
+    assert "configs/run.yaml" not in _members(archive)
+    assert "examples/seed.txt" in _members(archive)
+
+
+FOLDER_WORKFLOW = """
+kind: horus_workflow
+name: Folder Input
+tasks:
+  - kind: horus_task
+    id: consume
+    name: Consume
+    inputs:
+      - id: dataset
+        kind: folder
+        path: examples
+    outputs:
+      - id: report
+        kind: file
+        path: results/report.txt
+    executor:
+      kind: shell
+    runtime:
+      kind: command
+      command: ls ${dataset} > ${report}
+    target:
+      kind: local
+"""
+
+
+@pytest.mark.usefixtures("horus_context")
+def test_folder_input_is_expanded_and_junk_excluded(tmp_path: Path) -> None:
+    """A folder input ships its files, minus caches that are never input."""
+    (tmp_path / "examples" / "nested").mkdir(parents=True)
+    (tmp_path / "examples" / "seed.txt").write_text("seed\n")
+    (tmp_path / "examples" / "nested" / "more.txt").write_text("x\n")
+    (tmp_path / "examples" / "__pycache__").mkdir()
+    (tmp_path / "examples" / "__pycache__" / "c.pyc").write_text("x\n")
+    (tmp_path / "workflow.yaml").write_text(FOLDER_WORKFLOW)
+
+    archive, _members_out, _skipped = package_workflow(
+        tmp_path / "workflow.yaml"
+    )
+    names = _members(archive)
+
+    assert "examples/seed.txt" in names
+    assert "examples/nested/more.txt" in names
+    assert not any("__pycache__" in n for n in names)
+
+
+@pytest.mark.usefixtures("horus_context")
+def test_output_defaults_beside_the_workflow(workflow_dir: Path) -> None:
+    """With no -o, the zip is named after the workflow directory."""
+    archive, _members_out, _skipped = package_workflow(
+        workflow_dir / "workflow.yaml"
+    )
+    assert archive == (workflow_dir / f"{workflow_dir.name}.zip").resolve()


### PR DESCRIPTION
## Summary

Adds `horus package WORKFLOW_YAML [-o OUT.zip]`, which bundles a workflow with the files it actually references — every external input artifact, every `python_script` script, and every executor `environment_file` — so a workflow can move to a machine that never had the repo (for example, uploaded to a web UI that then runs it). Run output is excluded by construction rather than by a filename blocklist: it is only ever referenced as a task *output*.

Missing files are treated asymmetrically, on purpose:

- A missing **script or environment file** is a hard error. The author named it directly, it is never generated, so its absence means the workflow is broken and should fail here rather than halfway through a run.
- A missing **input artifact** is only reported (`- path (not found; assumed generated)`). A plugin may pin a path into the run root when it expands — `map:` generates `<task>.gathered` and `<task>.over.marker` — which is not knowable before a run, so this cannot be an error without breaking valid workflows.

`python_script` gains a companion capability: `script` may now be a `${artifact_id}` template naming an input artifact that the transfer layer has already materialised on the target. The runtime resolves the on-target path and skips the upload, because the orchestrator may not hold the file at all. This is what lets an imported bundle run on a host that never had the original directory.

### Incidental fix

The new `BaseExecutor.anchor_local_paths` hook (a no-op by default, mirroring `BaseRuntime.anchor_local_paths`) also fixes a **pre-existing bug**: a relative executor `environment_file` resolved against the *process* working directory instead of the workflow directory, so such workflows only ran when invoked from their own directory.

### Contract change

The workflow `name` pattern is relaxed from `^[a-zA-Z0-9 _-]+$` to `^[^\x00-\x1f\x7f]+$`. This is intentional. The old alphanumeric-only rule rejected 7 of the 25 workflows in the Pantheon library, whose names carry punctuation — `MD Setup - Protein-Ligand Complex (3HTB + JZ4)`, `p38α / Imatinib`. A name is display text and is never used as a path, so only control characters are now excluded. Anything deriving a filename from a name must sanitise it itself.

### Notes

- A companion **horus-environments** PR depends on the `is_template` helper introduced here and needs a **0.2.1** release to unblock.
- The i18n catalogs had drifted badly — `messages.pot` held 5 entries while the source carries 92, so `babel-check` was passing only because almost nothing was being extracted. `make babel-refresh` now extracts all 92 and every message is translated into Spanish, including the three new packaging strings.

Local: 542 tests pass, 95.66% coverage, `make lint` and `make babel-check` clean.

## Documentation impact

If a user, plugin, or GUI can observe the difference, it requires documentation.

- [ ] No documentation update required
- [x] Documentation updated / will be updated

If documentation was updated, link the docs PR here:

**horus-docs PR:** https://github.com/temple-compute/horus-docs/pull/45
