### PR TITLE
Added 'sanitize' CLI to fix workflow yaml issues

### DIFF
--- a/src/horus_runtime/cli.py
+++ b/src/horus_runtime/cli.py
@@ -31,6 +31,7 @@ from horus_runtime.core.workflow.base import BaseWorkflow
 from horus_runtime.i18n import tr as _
 from horus_runtime.logging import horus_logger
 from horus_runtime.packaging import package_workflow
+from horus_runtime.sanitize import find_root_inputs, sanitize_workflow
 from horus_runtime.version import __version__ as horus_version
 
 
@@ -179,6 +180,101 @@ def package(workflow_yaml: Path, output: Path | None) -> None:
     click.echo(
         _("Wrote %(archive)s (%(count)d file(s))")
         % {"archive": archive, "count": len(members) + 1}
+    )
+
+    # The files travel either way; undeclared, they just arrive unlabelled,
+    # so an importing UI cannot offer them as inputs. Warn, never rewrite.
+    root_inputs, _missing = find_root_inputs(
+        BaseWorkflow.from_yaml(workflow_yaml)
+    )
+    if root_inputs:
+        click.echo(
+            _(
+                "%(count)d undeclared root input(s); "
+                "run 'horus sanitize' to promote them"
+            )
+            % {"count": len(root_inputs)}
+        )
+
+
+@main.command()
+@click.argument(
+    "workflow_yaml",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+)
+@click.option(
+    "--output",
+    "-o",
+    default=None,
+    type=click.Path(dir_okay=False, path_type=Path),
+    help="YAML to write. Defaults to <name>.sanitized.yaml beside it.",
+)
+@click.option(
+    "--yes",
+    "-y",
+    is_flag=True,
+    default=False,
+    help="Promote every root input without asking.",
+)
+def sanitize(workflow_yaml: Path, output: Path | None, yes: bool) -> None:
+    """
+    Declare WORKFLOW_YAML's implicit root inputs as root artifacts.
+
+    A task input that no edge feeds is a file you supply rather than one the
+    run produces. Promoting it to the top-level `artifacts:` list, wired by an
+    edge, is what lets a UI show it as a workflow input. Task inputs are left
+    untouched, so command substitutions keep working.
+    """
+    ctx = HorusContext.boot()
+    try:
+        workflow = BaseWorkflow.from_yaml(workflow_yaml)
+        candidates, missing = find_root_inputs(workflow)
+    except click.ClickException:
+        raise
+    except Exception as exc:
+        raise click.ClickException(str(exc)) from exc
+    finally:
+        ctx.shutdown()
+
+    for gap in missing:
+        # Not a root input: the path is run output. Only the author can say
+        # whether the missing dependency or the path is the mistake.
+        click.echo(
+            f"  ! {gap.task_id}.{gap.input_id} -> {gap.path} "
+            + _("produced by %(producer)s; missing edge")
+            % {"producer": gap.producer}
+        )
+
+    if not candidates:
+        click.echo(_("No root inputs to promote."))
+        return
+
+    accept = {
+        root.root_id
+        for root in candidates
+        if yes
+        or click.confirm(
+            f"  {root.path} -> artifacts/{root.root_id}?", default=True
+        )
+    }
+    if not accept:
+        click.echo(_("Nothing promoted."))
+        return
+
+    try:
+        written, promoted, _missing = sanitize_workflow(
+            workflow_yaml, output, accept
+        )
+    except Exception as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    for root in promoted:
+        click.echo(f"  + artifacts/{root.root_id} ({root.path})")
+        for task_id, input_id in root.consumers:
+            click.echo(f"  + edge -> {task_id}.{input_id}")
+    click.echo(
+        _("Wrote %(path)s (%(count)d root input(s))")
+        % {"path": written, "count": len(promoted)}
     )
 
 

