### PR TITLE
feat(artifact): add view_bundle ClassVar to BaseArtifact

### DIFF
--- a/src/horus_runtime/core/artifact/base.py
+++ b/src/horus_runtime/core/artifact/base.py
@@ -77,6 +77,11 @@ class BaseArtifact[T: Any = Any](AutoRegistry, entry_point="artifact"):
     kind_description: ClassVar[str] = ""
     """Description of this artifact kind."""
 
+    view_bundle: ClassVar[str | None] = None
+    """``"import.package:relative/path.js"`` -- a built ESM bundle shipped
+    inside this distribution, resolved server-side via importlib.resources.
+    The browser never sees this string."""
+
     id: str
     """
     The artifact's stable ID.


### PR DESCRIPTION
Adds a single `view_bundle: ClassVar[str | None] = None` to `BaseArtifact`, alongside the existing `kind_name` / `kind_description` convention.

It names a built ESM bundle shipped inside the plugin's own distribution as `"import.package:relative/path.js"`, resolved server-side via `importlib.resources`. The browser never sees this string; tc-os turns it into a URL.

Declared on the class rather than via a `horus.artifact_view` entry point, because the renderer is a property *of the kind* and the class is already the single source of truth the tc-os backend reads live. A parallel entry-point group would only add a registry that can drift.

Default `None` means this is inert for every existing artifact kind.

**This unblocks temple-compute/tc-os `feat/artifact-layout-and-renderers`**, which pins the submodule to this commit and cannot build until this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)