--- a/src/horus_runtime/sanitize.py
+++ b/src/horus_runtime/sanitize.py
@@ -1,0 +1,291 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+"""
+Promote a workflow's implicit root inputs into declared root artifacts.
+
+A task input that no edge feeds is a *root input*: a file the author supplies
+rather than one the run produces. The runtime is happy to leave that implicit
+-- it just reads the path -- but nothing downstream can then tell an input
+apart from an incidental path. A UI importing the workflow has no list of
+"files the user provides", so it renders no input nodes.
+
+This module makes the implicit explicit: each such input gains an entry in the
+top-level ``artifacts:`` list and an edge wiring it to the task that consumes
+it (the ``artifact-<rootId>`` convention, see
+:meth:`horus_runtime.core.workflow.base.BaseWorkflow._assert_edge_source_resolves`).
+The task's own ``inputs:`` are left alone, so ``${input_id}`` substitutions in
+commands keep resolving.
+
+The rewrite is applied to the YAML *text*, inserting two blocks, rather than
+by re-dumping the model. Re-dumping would resolve every relative path to an
+absolute one (see :meth:`BaseWorkflow.to_yaml`), which makes the workflow
+unportable -- exactly what packaging then refuses to travel -- and would drop
+the comments and the executor anchor that these files are written around.
+"""
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from horus_runtime.core.workflow.base import BaseWorkflow
+
+
+class SanitizeError(Exception):
+    """A workflow could not be sanitized."""
+
+
+@dataclass(frozen=True)
+class RootInput:
+    """An unwired task input, and the root artifact it would be promoted to."""
+
+    root_id: str
+    """Id for the new root artifact."""
+
+    kind: str
+    """Artifact kind, copied from the task input."""
+
+    path: Path
+    """Workflow-relative path, exactly as declared."""
+
+    consumers: tuple[tuple[str, str], ...]
+    """``(task_id, input_id)`` pairs to wire, one edge each."""
+
+
+@dataclass(frozen=True)
+class MissingEdge:
+    """A task input whose path another task produces, but no edge feeds."""
+
+    task_id: str
+    input_id: str
+    path: Path
+    producer: str
+
+
+def _root_id(path: Path, input_id: str, task_id: str, taken: set[str]) -> str:
+    """
+    Pick a template-safe, unique id for the root artifact backing *path*.
+
+    Prefers the consumer's own input id, which is what the author already
+    reads in the command template. Falls back to qualifying it with the task,
+    then to a numeric suffix, so two unrelated inputs that happen to share a
+    name stay distinguishable.
+    """
+    for candidate in (input_id, f"{task_id}_{input_id}"):
+        if candidate not in taken:
+            return candidate
+    stem = re.sub(r"[^a-z0-9]+", "_", str(path).lower()).strip("_")
+    candidate = stem or input_id
+    suffix = 2
+    while candidate in taken:
+        candidate = f"{stem}_{suffix}"
+        suffix += 1
+    return candidate
+
+
+def find_root_inputs(
+    workflow: BaseWorkflow,
+) -> tuple[list[RootInput], list[MissingEdge]]:
+    """
+    Return ``(root_inputs, missing_edges)`` for *workflow*.
+
+    A task input qualifies as a root input when no edge targets it and its
+    declared path is relative. An input that no edge feeds but whose path
+    *is* produced by some task is not a root input at all -- it is a missing
+    edge, reported separately because only the author can decide whether the
+    dependency or the path is wrong.
+
+    Absolute paths are skipped: they name a location on this machine, cannot
+    travel, and are the author's responsibility (the same rule
+    :func:`horus_runtime.packaging.collect_bundle_paths` applies).
+    """
+    wired = {
+        (edge.target, edge.target_input)
+        for edge in workflow.edges
+        if edge.target_input is not None
+    }
+    # Reuses the runtime's own produced-vs-external rule rather than
+    # restating it here, so sanitizing can never drift from packaging.
+    produced = workflow._produced_declared_paths()  # noqa: SLF001
+    producer_of = {
+        artifact.declared_path: task.id
+        for task in workflow.tasks
+        for artifact in task.outputs
+        if artifact.declared_path is not None
+    }
+
+    taken = {artifact.id for artifact in workflow.artifacts}
+    by_path: dict[Path, RootInput] = {}
+    missing: list[MissingEdge] = []
+
+    for task in workflow.tasks:
+        for artifact in task.inputs:
+            declared = artifact.declared_path
+            if (task.id, artifact.id) in wired:
+                continue
+            if declared is None or declared.is_absolute():
+                continue
+            if declared in produced:
+                missing.append(
+                    MissingEdge(
+                        task_id=task.id,
+                        input_id=artifact.id,
+                        path=declared,
+                        producer=producer_of[declared],
+                    )
+                )
+                continue
+            # One file consumed by several tasks travels as one root
+            # artifact with one edge per consumer.
+            existing = by_path.get(declared)
+            if existing is not None:
+                by_path[declared] = RootInput(
+                    root_id=existing.root_id,
+                    kind=existing.kind,
+                    path=existing.path,
+                    consumers=(*existing.consumers, (task.id, artifact.id)),
+                )
+                continue
+            root_id = _root_id(declared, artifact.id, task.id, taken)
+            taken.add(root_id)
+            by_path[declared] = RootInput(
+                root_id=root_id,
+                kind=artifact.kind,
+                path=declared,
+                consumers=((task.id, artifact.id),),
+            )
+
+    return sorted(by_path.values(), key=lambda r: r.path), missing
+
+
+def _render(root_inputs: list[RootInput]) -> tuple[list[str], list[str]]:
+    """Render the ``artifacts:`` entries and ``edges:`` entries to insert."""
+    artifacts: list[str] = []
+    edges: list[str] = []
+    for root in root_inputs:
+        artifacts += [
+            f"  - id: {root.root_id}",
+            f"    kind: {root.kind}",
+            f"    path: {root.path.as_posix()}",
+            "",
+        ]
+        for task_id, input_id in root.consumers:
+            edges += [
+                f"  - source: artifact-{root.root_id}",
+                f"    source_output: {root.root_id}",
+                f"    target: {task_id}",
+                f"    target_input: {input_id}",
+                "",
+            ]
+    return artifacts, edges
+
+
+def _top_level_keys(lines: list[str]) -> dict[str, int]:
+    """Map each top-level mapping key to its line index."""
+    keys: dict[str, int] = {}
+    for i, line in enumerate(lines):
+        match = re.match(r"^([A-Za-z_][A-Za-z0-9_]*):", line)
+        if match and match.group(1) not in keys:
+            keys[match.group(1)] = i
+    return keys
+
+
+def _block_end(lines: list[str], start: int, keys: dict[str, int]) -> int:
+    """Line index just past the block whose key is at *start*."""
+    later = [i for i in keys.values() if i > start]
+    end = min(later) if later else len(lines)
+    # Don't swallow the blank line separating this block from the next key.
+    while end > start + 1 and not lines[end - 1].strip():
+        end -= 1
+    return end
+
+
+def apply_promotions(text: str, root_inputs: list[RootInput]) -> str:
+    """
+    Return *text* with the promoted artifacts and edges inserted.
+
+    Purely additive: existing lines are never rewritten, so comments, quoting
+    and YAML anchors survive untouched.
+    """
+    if not root_inputs:
+        return text
+    lines = text.splitlines()
+    artifact_lines, edge_lines = _render(root_inputs)
+    keys = _top_level_keys(lines)
+
+    if "edges" not in keys:
+        raise SanitizeError(
+            "Workflow has no top-level 'edges:' block to extend."
+        )
+
+    # Insert the later block first so the earlier block's index stays valid.
+    edges_at = _block_end(lines, keys["edges"], keys)
+    lines[edges_at:edges_at] = ["", *edge_lines] if edge_lines else []
+
+    if "artifacts" in keys:
+        at = _block_end(lines, keys["artifacts"], keys)
+        lines[at:at] = artifact_lines
+    else:
+        # Root inputs read best above the tasks that consume them; fall back
+        # to the edges block for a workflow with no tasks key of its own.
+        anchor = keys.get("tasks", keys["edges"])
+        lines[anchor:anchor] = ["artifacts:", *artifact_lines]
+
+    return "\n".join(lines) + "\n"
+
+
+def sanitize_workflow(
+    workflow_yaml: Path,
+    output: Path | None = None,
+    accept: "set[str] | None" = None,
+) -> tuple[Path, list[RootInput], list[MissingEdge]]:
+    """
+    Write a copy of *workflow_yaml* with its root inputs declared.
+
+    Returns ``(written, promoted, missing_edges)``. *accept*, when given,
+    limits promotion to those root artifact ids. Nothing is written when no
+    root input is promoted, and *written* is then the input path unchanged.
+
+    The result is re-loaded before returning, so a rewrite that would not
+    parse or validate fails here rather than at run time.
+    """
+    workflow_yaml = workflow_yaml.resolve()
+    workflow = BaseWorkflow.from_yaml(workflow_yaml)
+    root_inputs, missing = find_root_inputs(workflow)
+    if accept is not None:
+        root_inputs = [r for r in root_inputs if r.root_id in accept]
+    if not root_inputs:
+        return workflow_yaml, [], missing
+
+    text = workflow_yaml.read_text(encoding="utf-8")
+    output = (
+        output
+        or workflow_yaml.with_name(
+            f"{workflow_yaml.stem}.sanitized{workflow_yaml.suffix}"
+        )
+    ).resolve()
+    output.write_text(apply_promotions(text, root_inputs), encoding="utf-8")
+
+    try:
+        BaseWorkflow.from_yaml(output)
+    except Exception as exc:
+        raise SanitizeError(
+            f"Sanitized workflow does not validate: {exc}"
+        ) from exc
+
+    return output, root_inputs, missing

--- a/tests/unit/test_sanitize.py
+++ b/tests/unit/test_sanitize.py
@@ -1,0 +1,206 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Tests for promoting implicit root inputs into declared root artifacts.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from horus_runtime.core.workflow.base import BaseWorkflow
+from horus_runtime.sanitize import find_root_inputs, sanitize_workflow
+
+# `seed` and `config` are unwired inputs (root inputs). `data` is wired by an
+# edge. `shared.yaml` is read by both tasks, so it is one artifact, two edges.
+WORKFLOW = """
+kind: horus_workflow
+name: Sanitize Me
+# A comment the rewrite must not eat.
+_executor: &executor
+  kind: shell
+tasks:
+  - kind: horus_task
+    id: produce
+    name: Produce
+    inputs:
+      - id: seed
+        kind: file
+        path: examples/seed.txt
+      - id: shared
+        kind: file
+        path: configs/shared.yaml
+    outputs:
+      - id: data
+        kind: file
+        path: results/data.txt
+    executor: *executor
+    runtime:
+      kind: command
+      command: cat ${seed} ${shared} > ${data}
+    target:
+      kind: local
+  - kind: horus_task
+    id: consume
+    name: Consume
+    inputs:
+      - id: data
+        kind: file
+        path: results/data.txt
+      - id: config
+        kind: file
+        path: configs/run.yaml
+      - id: shared
+        kind: file
+        path: configs/shared.yaml
+    outputs:
+      - id: report
+        kind: file
+        path: results/report.txt
+    executor: *executor
+    runtime:
+      kind: command
+      command: cat ${data} ${config} ${shared} > ${report}
+    target:
+      kind: local
+edges:
+  - source: produce
+    source_output: data
+    target: consume
+    target_input: data
+
+orchestrator_target:
+  kind: local
+"""
+
+
+@pytest.fixture
+def workflow_dir(tmp_path: Path) -> Path:
+    """A workflow directory laid out the way Pantheon workflows are."""
+    (tmp_path / "examples").mkdir()
+    (tmp_path / "examples" / "seed.txt").write_text("seed\n")
+    (tmp_path / "configs").mkdir()
+    (tmp_path / "configs" / "run.yaml").write_text("k: v\n")
+    (tmp_path / "configs" / "shared.yaml").write_text("k: v\n")
+    (tmp_path / "workflow.yaml").write_text(WORKFLOW)
+    return tmp_path
+
+
+@pytest.mark.usefixtures("horus_context")
+def test_finds_unwired_inputs_only(workflow_dir: Path) -> None:
+    """An edge-fed input is not a root input; an unwired one is."""
+    workflow = BaseWorkflow.from_yaml(workflow_dir / "workflow.yaml")
+    roots, missing = find_root_inputs(workflow)
+
+    assert {r.path.as_posix() for r in roots} == {
+        "examples/seed.txt",
+        "configs/run.yaml",
+        "configs/shared.yaml",
+    }
+    assert missing == []
+
+
+@pytest.mark.usefixtures("horus_context")
+def test_shared_path_is_one_artifact_many_edges(workflow_dir: Path) -> None:
+    """One file read by two tasks travels once and wires twice."""
+    workflow = BaseWorkflow.from_yaml(workflow_dir / "workflow.yaml")
+    roots, _ = find_root_inputs(workflow)
+
+    shared = next(r for r in roots if r.path.name == "shared.yaml")
+    assert shared.consumers == (("produce", "shared"), ("consume", "shared"))
+
+
+@pytest.mark.usefixtures("horus_context")
+def test_unwired_produced_path_is_a_missing_edge(workflow_dir: Path) -> None:
+    """An unwired input a task produces needs an edge, not promotion."""
+    text = (workflow_dir / "workflow.yaml").read_text()
+    # Drop the only edge, orphaning `consume.data` -- a path `produce` makes.
+    text = text.split("edges:")[0] + "edges: []\n"
+    (workflow_dir / "workflow.yaml").write_text(text)
+
+    workflow = BaseWorkflow.from_yaml(workflow_dir / "workflow.yaml")
+    roots, missing = find_root_inputs(workflow)
+
+    assert [(m.task_id, m.input_id, m.producer) for m in missing] == [
+        ("consume", "data", "produce")
+    ]
+    assert all(r.path.as_posix() != "results/data.txt" for r in roots)
+
+
+@pytest.mark.usefixtures("horus_context")
+def test_sanitized_workflow_declares_roots_and_still_validates(
+    workflow_dir: Path,
+) -> None:
+    """The rewrite round-trips: roots declared, edges wired, model valid."""
+    written, promoted, _ = sanitize_workflow(workflow_dir / "workflow.yaml")
+
+    assert written.name == "workflow.sanitized.yaml"
+    doc = yaml.safe_load(written.read_text())
+    assert {a["id"] for a in doc["artifacts"]} == {"seed", "config", "shared"}
+    # Paths stay relative: an absolute one could not travel in a bundle.
+    assert all(not a["path"].startswith("/") for a in doc["artifacts"])
+
+    # 1 original edge + 1 seed + 1 config + 2 shared consumers.
+    assert len(doc["edges"]) == 5
+    root_edges = {
+        (e["source"], e["source_output"], e["target"], e["target_input"])
+        for e in doc["edges"]
+        if e["source"].startswith("artifact-")
+    }
+    assert ("artifact-seed", "seed", "produce", "seed") in root_edges
+
+    # Re-validates, and the promoted set matches what was written.
+    reloaded = BaseWorkflow.from_yaml(written)
+    assert {a.id for a in reloaded.artifacts} == {"seed", "config", "shared"}
+    assert len(promoted) == 3
+
+
+@pytest.mark.usefixtures("horus_context")
+def test_rewrite_is_additive(workflow_dir: Path) -> None:
+    """Comments and the executor anchor survive: nothing is re-dumped."""
+    written, _, _ = sanitize_workflow(workflow_dir / "workflow.yaml")
+    text = written.read_text()
+
+    assert "# A comment the rewrite must not eat." in text
+    assert "&executor" in text
+    assert "*executor" in text
+
+
+@pytest.mark.usefixtures("horus_context")
+def test_accept_limits_promotion(workflow_dir: Path) -> None:
+    """Declining a candidate leaves it implicit."""
+    written, promoted, _ = sanitize_workflow(
+        workflow_dir / "workflow.yaml", accept={"config"}
+    )
+
+    assert [r.root_id for r in promoted] == ["config"]
+    doc = yaml.safe_load(written.read_text())
+    assert {a["id"] for a in doc["artifacts"]} == {"config"}
+
+
+@pytest.mark.usefixtures("horus_context")
+def test_nothing_to_promote_writes_nothing(workflow_dir: Path) -> None:
+    """A workflow with every input wired is left alone."""
+    written, promoted, _ = sanitize_workflow(
+        workflow_dir / "workflow.yaml", accept=set()
+    )
+
+    assert promoted == []
+    assert written == (workflow_dir / "workflow.yaml").resolve()
+    assert not (workflow_dir / "workflow.sanitized.yaml").exists()


### PR DESCRIPTION
## Summary

This CLI command sanitizes the workflow and:
- Promotes input artifacts with no outputs to root artifacts
- Verifies the workflow can be instantiated
- Catches any missing plugin

## Documentation impact

If a user, plugin, or GUI can observe the difference, it requires documentation.

- [ ] No documentation update required
- [X] Documentation updated / will be updated

If documentation was updated, link the docs PR here:

**horus-docs PR:** ⬇️

https://github.com/temple-compute/horus-docs/pull/45
