### PR TITLE
feat(workflow): subworkflows, conditional edges, and branch routing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ local = "horus_builtin.target.local"
 
 [project.entry-points."horus.task"]
 horus_task = "horus_builtin.task.horus_task"
-subworkflow = "horus_builtin.workflow.subworkflow"
+subworkflow = "horus_builtin.workflow.subworkflow.expander"
 
 [project.entry-points."horus.transfer"]
 local_to_local = "horus_builtin.transfer.local_noop"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ local = "horus_builtin.target.local"
 
 [project.entry-points."horus.task"]
 horus_task = "horus_builtin.task.horus_task"
+subworkflow = "horus_builtin.workflow.subworkflow"
 
 [project.entry-points."horus.transfer"]
 local_to_local = "horus_builtin.transfer.local_noop"

--- a/src/horus_builtin/workflow/branch.py
+++ b/src/horus_builtin/workflow/branch.py
@@ -1,0 +1,444 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Switch-style branching: one function picks which downstream path(s) run.
+
+:mod:`horus_builtin.workflow.condition` already supports branching by putting
+a predicate on each outgoing edge. That is the right model for the canvas and
+for YAML, but it is an awkward way to write "pick one of these three" in
+Python: the author has to spread one decision across N mutually exclusive
+predicates and keep them consistent by hand. A :class:`BranchRouter` is the
+same decision written once, as a function returning the id(s) to take.
+
+Lowering, not a second evaluation path
+---------------------------------------
+The load-bearing design decision: a router **lowers to** the declarative form
+rather than teaching the scheduler a new trick. :meth:`BranchRouter._run`
+calls the function, validates what it returned against the declared
+``routes``, and writes a JSON sentinel shaped ``{"routes": [...]}``. Every
+outgoing edge is then an ordinary artifact-less ordering edge carrying an
+ordinary :class:`~horus_runtime.core.workflow.condition.EdgeCondition`
+(``key="routes"``, ``op="contains"``, ``value=<that route's task id>``) that
+reads the sentinel, exactly as if the user had hand-written it.
+
+So a router is *authoring sugar over data*, and everything downstream of the
+decision, the liveness rule
+(:func:`horus_builtin.workflow.condition.compute_liveness`), the scheduler's
+skip gate, the YAML round-trip, and the future canvas, needs zero extra cases:
+they only ever see edges with declarative conditions. The one thing a router
+adds is a task that computes the sentinel, and computing a JSON output is what
+every task already does.
+
+The consequence worth stating: a workflow whose router function cannot be
+re-imported (a lambda, or a module absent from the run's environment) still
+*routes* correctly wherever the function ran, because the decision has already
+been reduced to data by the time any edge is evaluated. Only re-deriving the
+decision needs the callable.
+
+Why the sentinel is always re-derived
+---------------------------------------
+:meth:`BranchRouter.is_complete` is permanently ``False``, mirroring
+:class:`~horus_builtin.workflow.map.MapExpander`: a stale sentinel from an
+earlier run would silently pin a resumed run to the old branch, so the router
+re-runs and re-decides deterministically. The tasks on the branches it selects
+are ordinary tasks and are still skipped individually by the usual
+``skip_if_complete`` behaviour, so re-deciding is cheap.
+"""
+
+import json
+from collections.abc import Callable
+from inspect import signature
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, ClassVar, Self
+
+from pydantic import ConfigDict, Field, model_validator
+
+from horus_builtin.artifact.file import FileArtifact
+from horus_builtin.executor.shell import ShellExecutor
+from horus_builtin.runtime.command import CommandRuntime
+from horus_builtin.target.local import LocalTarget
+from horus_builtin.task.horus_task import HorusTask
+from horus_builtin.workflow.condition import _resolve_ref
+from horus_runtime.core.artifact.store import ArtifactStore
+from horus_runtime.core.executor.base import BaseExecutor
+from horus_runtime.core.runtime.base import BaseRuntime
+from horus_runtime.core.target.base import BaseTarget
+from horus_runtime.core.workflow.condition import EdgeCondition, derive_ref
+from horus_runtime.core.workflow.edge import WorkflowEdge
+from horus_runtime.core.workflow.exceptions import WorkflowError
+from horus_runtime.i18n import tr as _
+from horus_runtime.logging import horus_logger
+
+if TYPE_CHECKING:
+    from horus_runtime.core.workflow.base import BaseWorkflow
+
+_ROUTES_SUFFIX = ".routes"
+_ROUTES_KEY = "routes"
+
+
+class BranchConfigurationError(WorkflowError):
+    """Raised when a ``wf.branch(...)`` call, or the function behind it, is
+    malformed.
+    """
+
+
+class BranchRouter(HorusTask):
+    """
+    Picks which downstream path(s) run by calling a Python function.
+
+    Writes its decision as a ``{"routes": [...]}`` JSON sentinel, which its
+    outgoing edges gate on declaratively. See the module docstring for why the
+    router lowers to the declarative form instead of being evaluated specially.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    kind: str = "branch_router"
+    kind_name: ClassVar[str] = "Branch Router"
+    kind_description: ClassVar[str] = _(
+        "Calls a Python function to pick which of its declared routes run, "
+        "and records the choice as a JSON sentinel its outgoing edges gate on."
+    )
+
+    runtime: BaseRuntime = Field(
+        default_factory=lambda: CommandRuntime(command="true")
+    )
+    """
+    Inert placeholder: :meth:`_run` is fully overridden and never delegates
+    to ``self.executor``/``self.runtime``, so these exist only to satisfy
+    ``BaseTask``'s required fields.
+    """
+
+    executor: BaseExecutor = Field(default_factory=ShellExecutor)
+    target: BaseTarget = Field(default_factory=LocalTarget)
+
+    routes: list[str]
+    """
+    Candidate target task ids, the closed set the function may return from.
+    Declared rather than inferred from the edges so a decision can be checked
+    against it before any edge is looked at, and so the canvas can draw the
+    branch's arms before the router has ever run.
+    """
+
+    func: Callable[..., str | list[str]] | None = Field(
+        default=None, exclude=True
+    )
+    """
+    The in-memory decision function, returning one route id or a list of them
+    (an empty list is legal and takes no branch at all). Optionally declares a
+    ``task`` parameter to receive this router, mirroring how
+    :class:`~horus_builtin.runtime.python.PythonFunctionRuntime` injects it.
+
+    Excluded from serialization, exactly as ``PythonCondition.func`` is: a
+    function cannot be written to YAML, and the backend stores workflows as
+    opaque JSON.
+    """
+
+    ref: str | None = None
+    """
+    ``module:qualname`` of ``func``, derived automatically via
+    :func:`~horus_runtime.core.workflow.condition.derive_ref`. This is what
+    survives ``model_dump``, so it is how a run dispatched to the orchestrator
+    recovers the decision function.
+    """
+
+    @property
+    def routes_output_id(self) -> str:
+        """Id of the JSON sentinel output holding this router's decision."""
+        return f"{self.id}{_ROUTES_SUFFIX}"
+
+    @model_validator(mode="after")
+    def _ensure_routes_output(self) -> Self:
+        """
+        Append the sentinel output if not already present (idempotent, so
+        re-loading an already-dumped router does not duplicate it).
+
+        Unlike :class:`~horus_builtin.workflow.map.MapExpander`'s wiring
+        marker, this one is really written: it is the whole interface between
+        the router and the declarative conditions on its outgoing edges.
+        """
+        output_id = self.routes_output_id
+        if not any(o.id == output_id for o in self.outputs):
+            self.outputs.append(
+                FileArtifact(id=output_id, path=Path(f"{output_id}.json"))
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _derive_ref(self) -> Self:
+        """Fill ``ref`` from ``func`` so the dump stays meaningful."""
+        if self.ref is None:
+            self.ref = derive_ref(self.func)
+        return self
+
+    @model_validator(mode="after")
+    def _check_resolvable(self) -> Self:
+        """A router with neither a callable nor a reference can never
+        decide.
+        """
+        if self.func is None and self.ref is None:
+            raise ValueError(
+                _(
+                    "A branch router needs either a callable or a "
+                    "'module:qualname' reference."
+                )
+            )
+        return self
+
+    async def is_complete(self) -> bool:
+        """
+        Always incomplete: the router must re-run on every trigger to
+        re-derive its decision. A sentinel left over from an earlier run
+        would otherwise pin a resumed run to the branch it took last time.
+        """
+        return False
+
+    async def _reset(self) -> None:
+        """
+        Delete the sentinel, mirroring
+        :meth:`~horus_builtin.task.horus_task.HorusTask._reset`. The tasks on
+        the routes are ordinary tasks and reset independently.
+        """
+        store = ArtifactStore(self.target)
+        for artifact in self.outputs:
+            await store.delete(artifact)
+        self.runs = 0
+
+    async def _run(self) -> None:
+        """
+        Call the decision function, validate what it returned, and write the
+        ``{"routes": [...]}`` sentinel its outgoing edges gate on.
+        """
+        self.runs += 1
+
+        chosen = self._normalize(await self._decide())
+
+        unknown = [route for route in chosen if route not in self.routes]
+        if unknown:
+            raise BranchConfigurationError(
+                _(
+                    "Branch router '%(id)s' chose route(s) %(unknown)s, which "
+                    "are not among its declared routes %(routes)s."
+                )
+                % {
+                    "id": self.id,
+                    "unknown": ", ".join(repr(r) for r in unknown),
+                    "routes": ", ".join(repr(r) for r in self.routes),
+                }
+            )
+
+        await self._write_sentinel(chosen)
+
+        horus_logger.log.debug(
+            _("Branch router '%(id)s' chose %(chosen)s.")
+            % {"id": self.id, "chosen": chosen or "no route"}
+        )
+
+    async def _decide(self) -> Any:
+        """
+        Resolve and invoke the decision function.
+
+        The in-memory callable wins over ``ref``: a router built in this
+        process holds the real function, and re-importing it would be both
+        pointless and wrong for a closure that never had an importable name.
+        """
+        func = self.func
+        if func is None:
+            if self.ref is None:
+                raise BranchConfigurationError(
+                    _(
+                        "Branch router '%(id)s' has neither a callable nor a "
+                        "reference."
+                    )
+                    % {"id": self.id}
+                )
+            func = _resolve_ref(self.ref)
+
+        result = func(**self._call_kwargs(func))
+        # Async deciders are supported for the same reason evaluate_condition
+        # supports them: a decision may need to read something remote.
+        if hasattr(result, "__await__"):
+            result = await result
+        return result
+
+    def _call_kwargs(self, func: Callable[..., Any]) -> dict[str, Any]:
+        """
+        Inject this router as ``task`` if, and only if, the function asks for
+        it by name, following
+        :class:`~horus_builtin.runtime.python.PythonFunctionRuntime`'s
+        convention. A self-contained decider stays a zero-argument function.
+        """
+        try:
+            parameters = signature(func).parameters
+        except (TypeError, ValueError):
+            # A builtin or C-implemented callable exposes no signature; it
+            # cannot be asking for a task parameter either.
+            return {}
+        return {"task": self} if "task" in parameters else {}
+
+    def _normalize(self, result: Any) -> list[str]:
+        """
+        Accept a single route id or a list of them, and reject anything else.
+
+        Returning a bare string is the common case ("take this branch"), so
+        requiring a one-element list for it would be noise.
+        """
+        if isinstance(result, str):
+            return [result]
+        if isinstance(result, (list, tuple)) and all(
+            isinstance(item, str) for item in result
+        ):
+            return list(result)
+        raise BranchConfigurationError(
+            _(
+                "Branch router '%(id)s' function must return a route id or a "
+                "list of route ids, got %(result)r."
+            )
+            % {"id": self.id, "result": result}
+        )
+
+    async def _write_sentinel(self, chosen: list[str]) -> None:
+        """Write the decision as ``{"routes": [...]}`` on this router's own
+        target, where the edge conditions will read it back from.
+        """
+        artifact = next(
+            (a for a in self.outputs if a.id == self.routes_output_id), None
+        )
+        if artifact is None:  # pragma: no cover - the validator guarantees it
+            raise BranchConfigurationError(
+                _("Branch router '%(id)s' lost its sentinel output.")
+                % {"id": self.id}
+            )
+        path = self.target.path_on_target(artifact)
+        await self.target.mkdir(str(Path(path).parent))
+        await self.target.put_file(
+            json.dumps({_ROUTES_KEY: chosen}).encode("utf-8"), path
+        )
+
+
+def route_edge(
+    router_id: str, routes_output_id: str, route: str
+) -> WorkflowEdge:
+    """
+    Build the one edge that gates *route* on *router_id*'s sentinel.
+
+    Deliberately the only place a router's wiring is expressed, so "what a
+    router lowers to" has a single definition that
+    :func:`branch_task` uses and tests can compare a hand-written declarative
+    branch against.
+
+    The edge is artifact-less (hence ordering-only): the branch target depends
+    on the *decision*, not on the sentinel's bytes, so it needs no input to
+    receive them into. That in turn is why the condition names its own source
+    rather than inheriting the edge's endpoints.
+
+    Args:
+        router_id: Id of the :class:`BranchRouter`.
+        routes_output_id: Id of the router's sentinel output.
+        route: Target task id this edge gates.
+
+    Returns:
+        The gated :class:`~horus_runtime.core.workflow.edge.WorkflowEdge`.
+    """
+    return WorkflowEdge(
+        source=router_id,
+        target=route,
+        condition=EdgeCondition(
+            source_task=router_id,
+            source_output=routes_output_id,
+            key=_ROUTES_KEY,
+            op="contains",
+            value=route,
+        ),
+    )
+
+
+def branch_task(
+    wf: "BaseWorkflow",
+    *,
+    id: str,
+    func: Callable[..., str | list[str]],
+    routes: list[str],
+    name: str | None = None,
+    target: BaseTarget | None = None,
+) -> BranchRouter:
+    """
+    Append a switch-style branch to *wf*: a router task plus one gated edge
+    per route.
+
+    Mirrors :func:`~horus_builtin.workflow.map.map_task`'s ergonomics. Unlike
+    map and loop there is no YAML block to lower from, because the declarative
+    form a router lowers *to* is already the YAML authoring form: hand-write
+    the conditions on the edges and no router is needed at all.
+
+    Args:
+        wf: The workflow to append to.
+        id: Id of the router task.
+        func: The decision function, returning one route id or a list of them.
+            May declare a ``task`` parameter to receive the router.
+        routes: Candidate target task ids. Each must already name a task on
+            *wf*, since each gets a gated edge from the router.
+        name: Display name; defaults to *id*.
+        target: Target the router itself runs on; defaults to
+            ``LocalTarget()``.
+
+    Returns:
+        The appended :class:`BranchRouter`.
+
+    Raises:
+        BranchConfigurationError: If *routes* is empty, contains duplicates,
+            or names a task that does not exist on *wf*.
+    """
+    if not routes:
+        raise BranchConfigurationError(
+            _("wf.branch(id='%(id)s', ...) requires at least one route.")
+            % {"id": id}
+        )
+    if len(set(routes)) != len(routes):
+        raise BranchConfigurationError(
+            _("wf.branch(id='%(id)s', ...) has duplicate routes.") % {"id": id}
+        )
+
+    known = {task.id for task in wf.tasks}
+    unknown = [route for route in routes if route not in known]
+    if unknown:
+        raise BranchConfigurationError(
+            _(
+                "wf.branch(id='%(id)s', ...) routes to unknown task(s) "
+                "%(unknown)s. Add the branch targets to the workflow first."
+            )
+            % {"id": id, "unknown": ", ".join(repr(r) for r in unknown)}
+        )
+
+    kwargs: dict[str, Any] = {
+        "id": id,
+        "name": name or id,
+        "func": func,
+        "routes": routes,
+    }
+    if target is not None:
+        kwargs["target"] = target
+
+    router = BranchRouter(**kwargs)
+
+    wf.tasks.append(router)
+    wf.edges.extend(
+        route_edge(router.id, router.routes_output_id, route)
+        for route in routes
+    )
+    return router

--- a/src/horus_builtin/workflow/condition.py
+++ b/src/horus_builtin/workflow/condition.py
@@ -101,6 +101,8 @@ _OPS: dict[str, Callable[[Any, Any], bool]] = {
     "ne": lambda actual, expected: bool(actual != expected),
     "in": lambda actual, expected: actual in expected,
     "not_in": lambda actual, expected: actual not in expected,
+    # Mirror of "in": the collection is in the document, not in the literal.
+    "contains": lambda actual, expected: expected in actual,
     "lt": lambda actual, expected: bool(actual < expected),
     "le": lambda actual, expected: bool(actual <= expected),
     "gt": lambda actual, expected: bool(actual > expected),

--- a/src/horus_builtin/workflow/condition.py
+++ b/src/horus_builtin/workflow/condition.py
@@ -1,0 +1,339 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Evaluation of edge conditions, and the liveness rule built on top of them.
+
+A conditional workflow is a DAG in which some edges are gated. The rule that
+decides what runs:
+
+    A task is **live** iff it has no incoming task-edges, or at least one
+    incoming task-edge is live. An edge is live iff its source task is live
+    and its condition (if any) evaluates true.
+
+This is an OR-join (BPMN inclusive merge), and it is chosen because it makes
+the two shapes users actually draw both behave:
+
+``A -> (B | C) -> D`` (diamond)
+    Taking ``B`` leaves ``C`` dead, but ``D`` still has a live incoming edge
+    from ``B``, so the join runs. An "all parents must be live" rule would
+    strand every join behind a branch.
+
+``C -> E`` (chain below a dead branch)
+    ``E`` has no condition of its own, but its only incoming edge comes from a
+    dead task, so ``E`` is dead too. Deactivation propagates without any
+    explicit marking.
+
+Liveness depends only on the tasks, the edges, and the condition values, so the
+canvas can compute exactly the same result client-side and grey out the paths
+that will not be taken.
+
+Known limitation, deliberately not solved here: a task that genuinely needs
+*all* of its parents will still run when only some are live, and will fail on
+the missing input. If that shape becomes common, the fix is a per-task
+``join_policy`` rather than a change to this rule.
+"""
+
+import json
+from collections.abc import Callable
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
+
+from horus_runtime.core.workflow.condition import (
+    EdgeCondition,
+    PythonCondition,
+)
+from horus_runtime.core.workflow.exceptions import WorkflowError
+from horus_runtime.i18n import tr as _
+
+if TYPE_CHECKING:
+    from horus_runtime.core.workflow.base import BaseWorkflow
+    from horus_runtime.core.workflow.edge import WorkflowEdge
+
+
+class ConditionEvaluationError(WorkflowError):
+    """
+    Raised when a condition cannot be evaluated at all.
+
+    Deliberately fatal rather than defaulting to "not live": a predicate that
+    cannot be read is a broken workflow, and silently pruning the branch would
+    hide it behind a run that looks successful.
+    """
+
+    pass
+
+
+def _walk(document: Any, key: str | None) -> Any:
+    """
+    Follow a dotted path into a decoded JSON document.
+
+    Returns ``None`` for a path that does not resolve, so ``exists`` can tell
+    absent from false without raising.
+    """
+    if key is None:
+        return document
+    current = document
+    for part in key.split("."):
+        if not isinstance(current, dict) or part not in current:
+            return None
+        current = current[part]
+    return current
+
+
+_OPS: dict[str, Callable[[Any, Any], bool]] = {
+    "exists": lambda actual, _expected: actual is not None,
+    "truthy": lambda actual, _expected: bool(actual),
+    "eq": lambda actual, expected: bool(actual == expected),
+    "ne": lambda actual, expected: bool(actual != expected),
+    "in": lambda actual, expected: actual in expected,
+    "not_in": lambda actual, expected: actual not in expected,
+    "lt": lambda actual, expected: bool(actual < expected),
+    "le": lambda actual, expected: bool(actual <= expected),
+    "gt": lambda actual, expected: bool(actual > expected),
+    "ge": lambda actual, expected: bool(actual >= expected),
+}
+"""
+The operator table. A dict rather than a match statement so that the set of
+operators has exactly one definition, which ``ConditionOp`` mirrors.
+"""
+
+
+def _apply(op: str, actual: Any, expected: Any) -> bool:
+    """
+    Apply one comparison from the closed operator set.
+    """
+    try:
+        compare = _OPS[op]
+    except KeyError as exc:
+        raise ConditionEvaluationError(
+            _("Unknown condition operator '%(op)s'.") % {"op": op}
+        ) from exc
+
+    try:
+        return compare(actual, expected)
+    except TypeError as exc:
+        # Ordering an int against a string, or testing membership in a
+        # non-collection: a workflow bug, not an evaluation that is merely
+        # false.
+        raise ConditionEvaluationError(
+            _("Cannot compare %(actual)r and %(expected)r with '%(op)s'.")
+            % {"actual": actual, "expected": expected, "op": op}
+        ) from exc
+
+
+async def _read_source_document(
+    wf: "BaseWorkflow",
+    task_id: str,
+    output_id: str,
+) -> Any:
+    """
+    Read and decode the JSON sentinel an upstream task wrote.
+
+    Mirrors ``LoopController._read_signal``: resolve the artifact on the
+    producing task's own target, confirm it was written, then decode it.
+    """
+    task = next((t for t in wf.tasks if t.id == task_id), None)
+    if task is None:
+        raise ConditionEvaluationError(
+            _("Condition references unknown task '%(task)s'.")
+            % {"task": task_id}
+        )
+
+    artifact = next(
+        (a for a in task.outputs if a.id == output_id),
+        None,
+    )
+    if artifact is None:
+        raise ConditionEvaluationError(
+            _(
+                "Condition references output '%(output)s', which task "
+                "'%(task)s' does not declare."
+            )
+            % {"output": output_id, "task": task_id}
+        )
+
+    path = task.target.path_on_target(artifact)
+    if not await task.target.path_exists(path):
+        raise ConditionEvaluationError(
+            _(
+                "Condition reads output '%(output)s' of task '%(task)s', "
+                "which was never written."
+            )
+            % {"output": output_id, "task": task_id}
+        )
+
+    raw = await task.target.get_file(path)
+    try:
+        return json.loads(raw)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ConditionEvaluationError(
+            _(
+                "Condition reads output '%(output)s' of task '%(task)s', "
+                "which is not valid JSON."
+            )
+            % {"output": output_id, "task": task_id}
+        ) from exc
+
+
+def _resolve_ref(ref: str) -> Any:
+    """
+    Import a ``module:qualname`` reference.
+
+    Used when a Python condition crossed a process boundary (the canvas, the
+    orchestrator) and lost its in-memory callable.
+    """
+    module_name, _sep, qualname = ref.partition(":")
+    if not module_name or not qualname:
+        raise ConditionEvaluationError(
+            _(
+                "Python condition reference '%(ref)s' is not of the form "
+                "'module:qualname'."
+            )
+            % {"ref": ref}
+        )
+    try:
+        obj: Any = import_module(module_name)
+    except ImportError as exc:
+        raise ConditionEvaluationError(
+            _(
+                "Python condition '%(ref)s' cannot be imported. The module "
+                "must be installed in this run's environment."
+            )
+            % {"ref": ref}
+        ) from exc
+
+    for part in qualname.split("."):
+        try:
+            obj = getattr(obj, part)
+        except AttributeError as exc:
+            raise ConditionEvaluationError(
+                _("Python condition '%(ref)s' does not exist.") % {"ref": ref}
+            ) from exc
+    return obj
+
+
+async def evaluate_condition(
+    wf: "BaseWorkflow",
+    edge: "WorkflowEdge",
+) -> bool:
+    """
+    Evaluate one edge's condition. An edge with no condition is always taken.
+    """
+    condition = edge.condition
+    if condition is None:
+        return True
+
+    # Both forms resolve their sentinel the same way: the condition's own
+    # source if it names one, else the edge's endpoints.
+    task_id = condition.source_task or edge.source
+    output_id = condition.source_output or edge.source_output
+
+    if isinstance(condition, EdgeCondition):
+        if output_id is None:
+            raise ConditionEvaluationError(
+                _(
+                    "Condition on edge '%(source)s' -> '%(target)s' names no "
+                    "output to read."
+                )
+                % {"source": edge.source, "target": edge.target}
+            )
+        document = await _read_source_document(wf, task_id, output_id)
+        return _apply(
+            condition.op,
+            _walk(document, condition.key),
+            condition.value,
+        )
+
+    if isinstance(condition, PythonCondition):
+        func = condition.func
+        if func is None:
+            if condition.ref is None:
+                raise ConditionEvaluationError(
+                    _(
+                        "Python condition on edge '%(source)s' -> "
+                        "'%(target)s' has neither a callable nor a reference."
+                    )
+                    % {"source": edge.source, "target": edge.target}
+                )
+            func = _resolve_ref(condition.ref)
+
+        # The callable sees the same document a declarative condition would,
+        # so the two forms are interchangeable from the workflow's side. A
+        # source that wrote nothing yields None rather than raising: unlike the
+        # declarative form, a Python predicate may legitimately want to decide
+        # on absence.
+        payload: Any = None
+        if output_id is not None:
+            try:
+                payload = await _read_source_document(wf, task_id, output_id)
+            except ConditionEvaluationError:
+                payload = None
+
+        result = func(payload)
+        if hasattr(result, "__await__"):
+            result = await result
+        return bool(result)
+
+    raise ConditionEvaluationError(
+        _("Unsupported condition type %(type)s.")
+        % {"type": type(condition).__name__}
+    )
+
+
+async def compute_liveness(
+    wf: "BaseWorkflow",
+    task_id: str,
+    cache: dict[str, bool],
+) -> bool:
+    """
+    Whether ``task_id`` should run, per the OR-join rule described above.
+
+    ``cache`` is the scheduler's per-run memo, and doubles as the record of
+    what has already been decided. By the time the scheduler asks about a task,
+    every parent has passed through this gate, so a cache miss means the parent
+    is outside the run's scope (or is a root) and is treated as live.
+
+    Conditions on edges whose source is already dead are **not** evaluated: the
+    dead task never wrote the sentinel those conditions would read, so
+    evaluating them would raise instead of simply pruning the branch.
+    """
+    if task_id in cache:
+        return cache[task_id]
+
+    task_ids = {t.id for t in wf.tasks}
+    incoming = [
+        edge
+        for edge in wf.edges
+        if edge.target == task_id and edge.source in task_ids
+    ]
+
+    # No task feeds this one: it is a root (or fed only by root artifacts), so
+    # there is nothing that could have deactivated it.
+    if not incoming:
+        cache[task_id] = True
+        return True
+
+    live = False
+    for edge in incoming:
+        if not cache.get(edge.source, True):
+            continue
+        if await evaluate_condition(wf, edge):
+            live = True
+            break
+
+    cache[task_id] = live
+    return live

--- a/src/horus_builtin/workflow/scheduler.py
+++ b/src/horus_builtin/workflow/scheduler.py
@@ -28,6 +28,7 @@ import asyncio
 from typing import TYPE_CHECKING
 
 from horus_builtin.event.task_event import HorusTaskEvent
+from horus_builtin.workflow.condition import compute_liveness
 from horus_builtin.workflow.dag import (
     UnknownTaskError,
     ancestors,
@@ -38,6 +39,7 @@ from horus_builtin.workflow.dag import (
 from horus_runtime.context import HorusContext
 from horus_runtime.core.placement import PlacementManager
 from horus_runtime.core.target.base import BaseTarget
+from horus_runtime.core.task.status import SkipReason, TaskStatus
 from horus_runtime.core.workflow.base import BaseWorkflow, _EdgeSource
 from horus_runtime.core.workflow.exceptions import WorkflowExecutionError
 from horus_runtime.i18n import tr as _
@@ -121,6 +123,7 @@ async def _execute_ready_task(
     source_map: dict[tuple[str, str], _EdgeSource],
     pool: TargetPool,
     placement: PlacementManager,
+    liveness: dict[str, bool],
 ) -> None:
     """
     Run one ready task to completion: reserve placement, acquire a target,
@@ -134,7 +137,30 @@ async def _execute_ready_task(
     isn't resource-gated at all — see :class:`PlacementManager`), so a
     resource-constrained fan-out can genuinely hold this coroutine here
     without ever occupying a pool slot.
+
+    A task on a branch that was not taken is skipped here and returns cleanly,
+    so the caller counts it as completed and the DAG moves on (exactly as a
+    memoized ``skip_if_complete`` task does). The check has to happen *before*
+    ``placement.acquire`` and the transfer below: an inactive task's inputs
+    were never produced, so transferring them would fail on any target where
+    transfer is not a no-op.
     """
+    if not await compute_liveness(workflow, task.id, liveness):
+        task.status = TaskStatus.SKIPPED
+        task.skip_reason = SkipReason.INACTIVE
+        message = _(
+            "Task %(task_name)s skipped: no incoming branch was taken."
+        ) % {"task_name": task.name}
+        horus_logger.log.debug(message)
+        HorusContext.get_context().bus.emit(
+            HorusTaskEvent(
+                task_id=task.id,
+                task_name=task.name,
+                message=message,
+            )
+        )
+        return
+
     declared_target = task.target
     location_id = declared_target.location_id
     await placement.acquire(task.name, location_id, task.resources)
@@ -292,6 +318,14 @@ async def run_schedule(workflow: BaseWorkflow, trigger_id: str) -> None:
     blocked: set[str] = set()
     failed: dict[str, BaseException] = {}
 
+    # Conditional-branch bookkeeping: task_id -> whether any incoming edge was
+    # live. Populated by the gate in `_execute_ready_task` as each task is
+    # dispatched, and read back there when deciding a task's own liveness, so
+    # deactivation propagates down a chain without a second traversal. Distinct
+    # from `blocked`: an inactive task still counts as completed, so a join
+    # downstream of both branches of a fork still runs.
+    liveness: dict[str, bool] = {}
+
     while True:
         # Recomputed every iteration (instead of once up front) so the
         # runtime DAG-mutation API (BaseWorkflow.add_task/add_edge/expand)
@@ -340,7 +374,7 @@ async def run_schedule(workflow: BaseWorkflow, trigger_id: str) -> None:
                 dispatched.add(task_id)
                 wrapper = asyncio.create_task(
                     _execute_ready_task(
-                        workflow, task, source_map, pool, placement
+                        workflow, task, source_map, pool, placement, liveness
                     )
                 )
                 running[wrapper] = task_id

--- a/src/horus_builtin/workflow/subworkflow.py
+++ b/src/horus_builtin/workflow/subworkflow.py
@@ -1,0 +1,777 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Declarative subworkflow (composition) construct.
+
+A ``subworkflow`` task carries a *complete* child workflow document in its
+``body`` and, when it runs, inlines that child's tasks and edges into the
+parent's live DAG. It is expressed either as a ``sub:`` block in YAML
+(lowered by :func:`lower_subworkflow_entry`, hooked into
+:class:`~horus_runtime.core.workflow.base.BaseWorkflow`'s ``model_validate``
+pipeline) or via the :func:`subworkflow_task` Python builder
+(``wf.subworkflow(...)``).
+
+Inlining, not nesting
+---------------------
+The child is deliberately *not* executed by a nested ``BaseWorkflow.run``:
+a nested run is rejected outright by ``OneWorkflowAtATimeError`` and would
+give the child its own target pool and placement manager, so the parent's
+``max_concurrency`` would no longer bound the whole run. Inlining instead
+puts every inner task into the parent's ``wf.tasks`` with a live status,
+which is also what lets a UI show per-child progress.
+
+The interface is the child workflow itself
+------------------------------------------
+Ports are *derived* from the body (see :func:`derive_ports`), never
+declared. The protocol a workflow offers is already written down inside it,
+so there is no second place to keep in sync and no binding table to
+validate:
+
+- **Inputs are the child's root artifacts.** ``BaseWorkflow.artifacts`` is
+  defined as "standalone root artifacts (no producer task)", referenced by
+  inner edges through the ``artifact-<rootId>`` convention. That set *is* a
+  workflow's input interface. The port name is the root artifact's id.
+- **Outputs are task outputs no inner edge consumes** (the child's leaves).
+  The port name is the artifact id, qualified to ``taskid.artifactid`` when
+  two leaves share an id.
+
+``port_overrides`` exists only to rename a derived port that reads badly or
+collides; it is not a binding table.
+
+Because parent edges must name ``(subworkflow_id, port)`` at *construction*
+time, the expander declares one never-written placeholder artifact per
+derived port, so the ordinary construction-time ``check_edges_resolve``
+accepts them with no change to core validation. Those placeholders are
+never written, so :meth:`SubworkflowExpander.is_complete` stays ``False``
+and the expansion is re-derived deterministically on a resumed run.
+
+Boundary rewiring
+-----------------
+:meth:`SubworkflowExpander._run` prefixes every inner id with
+``f"{self.id}/{inner_id}"`` — ``/`` is unused by the map (``[i]``) and loop
+(``#k``/``~k``) schemes, reads as a path, and nests
+(``outer/inner/leaf``) — then:
+
+- rewrites inner edges onto the prefixed ids, carrying ``condition``
+  through verbatim so a conditional inside a subworkflow still composes;
+- for an **in-port**, re-emits the parent edge that feeds
+  ``(self.id, port)`` onto every inner task that consumed
+  ``artifact-<port>``, and drops that child root artifact (the parent
+  supplies it now);
+- for an **out-port**, re-emits every parent edge sourcing
+  ``(self.id, port)`` from the real inner producer instead.
+
+Parent boundary edges must therefore be ``transfer=False``: the re-emitted
+edge is the one that carries the data, and a second ``transfer=True`` edge
+on the same ``(target, target_input)`` would make ``expand()`` raise
+``DuplicateEdgeTargetError``. The YAML lowering and the Python builder both
+force this; :meth:`_run` raises if it still finds one.
+
+No ordering edges are emitted from the expander to its inner tasks:
+``BaseWorkflow._gate_new_tasks_behind_creator`` (applied by ``expand()``)
+already records an implicit dependency from each new task *with no incoming
+task edge* onto the task that created it, so inner roots are gated behind
+the expander and the rest of the inner graph follows transitively through
+its own edges.
+
+Everything is committed through a single atomic ``wf.expand(...)``.
+"""
+
+from collections import Counter
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, ClassVar, Self
+
+from pydantic import BaseModel, Field, model_validator
+
+from horus_builtin.artifact.file import FileArtifact
+from horus_builtin.executor.shell import ShellExecutor
+from horus_builtin.runtime.command import CommandRuntime
+from horus_builtin.target.local import LocalTarget
+from horus_builtin.task.horus_task import HorusTask
+from horus_runtime.core.artifact.base import BaseArtifact
+from horus_runtime.core.artifact.store import ArtifactStore
+from horus_runtime.core.executor.base import BaseExecutor
+from horus_runtime.core.runtime.base import BaseRuntime
+from horus_runtime.core.target.base import BaseTarget
+from horus_runtime.core.task.base import BaseTask
+from horus_runtime.core.workflow.edge import WorkflowEdge
+from horus_runtime.core.workflow.exceptions import WorkflowError
+from horus_runtime.i18n import tr as _
+from horus_runtime.logging import horus_logger
+
+if TYPE_CHECKING:
+    from horus_runtime.core.workflow.base import BaseWorkflow
+
+_ROOT_PREFIX = "artifact-"
+_ID_SEPARATOR = "/"
+_PORT_SUFFIX = ".port"
+
+
+class SubworkflowError(WorkflowError):
+    """Raised when a ``sub:`` block or a subworkflow body is malformed."""
+
+
+class SubworkflowPort(BaseModel):
+    """
+    One derived port of a subworkflow body.
+
+    A port is the parent-visible name of something already present in the
+    child: a root artifact (in-port) or an unconsumed task output
+    (out-port).
+    """
+
+    name: str
+    """Parent-visible port name (post ``port_overrides``)."""
+
+    artifact: str
+    """Artifact id inside the body (root id, or the producer's output id)."""
+
+    task: str | None = None
+    """Inner producer task id; ``None`` for an in-port (a root artifact)."""
+
+
+def _restore_declared_paths(
+    entries: list[dict[str, Any]], artifacts: list[BaseArtifact]
+) -> None:
+    """
+    Undo the eager CWD resolution ``BaseArtifact`` applies at construction.
+
+    A live workflow's artifact paths are already absolute by the time it is
+    dumped, so a document made from one would pin every inner artifact
+    beside the *parent's* process CWD instead of inside the run directory.
+    Restoring each artifact's ``declared_path`` makes the document say what
+    its author wrote, which is also exactly what a YAML body already says.
+    """
+    for entry, artifact in zip(entries, artifacts, strict=False):
+        if artifact.declared_path is not None:
+            entry["path"] = str(artifact.declared_path)
+
+
+def _as_document(body: Any) -> Any:
+    """Serialize a live ``BaseWorkflow`` body, keeping declared paths."""
+    if not isinstance(body, BaseModel):
+        return body
+    document: dict[str, Any] = body.model_dump(mode="json")
+    tasks: list[BaseTask] = getattr(body, "tasks", [])
+    roots: list[BaseArtifact] = getattr(body, "artifacts", [])
+    _restore_declared_paths(_entries(document, "artifacts"), roots)
+    for entry, task in zip(_entries(document, "tasks"), tasks, strict=False):
+        _restore_declared_paths(entry.get("inputs") or [], list(task.inputs))
+        _restore_declared_paths(entry.get("outputs") or [], list(task.outputs))
+    return document
+
+
+def _entries(body: dict[str, Any], key: str) -> list[dict[str, Any]]:
+    """Return the ``key`` list of a body document as plain dicts."""
+    raw = body.get(key) or []
+    if not isinstance(raw, list):
+        return []
+    return [item for item in raw if isinstance(item, dict)]
+
+
+def derive_ports(
+    body: dict[str, Any],
+    port_overrides: dict[str, str] | None = None,
+) -> tuple[list[SubworkflowPort], list[SubworkflowPort]]:
+    """
+    Derive a subworkflow body's input and output ports.
+
+    This is the single definition of a subworkflow's interface, shared by
+    the load-time validator, the runtime expansion, and any other consumer
+    (a UI, or a future port of this rule to TypeScript). Nothing is
+    declared twice: the protocol lives in the child workflow document
+    itself.
+
+    Args:
+        body: A complete ``BaseWorkflow`` document.
+        port_overrides: Optional ``derived_name -> new_name`` renames,
+            applied last.
+
+    Returns:
+        ``(in_ports, out_ports)``. In-ports are the body's root artifacts
+        (``body["artifacts"]``), which inner edges reference as
+        ``artifact-<rootId>``. Out-ports are the task outputs no inner edge
+        consumes, named by artifact id and qualified to ``taskid.artifactid``
+        when two of them share an id.
+    """
+    overrides = port_overrides or {}
+
+    def rename(name: str) -> str:
+        return overrides.get(name, name)
+
+    in_ports = [
+        SubworkflowPort(name=rename(str(art["id"])), artifact=str(art["id"]))
+        for art in _entries(body, "artifacts")
+        if "id" in art
+    ]
+
+    consumed = {
+        (str(edge.get("source")), str(edge.get("source_output")))
+        for edge in _entries(body, "edges")
+    }
+    leaves = [
+        (str(task["id"]), str(out["id"]))
+        for task in _entries(body, "tasks")
+        if "id" in task
+        for out in (task.get("outputs") or [])
+        if isinstance(out, dict)
+        and "id" in out
+        and (str(task["id"]), str(out["id"])) not in consumed
+    ]
+    seen = Counter(artifact for _task, artifact in leaves)
+    out_ports = [
+        SubworkflowPort(
+            name=rename(
+                artifact if seen[artifact] == 1 else f"{task}.{artifact}"
+            ),
+            artifact=artifact,
+            task=task,
+        )
+        for task, artifact in leaves
+    ]
+
+    return in_ports, out_ports
+
+
+class SubworkflowExpander(HorusTask):
+    """
+    Inlines a complete child workflow into the parent's live DAG.
+
+    See the module docstring for port derivation and boundary rewiring.
+    """
+
+    kind: str = "subworkflow"
+    kind_name: ClassVar[str] = "Subworkflow"
+    kind_description: ClassVar[str] = _(
+        "Inlines a complete child workflow's tasks and edges into the "
+        "parent workflow at run time."
+    )
+
+    runtime: BaseRuntime = Field(
+        default_factory=lambda: CommandRuntime(command="true")
+    )
+    """
+    Inert placeholder: :meth:`_run` is fully overridden and never delegates
+    to ``self.executor``/``self.runtime``, so these exist only to satisfy
+    ``BaseTask``'s required fields.
+    """
+
+    executor: BaseExecutor = Field(default_factory=ShellExecutor)
+    target: BaseTarget = Field(default_factory=LocalTarget)
+
+    body: dict[str, Any]
+    """
+    A complete, valid ``BaseWorkflow`` document. Any existing workflow can
+    be dropped in unchanged: its ports are derived from it (see
+    :func:`derive_ports`), so nothing about it has to be adapted first.
+    """
+
+    port_overrides: dict[str, str] = Field(default_factory=dict)
+    """Optional ``derived_name -> new_name`` renames for derived ports."""
+
+    max_depth: int = 10
+    """
+    Maximum nesting depth, counted from the ``/``-separated inner-id prefix.
+    Guards against a body that (transitively) embeds itself.
+    """
+
+    @model_validator(mode="before")
+    @classmethod
+    def _accept_live_workflow(cls, data: Any) -> Any:
+        """
+        Accept a live ``BaseWorkflow`` as ``body`` and serialize it.
+
+        Dropping an existing workflow in should not require the author to
+        decide how to dump it; see :func:`_as_document` for why a plain
+        ``model_dump`` is not enough.
+        """
+        if isinstance(data, dict) and isinstance(data.get("body"), BaseModel):
+            return {**data, "body": _as_document(data["body"])}
+        return data
+
+    @model_validator(mode="after")
+    def _ensure_ports(self) -> Self:
+        """
+        Validate the body and append one placeholder artifact per derived
+        port, idempotently (so a dumped-and-reloaded expander does not
+        duplicate them).
+
+        The body is checked by simply constructing a ``BaseWorkflow`` from
+        it, which reuses every existing workflow validation (unique ids,
+        edges resolve, no cycles) instead of reimplementing any of it. This
+        matters at load time, not only at run time: a UI must be able to
+        reject a malformed subworkflow when it is saved rather than
+        halfway through a run.
+        """
+        # Local import: base.py imports this module at import time.
+        from horus_runtime.core.workflow.base import (  # noqa: PLC0415
+            BaseWorkflow,
+        )
+
+        for entry in _entries(self.body, "tasks"):
+            inner_id = str(entry.get("id", ""))
+            if _ID_SEPARATOR in inner_id:
+                raise SubworkflowError(
+                    _(
+                        "Subworkflow '%(id)s' body task id '%(inner)s' may "
+                        "not contain '/': it is reserved for the inlined "
+                        "id prefix."
+                    )
+                    % {"id": self.id, "inner": inner_id}
+                )
+
+        BaseWorkflow.model_validate(self.body)
+
+        in_ports, out_ports = derive_ports(self.body, self.port_overrides)
+        for port in in_ports:
+            if not any(a.id == port.name for a in self.inputs):
+                self.inputs.append(self._placeholder(port.name))
+        for port in out_ports:
+            if not any(a.id == port.name for a in self.outputs):
+                self.outputs.append(self._placeholder(port.name))
+        return self
+
+    def _placeholder(self, port_name: str) -> FileArtifact:
+        """Build the never-written placeholder artifact for *port_name*."""
+        slug = self.id.replace(_ID_SEPARATOR, "_")
+        return FileArtifact(
+            id=port_name, path=Path(f"{slug}.{port_name}{_PORT_SUFFIX}")
+        )
+
+    async def is_complete(self) -> bool:
+        """
+        Always incomplete: the expander must re-run on every trigger to
+        re-derive its deterministic expansion. Each inlined task then
+        decides independently, through ordinary ``skip_if_complete``
+        behaviour, whether it still has work to do.
+        """
+        return False
+
+    async def _reset(self) -> None:
+        """
+        Delete the (never-written) port placeholders, mirroring
+        :meth:`~horus_builtin.task.horus_task.HorusTask._reset`. The inlined
+        tasks and edges are re-derived from scratch on every :meth:`_run`
+        and reset independently as ordinary tasks.
+        """
+        store = ArtifactStore(self.target)
+        for artifact in self.outputs:
+            await store.delete(artifact)
+        self.runs = 0
+
+    async def _run(self) -> None:
+        """
+        Inline the body: build the prefixed inner tasks, rewrite the inner
+        edges, rewire the parent boundary edges, and commit everything in
+        one atomic ``wf.expand(...)``. See the module docstring.
+        """
+        wf = self.workflow
+        if wf is None:
+            raise SubworkflowError(
+                _("Subworkflow '%(id)s' must run inside a workflow.")
+                % {"id": self.id}
+            )
+        if self.id.count(_ID_SEPARATOR) >= self.max_depth:
+            raise SubworkflowError(
+                _(
+                    "Subworkflow '%(id)s' exceeds max_depth=%(depth)d; a "
+                    "body that embeds itself would expand forever."
+                )
+                % {"id": self.id, "depth": self.max_depth}
+            )
+
+        self.runs += 1
+
+        in_ports, out_ports = derive_ports(self.body, self.port_overrides)
+        tasks = self._build_inner_tasks(wf.run_directory)
+        by_id = {task.id: task for task in tasks}
+
+        edges: list[WorkflowEdge] = []
+        artifacts: list[BaseArtifact] = []
+        feeds = {
+            port.artifact: self._resolve_in_port(wf, port) for port in in_ports
+        }
+
+        for raw in _entries(self.body, "edges"):
+            source = str(raw.get("source"))
+            if source.startswith(_ROOT_PREFIX):
+                root = str(raw.get("source_output"))
+                self._wire_in_port(root, raw, feeds, by_id, edges, artifacts)
+            else:
+                edges.append(
+                    WorkflowEdge(
+                        source=self._prefixed(source),
+                        source_output=raw.get("source_output"),
+                        target=self._prefixed(str(raw.get("target"))),
+                        target_input=raw.get("target_input"),
+                        transfer=bool(raw.get("transfer", True)),
+                        condition=self._prefixed_condition(
+                            raw.get("condition")
+                        ),
+                    )
+                )
+
+        edges.extend(self._out_port_edges(wf, out_ports))
+
+        wf.expand(tasks=tasks, edges=edges, artifacts=artifacts)
+        horus_logger.log.debug(
+            _("Subworkflow '%(id)s' inlined %(n)d task(s).")
+            % {"id": self.id, "n": len(tasks)}
+        )
+
+    def _prefixed(self, inner_id: str) -> str:
+        """Parent-scope id of the inner element *inner_id*."""
+        return f"{self.id}{_ID_SEPARATOR}{inner_id}"
+
+    def _prefixed_condition(self, condition: Any) -> Any:
+        """
+        Carry an inner edge's condition through, re-pointing the task it
+        reads its sentinel from at that task's inlined id.
+
+        Everything else about the condition is preserved verbatim, so a
+        branch authored inside a child workflow composes unchanged.
+        """
+        if not isinstance(condition, dict):
+            return condition
+        source_task = condition.get("source_task")
+        if not isinstance(source_task, str):
+            return condition
+        return {**condition, "source_task": self._prefixed(source_task)}
+
+    def _build_inner_tasks(self, run_root: Path) -> list[BaseTask]:
+        """
+        Reconstruct every body task as a fresh, prefixed parent-scope task.
+
+        Relative artifact paths are re-rooted under a run-directory folder
+        named after this expander, so two instances of the same body (two
+        map clones, say) never write to the same place, and an inner input
+        fed across the boundary lands inside the run rather than beside the
+        workflow file.
+        """
+        tasks: list[BaseTask] = []
+        for entry in _entries(self.body, "tasks"):
+            inner_id = str(entry["id"])
+            if _ID_SEPARATOR in inner_id:
+                raise SubworkflowError(
+                    _(
+                        "Subworkflow '%(id)s' body task id '%(inner)s' may "
+                        "not contain '/'."
+                    )
+                    % {"id": self.id, "inner": inner_id}
+                )
+            data: dict[str, Any] = {**entry}
+            data.setdefault("kind", "horus_task")
+            data["id"] = self._prefixed(inner_id)
+            data["name"] = data["id"]
+            # A forced re-run of the expander (e.g. CLI --no-skip-all)
+            # must reach the tasks it inlines.
+            if not self.skip_if_complete:
+                data["skip_if_complete"] = False
+            task = BaseTask.model_validate(data)
+            task.target = task.target.model_copy(deep=True)
+            self._localize_paths(task, run_root)
+            tasks.append(task)
+        return tasks
+
+    def _localize_paths(self, task: BaseTask, run_root: Path) -> None:
+        """
+        Re-root *task*'s still-relative artifact paths under this id.
+
+        A nested expander is left alone: its artifacts are never-written
+        port placeholders, and pinning them to an absolute path would be
+        read back as "an enclosing construct materialized this port"
+        (see :meth:`_resolve_in_port`).
+        """
+        if isinstance(task, SubworkflowExpander):
+            return
+        for artifact in (*task.inputs, *task.outputs):
+            declared = artifact.declared_path
+            if declared is None or declared.is_absolute():
+                continue
+            _pin(artifact, run_root / self.id / declared)
+
+    def _resolve_in_port(
+        self, wf: "BaseWorkflow", port: SubworkflowPort
+    ) -> tuple[str, Any]:
+        """
+        Decide how the child root artifact behind *port* is fed.
+
+        Returns ``(mode, payload)``:
+
+        - ``("pinned", path)`` when the port placeholder has been pinned to
+          an absolute path by an enclosing construct (a ``MapExpander``
+          materializes each clone's slice directly rather than through an
+          edge), in which case inner consumers are pointed straight at it;
+        - ``("edges", parent_edges)`` when the parent feeds the port
+          through boundary edges, which are re-emitted onto the real inner
+          consumers;
+        - ``("root", None)`` when nothing feeds it, so the child keeps its
+          own root artifact (re-registered under a prefixed id).
+        """
+        parent_edges = [
+            edge
+            for edge in wf.edges
+            if edge.target == self.id and edge.target_input == port.name
+        ]
+        for edge in parent_edges:
+            if edge.transfer:
+                raise SubworkflowError(
+                    _(
+                        "Edge '%(source)s' -> subworkflow '%(id)s."
+                        "%(port)s' must set transfer=False: the data is "
+                        "carried by the edge re-emitted onto the inlined "
+                        "consumer instead."
+                    )
+                    % {"source": edge.source, "id": self.id, "port": port.name}
+                )
+
+        if _is_pinned(self.inputs, port.name):
+            placeholder = next(a for a in self.inputs if a.id == port.name)
+            return "pinned", placeholder.declared_path
+        if parent_edges:
+            return "edges", parent_edges
+        return "root", None
+
+    def _wire_in_port(
+        self,
+        root: str,
+        raw: dict[str, Any],
+        feeds: dict[str, tuple[str, Any]],
+        by_id: dict[str, BaseTask],
+        edges: list[WorkflowEdge],
+        artifacts: list[BaseArtifact],
+    ) -> None:
+        """
+        Rewire one inner ``artifact-<root>`` edge onto its parent source.
+
+        Mutates *edges*/*artifacts* in place; see :meth:`_resolve_in_port`
+        for the three feeding modes.
+        """
+        target = self._prefixed(str(raw.get("target")))
+        target_input = raw.get("target_input")
+        mode, payload = feeds.get(root, ("root", None))
+
+        if mode == "pinned":
+            consumer = by_id.get(target)
+            artifact = (
+                next(
+                    (a for a in consumer.inputs if a.id == target_input),
+                    None,
+                )
+                if consumer is not None
+                else None
+            )
+            if artifact is not None:
+                _pin(artifact, Path(payload))
+            return
+
+        if mode == "edges":
+            for parent_edge in payload:
+                edges.append(
+                    WorkflowEdge(
+                        source=parent_edge.source,
+                        source_output=parent_edge.source_output,
+                        target=target,
+                        target_input=target_input,
+                        transfer=True,
+                        condition=parent_edge.condition,
+                    )
+                )
+            return
+
+        prefixed_root = self._prefixed(root)
+        if not any(a.id == prefixed_root for a in artifacts):
+            entry = next(
+                (
+                    a
+                    for a in _entries(self.body, "artifacts")
+                    if str(a.get("id")) == root
+                ),
+                None,
+            )
+            if entry is None:
+                raise SubworkflowError(
+                    _(
+                        "Subworkflow '%(id)s' body references unknown root "
+                        "artifact '%(root)s'."
+                    )
+                    % {"id": self.id, "root": root}
+                )
+            artifacts.append(
+                BaseArtifact.model_validate({**entry, "id": prefixed_root})
+            )
+        edges.append(
+            WorkflowEdge(
+                source=f"{_ROOT_PREFIX}{prefixed_root}",
+                source_output=prefixed_root,
+                target=target,
+                target_input=target_input,
+                transfer=bool(raw.get("transfer", True)),
+                condition=self._prefixed_condition(raw.get("condition")),
+            )
+        )
+
+    def _out_port_edges(
+        self, wf: "BaseWorkflow", out_ports: list[SubworkflowPort]
+    ) -> list[WorkflowEdge]:
+        """
+        Re-emit every parent edge sourcing an out-port from the real inner
+        producer, so the consumer receives the child's data rather than the
+        never-written port placeholder.
+        """
+        edges: list[WorkflowEdge] = []
+        for port in out_ports:
+            if port.task is None or _is_pinned(self.outputs, port.name):
+                # An enclosing construct (a MapExpander materializing this
+                # clone's slot) has taken the port over and consumes the
+                # placeholder directly. Known gap: fan-in of a mapped
+                # subworkflow's results therefore sees the placeholder
+                # rather than the inner producer's real output.
+                continue
+            for edge in wf.edges:
+                if edge.source != self.id or edge.source_output != port.name:
+                    continue
+                if edge.transfer:
+                    raise SubworkflowError(
+                        _(
+                            "Edge subworkflow '%(id)s.%(port)s' -> "
+                            "'%(target)s' must set transfer=False: the data "
+                            "is carried by the edge re-emitted from the "
+                            "inlined producer instead."
+                        )
+                        % {
+                            "id": self.id,
+                            "port": port.name,
+                            "target": edge.target,
+                        }
+                    )
+                edges.append(
+                    WorkflowEdge(
+                        source=self._prefixed(port.task),
+                        source_output=port.artifact,
+                        target=edge.target,
+                        target_input=edge.target_input,
+                        transfer=True,
+                        condition=edge.condition,
+                    )
+                )
+        return edges
+
+
+def _is_pinned(artifacts: list[BaseArtifact], port_name: str) -> bool:
+    """Whether *port_name*'s placeholder was pinned to an absolute path."""
+    artifact = next((a for a in artifacts if a.id == port_name), None)
+    return (
+        artifact is not None
+        and artifact.declared_path is not None
+        and artifact.declared_path.is_absolute()
+    )
+
+
+def _pin(artifact: BaseArtifact, path: Path) -> None:
+    """
+    Point *artifact* at *path* and mark it anchored, so the workflow's
+    run-directory anchoring (applied by ``expand()``) leaves it untouched.
+    """
+    artifact.path = path
+    artifact.declared_path = path
+
+
+def lower_subworkflow_entry(entry: dict[str, Any]) -> dict[str, Any]:
+    """
+    Lower one raw YAML task-dict carrying a ``sub:`` block into a
+    ``kind: subworkflow`` task-dict.
+
+    Because ports are derived from the body, the sugar is just the child
+    workflow written inline — there is no port or binding block to author.
+
+    Args:
+        entry: The raw task dict as parsed from YAML, carrying ``id`` and a
+            ``sub`` key holding a complete child workflow document.
+
+    Returns:
+        A ``kind: subworkflow`` task dict ready for
+        ``BaseTask.model_validate``.
+    """
+    task_id = entry["id"]
+    data: dict[str, Any] = {
+        "kind": "subworkflow",
+        "id": task_id,
+        "name": entry.get("name") or task_id,
+        "description": entry.get("description", ""),
+        "body": entry["sub"],
+    }
+    if entry.get("port_overrides"):
+        data["port_overrides"] = entry["port_overrides"]
+    if entry.get("max_depth") is not None:
+        data["max_depth"] = entry["max_depth"]
+    if entry.get("target") is not None:
+        data["target"] = entry["target"]
+    return data
+
+
+def subworkflow_task(
+    wf: "BaseWorkflow",
+    *,
+    id: str,
+    body: "BaseWorkflow | dict[str, Any]",
+    port_overrides: dict[str, str] | None = None,
+    max_depth: int | None = None,
+    name: str | None = None,
+    target: BaseTarget | None = None,
+) -> SubworkflowExpander:
+    """
+    Append a subworkflow task to *wf*.
+
+    Mirrors the YAML ``sub:`` block (see :func:`lower_subworkflow_entry`),
+    so the two authoring paths produce structurally equivalent tasks.
+
+    Args:
+        wf: The workflow to append to.
+        id: Id of the subworkflow task, and the ``/``-separated prefix of
+            every inlined inner id.
+        body: The child workflow, either as a live ``BaseWorkflow`` (dumped
+            here) or as an already-serialized document.
+        port_overrides: Optional renames for derived ports.
+        max_depth: Maximum nesting depth; defaults to the field default.
+        name: Display name; defaults to *id*.
+        target: Target the expander itself runs on; defaults to
+            ``LocalTarget()``.
+
+    Returns:
+        The appended :class:`SubworkflowExpander`.
+    """
+    kwargs: dict[str, Any] = {
+        "id": id,
+        "name": name or id,
+        "body": body,
+        "port_overrides": port_overrides or {},
+    }
+    if max_depth is not None:
+        kwargs["max_depth"] = max_depth
+    if target is not None:
+        kwargs["target"] = target
+
+    expander = SubworkflowExpander(**kwargs)
+    wf.tasks.append(expander)
+    # Boundary edges never carry data themselves (see the module
+    # docstring); force any that already exist, as the YAML lowering does.
+    for edge in wf.edges:
+        if id in (edge.source, edge.target):
+            edge.transfer = False
+    return expander

--- a/src/horus_builtin/workflow/subworkflow/__init__.py
+++ b/src/horus_builtin/workflow/subworkflow/__init__.py
@@ -1,0 +1,43 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Declarative subworkflow (composition) construct.
+
+A ``subworkflow`` task carries a *complete* child workflow document in its
+``body`` and, when it runs, inlines that child's tasks and edges into the
+parent's live DAG. It is expressed either as a ``sub:`` block in YAML
+(lowered by :func:`~horus_builtin.workflow.subworkflow.lowering.
+lower_subworkflow_entry`, hooked into
+:class:`~horus_runtime.core.workflow.base.BaseWorkflow`'s ``model_validate``
+pipeline) or via the :func:`~horus_builtin.workflow.subworkflow.expander.
+subworkflow_task` Python builder (``wf.subworkflow(...)``).
+"""
+
+from horus_builtin.workflow.subworkflow.errors import SubworkflowError
+from horus_builtin.workflow.subworkflow.lowering import lower_subworkflow_entry
+from horus_builtin.workflow.subworkflow.ports import (
+    SubworkflowPort,
+    derive_ports,
+)
+
+__all__ = [
+    "SubworkflowError",
+    "SubworkflowPort",
+    "derive_ports",
+    "lower_subworkflow_entry",
+]

--- a/src/horus_builtin/workflow/subworkflow/errors.py
+++ b/src/horus_builtin/workflow/subworkflow/errors.py
@@ -1,0 +1,24 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""Errors raised by the subworkflow construct."""
+
+from horus_runtime.core.workflow.exceptions import WorkflowError
+
+
+class SubworkflowError(WorkflowError):
+    """Raised when a ``sub:`` block or a subworkflow body is malformed."""

--- a/src/horus_builtin/workflow/subworkflow/expander.py
+++ b/src/horus_builtin/workflow/subworkflow/expander.py
@@ -16,133 +16,40 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 """
-Declarative subworkflow (composition) construct.
-
-A ``subworkflow`` task carries a *complete* child workflow document in its
-``body`` and, when it runs, inlines that child's tasks and edges into the
-parent's live DAG. It is expressed either as a ``sub:`` block in YAML
-(lowered by :func:`lower_subworkflow_entry`, hooked into
-:class:`~horus_runtime.core.workflow.base.BaseWorkflow`'s ``model_validate``
-pipeline) or via the :func:`subworkflow_task` Python builder
-(``wf.subworkflow(...)``).
-
-Inlining, not nesting
----------------------
-The child is deliberately *not* executed by a nested ``BaseWorkflow.run``:
-a nested run is rejected outright by ``OneWorkflowAtATimeError`` and would
-give the child its own target pool and placement manager, so the parent's
-``max_concurrency`` would no longer bound the whole run. Inlining instead
-puts every inner task into the parent's ``wf.tasks`` with a live status,
-which is also what lets a UI show per-child progress.
-
-The interface is the child workflow itself
-------------------------------------------
-Ports are *derived* from the body (see :func:`derive_ports`), never
-declared. The protocol a workflow offers is already written down inside it,
-so there is no second place to keep in sync and no binding table to
-validate:
-
-- **Inputs are the child's root artifacts.** ``BaseWorkflow.artifacts`` is
-  defined as "standalone root artifacts (no producer task)", referenced by
-  inner edges through the ``artifact-<rootId>`` convention. That set *is* a
-  workflow's input interface. The port name is the root artifact's id.
-- **Outputs are task outputs no inner edge consumes** (the child's leaves).
-  The port name is the artifact id, qualified to ``taskid.artifactid`` when
-  two leaves share an id.
-
-``port_overrides`` exists only to rename a derived port that reads badly or
-collides; it is not a binding table.
-
-Because parent edges must name ``(subworkflow_id, port)`` at *construction*
-time, the expander declares one never-written placeholder artifact per
-derived port, so the ordinary construction-time ``check_edges_resolve``
-accepts them with no change to core validation. Those placeholders are
-never written, so :meth:`SubworkflowExpander.is_complete` stays ``False``
-and the expansion is re-derived deterministically on a resumed run.
-
-Boundary rewiring
------------------
-:meth:`SubworkflowExpander._run` prefixes every inner id with
-``f"{self.id}/{inner_id}"`` — ``/`` is unused by the map (``[i]``) and loop
-(``#k``/``~k``) schemes, reads as a path, and nests
-(``outer/inner/leaf``) — then:
-
-- rewrites inner edges onto the prefixed ids, carrying ``condition``
-  through verbatim so a conditional inside a subworkflow still composes;
-- for an **in-port**, re-emits the parent edge that feeds
-  ``(self.id, port)`` onto every inner task that consumed
-  ``artifact-<port>``, and drops that child root artifact (the parent
-  supplies it now);
-- for an **out-port**, re-emits every parent edge sourcing
-  ``(self.id, port)`` from the real inner producer instead.
-
-Parent boundary edges must therefore be ``transfer=False``: the re-emitted
-edge is the one that carries the data, and a second ``transfer=True`` edge
-on the same ``(target, target_input)`` would make ``expand()`` raise
-``DuplicateEdgeTargetError``. The YAML lowering and the Python builder both
-force this; :meth:`_run` raises if it still finds one.
-
-No ordering edges are emitted from the expander to its inner tasks:
-``BaseWorkflow._gate_new_tasks_behind_creator`` (applied by ``expand()``)
-already records an implicit dependency from each new task *with no incoming
-task edge* onto the task that created it, so inner roots are gated behind
-the expander and the rest of the inner graph follows transitively through
-its own edges.
-
-Everything is committed through a single atomic ``wf.expand(...)``.
+``SubworkflowExpander``: inlines a complete child workflow into the parent's
+live DAG. See :mod:`horus_builtin.workflow.subworkflow` for the full design.
 """
 
-from collections import Counter
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, ClassVar, Self
+from typing import Any, ClassVar, Self
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import Field, field_serializer, model_validator
+from pydantic_core.core_schema import SerializerFunctionWrapHandler
 
 from horus_builtin.artifact.file import FileArtifact
 from horus_builtin.executor.shell import ShellExecutor
 from horus_builtin.runtime.command import CommandRuntime
 from horus_builtin.target.local import LocalTarget
 from horus_builtin.task.horus_task import HorusTask
+from horus_builtin.workflow.subworkflow.errors import SubworkflowError
+from horus_builtin.workflow.subworkflow.ports import (
+    SubworkflowPort,
+    derive_ports,
+)
 from horus_runtime.core.artifact.base import BaseArtifact
 from horus_runtime.core.artifact.store import ArtifactStore
 from horus_runtime.core.executor.base import BaseExecutor
 from horus_runtime.core.runtime.base import BaseRuntime
 from horus_runtime.core.target.base import BaseTarget
 from horus_runtime.core.task.base import BaseTask
+from horus_runtime.core.workflow.base import BaseWorkflow
 from horus_runtime.core.workflow.edge import WorkflowEdge
-from horus_runtime.core.workflow.exceptions import WorkflowError
 from horus_runtime.i18n import tr as _
 from horus_runtime.logging import horus_logger
-
-if TYPE_CHECKING:
-    from horus_runtime.core.workflow.base import BaseWorkflow
 
 _ROOT_PREFIX = "artifact-"
 _ID_SEPARATOR = "/"
 _PORT_SUFFIX = ".port"
-
-
-class SubworkflowError(WorkflowError):
-    """Raised when a ``sub:`` block or a subworkflow body is malformed."""
-
-
-class SubworkflowPort(BaseModel):
-    """
-    One derived port of a subworkflow body.
-
-    A port is the parent-visible name of something already present in the
-    child: a root artifact (in-port) or an unconsumed task output
-    (out-port).
-    """
-
-    name: str
-    """Parent-visible port name (post ``port_overrides``)."""
-
-    artifact: str
-    """Artifact id inside the body (root id, or the producer's output id)."""
-
-    task: str | None = None
-    """Inner producer task id; ``None`` for an in-port (a root artifact)."""
 
 
 def _restore_declared_paths(
@@ -151,108 +58,24 @@ def _restore_declared_paths(
     """
     Undo the eager CWD resolution ``BaseArtifact`` applies at construction.
 
-    A live workflow's artifact paths are already absolute by the time it is
-    dumped, so a document made from one would pin every inner artifact
-    beside the *parent's* process CWD instead of inside the run directory.
-    Restoring each artifact's ``declared_path`` makes the document say what
-    its author wrote, which is also exactly what a YAML body already says.
+    ``BaseArtifact.path`` is resolved to an absolute, CWD-anchored path the
+    moment the artifact is built, while the original (possibly relative)
+    value is kept separately on ``declared_path`` (excluded from
+    ``model_dump``). Dumping a body as-is would therefore bake in the
+    *parent's* process CWD instead of leaving relative paths for the run
+    directory to anchor. Restoring each artifact's ``declared_path`` onto
+    the dumped ``path`` makes the document say what its author wrote.
     """
     for entry, artifact in zip(entries, artifacts, strict=False):
         if artifact.declared_path is not None:
             entry["path"] = str(artifact.declared_path)
 
 
-def _as_document(body: Any) -> Any:
-    """Serialize a live ``BaseWorkflow`` body, keeping declared paths."""
-    if not isinstance(body, BaseModel):
-        return body
-    document: dict[str, Any] = body.model_dump(mode="json")
-    tasks: list[BaseTask] = getattr(body, "tasks", [])
-    roots: list[BaseArtifact] = getattr(body, "artifacts", [])
-    _restore_declared_paths(_entries(document, "artifacts"), roots)
-    for entry, task in zip(_entries(document, "tasks"), tasks, strict=False):
-        _restore_declared_paths(entry.get("inputs") or [], list(task.inputs))
-        _restore_declared_paths(entry.get("outputs") or [], list(task.outputs))
-    return document
-
-
-def _entries(body: dict[str, Any], key: str) -> list[dict[str, Any]]:
-    """Return the ``key`` list of a body document as plain dicts."""
-    raw = body.get(key) or []
-    if not isinstance(raw, list):
-        return []
-    return [item for item in raw if isinstance(item, dict)]
-
-
-def derive_ports(
-    body: dict[str, Any],
-    port_overrides: dict[str, str] | None = None,
-) -> tuple[list[SubworkflowPort], list[SubworkflowPort]]:
-    """
-    Derive a subworkflow body's input and output ports.
-
-    This is the single definition of a subworkflow's interface, shared by
-    the load-time validator, the runtime expansion, and any other consumer
-    (a UI, or a future port of this rule to TypeScript). Nothing is
-    declared twice: the protocol lives in the child workflow document
-    itself.
-
-    Args:
-        body: A complete ``BaseWorkflow`` document.
-        port_overrides: Optional ``derived_name -> new_name`` renames,
-            applied last.
-
-    Returns:
-        ``(in_ports, out_ports)``. In-ports are the body's root artifacts
-        (``body["artifacts"]``), which inner edges reference as
-        ``artifact-<rootId>``. Out-ports are the task outputs no inner edge
-        consumes, named by artifact id and qualified to ``taskid.artifactid``
-        when two of them share an id.
-    """
-    overrides = port_overrides or {}
-
-    def rename(name: str) -> str:
-        return overrides.get(name, name)
-
-    in_ports = [
-        SubworkflowPort(name=rename(str(art["id"])), artifact=str(art["id"]))
-        for art in _entries(body, "artifacts")
-        if "id" in art
-    ]
-
-    consumed = {
-        (str(edge.get("source")), str(edge.get("source_output")))
-        for edge in _entries(body, "edges")
-    }
-    leaves = [
-        (str(task["id"]), str(out["id"]))
-        for task in _entries(body, "tasks")
-        if "id" in task
-        for out in (task.get("outputs") or [])
-        if isinstance(out, dict)
-        and "id" in out
-        and (str(task["id"]), str(out["id"])) not in consumed
-    ]
-    seen = Counter(artifact for _task, artifact in leaves)
-    out_ports = [
-        SubworkflowPort(
-            name=rename(
-                artifact if seen[artifact] == 1 else f"{task}.{artifact}"
-            ),
-            artifact=artifact,
-            task=task,
-        )
-        for task, artifact in leaves
-    ]
-
-    return in_ports, out_ports
-
-
 class SubworkflowExpander(HorusTask):
     """
     Inlines a complete child workflow into the parent's live DAG.
 
-    See the module docstring for port derivation and boundary rewiring.
+    See the package docstring for port derivation and boundary rewiring.
     """
 
     kind: str = "subworkflow"
@@ -274,15 +97,45 @@ class SubworkflowExpander(HorusTask):
     executor: BaseExecutor = Field(default_factory=ShellExecutor)
     target: BaseTarget = Field(default_factory=LocalTarget)
 
-    body: dict[str, Any]
+    body: BaseWorkflow
     """
-    A complete, valid ``BaseWorkflow`` document. Any existing workflow can
-    be dropped in unchanged: its ports are derived from it (see
-    :func:`derive_ports`), so nothing about it has to be adapted first.
+    A complete, valid child ``BaseWorkflow``. Any existing workflow can be
+    dropped in unchanged: its ports are derived from it (see
+    :func:`~horus_builtin.workflow.subworkflow.ports.derive_ports`), so
+    nothing about it has to be adapted first.
     """
 
     port_overrides: dict[str, str] = Field(default_factory=dict)
     """Optional ``derived_name -> new_name`` renames for derived ports."""
+
+    @field_serializer("body", mode="wrap")
+    def _dump_body(
+        self, body: BaseWorkflow, handler: SerializerFunctionWrapHandler
+    ) -> Any:
+        """
+        Dump ``body`` with declared (pre-resolution) artifact paths, not the
+        eagerly CWD-resolved ones ``BaseArtifact`` carries at runtime.
+
+        This matters whenever a ``SubworkflowExpander`` is itself dumped and
+        reloaded elsewhere (``to_yaml``/``from_yaml``, or a ``MapExpander``
+        capturing this as its per-clone template): without it, a relative
+        artifact path would be baked in absolute and never re-anchored to
+        the eventual run directory. See :func:`_restore_declared_paths`.
+        """
+        document = handler(body)
+        _restore_declared_paths(
+            document.get("artifacts") or [], body.artifacts
+        )
+        for entry, task in zip(
+            document.get("tasks") or [], body.tasks, strict=False
+        ):
+            _restore_declared_paths(
+                entry.get("inputs") or [], list(task.inputs)
+            )
+            _restore_declared_paths(
+                entry.get("outputs") or [], list(task.outputs)
+            )
+        return document
 
     max_depth: int = 10
     """
@@ -290,52 +143,28 @@ class SubworkflowExpander(HorusTask):
     Guards against a body that (transitively) embeds itself.
     """
 
-    @model_validator(mode="before")
-    @classmethod
-    def _accept_live_workflow(cls, data: Any) -> Any:
-        """
-        Accept a live ``BaseWorkflow`` as ``body`` and serialize it.
-
-        Dropping an existing workflow in should not require the author to
-        decide how to dump it; see :func:`_as_document` for why a plain
-        ``model_dump`` is not enough.
-        """
-        if isinstance(data, dict) and isinstance(data.get("body"), BaseModel):
-            return {**data, "body": _as_document(data["body"])}
-        return data
-
     @model_validator(mode="after")
     def _ensure_ports(self) -> Self:
         """
-        Validate the body and append one placeholder artifact per derived
-        port, idempotently (so a dumped-and-reloaded expander does not
-        duplicate them).
+        Append one placeholder artifact per derived port, idempotently (so
+        a dumped-and-reloaded expander does not duplicate them).
 
-        The body is checked by simply constructing a ``BaseWorkflow`` from
-        it, which reuses every existing workflow validation (unique ids,
-        edges resolve, no cycles) instead of reimplementing any of it. This
-        matters at load time, not only at run time: a UI must be able to
-        reject a malformed subworkflow when it is saved rather than
-        halfway through a run.
+        ``self.body`` is already a validated ``BaseWorkflow`` by this point
+        (pydantic validates it as a nested field, reusing every existing
+        workflow validation: unique ids, edges resolve, no cycles), so
+        there is nothing left to check here but the ``/``-in-id rule that
+        is specific to inlining.
         """
-        # Local import: base.py imports this module at import time.
-        from horus_runtime.core.workflow.base import (  # noqa: PLC0415
-            BaseWorkflow,
-        )
-
-        for entry in _entries(self.body, "tasks"):
-            inner_id = str(entry.get("id", ""))
-            if _ID_SEPARATOR in inner_id:
+        for task in self.body.tasks:
+            if _ID_SEPARATOR in task.id:
                 raise SubworkflowError(
                     _(
                         "Subworkflow '%(id)s' body task id '%(inner)s' may "
                         "not contain '/': it is reserved for the inlined "
                         "id prefix."
                     )
-                    % {"id": self.id, "inner": inner_id}
+                    % {"id": self.id, "inner": task.id}
                 )
-
-        BaseWorkflow.model_validate(self.body)
 
         in_ports, out_ports = derive_ports(self.body, self.port_overrides)
         for port in in_ports:
@@ -378,7 +207,7 @@ class SubworkflowExpander(HorusTask):
         """
         Inline the body: build the prefixed inner tasks, rewrite the inner
         edges, rewire the parent boundary edges, and commit everything in
-        one atomic ``wf.expand(...)``. See the module docstring.
+        one atomic ``wf.expand(...)``. See the package docstring.
         """
         wf = self.workflow
         if wf is None:
@@ -407,22 +236,19 @@ class SubworkflowExpander(HorusTask):
             port.artifact: self._resolve_in_port(wf, port) for port in in_ports
         }
 
-        for raw in _entries(self.body, "edges"):
-            source = str(raw.get("source"))
-            if source.startswith(_ROOT_PREFIX):
-                root = str(raw.get("source_output"))
+        for raw in self.body.edges:
+            if raw.source.startswith(_ROOT_PREFIX):
+                root = str(raw.source_output)
                 self._wire_in_port(root, raw, feeds, by_id, edges, artifacts)
             else:
                 edges.append(
                     WorkflowEdge(
-                        source=self._prefixed(source),
-                        source_output=raw.get("source_output"),
-                        target=self._prefixed(str(raw.get("target"))),
-                        target_input=raw.get("target_input"),
-                        transfer=bool(raw.get("transfer", True)),
-                        condition=self._prefixed_condition(
-                            raw.get("condition")
-                        ),
+                        source=self._prefixed(raw.source),
+                        source_output=raw.source_output,
+                        target=self._prefixed(raw.target),
+                        target_input=raw.target_input,
+                        transfer=raw.transfer,
+                        condition=self._prefixed_condition(raw.condition),
                     )
                 )
 
@@ -446,12 +272,11 @@ class SubworkflowExpander(HorusTask):
         Everything else about the condition is preserved verbatim, so a
         branch authored inside a child workflow composes unchanged.
         """
-        if not isinstance(condition, dict):
+        if condition is None or condition.source_task is None:
             return condition
-        source_task = condition.get("source_task")
-        if not isinstance(source_task, str):
-            return condition
-        return {**condition, "source_task": self._prefixed(source_task)}
+        return condition.model_copy(
+            update={"source_task": self._prefixed(condition.source_task)}
+        )
 
     def _build_inner_tasks(self, run_root: Path) -> list[BaseTask]:
         """
@@ -464,25 +289,22 @@ class SubworkflowExpander(HorusTask):
         workflow file.
         """
         tasks: list[BaseTask] = []
-        for entry in _entries(self.body, "tasks"):
-            inner_id = str(entry["id"])
-            if _ID_SEPARATOR in inner_id:
+        for entry in self.body.tasks:
+            if _ID_SEPARATOR in entry.id:
                 raise SubworkflowError(
                     _(
                         "Subworkflow '%(id)s' body task id '%(inner)s' may "
                         "not contain '/'."
                     )
-                    % {"id": self.id, "inner": inner_id}
+                    % {"id": self.id, "inner": entry.id}
                 )
-            data: dict[str, Any] = {**entry}
-            data.setdefault("kind", "horus_task")
-            data["id"] = self._prefixed(inner_id)
-            data["name"] = data["id"]
+            task = entry.model_copy(deep=True)
+            task.id = self._prefixed(entry.id)
+            task.name = task.id
             # A forced re-run of the expander (e.g. CLI --no-skip-all)
             # must reach the tasks it inlines.
             if not self.skip_if_complete:
-                data["skip_if_complete"] = False
-            task = BaseTask.model_validate(data)
+                task.skip_if_complete = False
             task.target = task.target.model_copy(deep=True)
             self._localize_paths(task, run_root)
             tasks.append(task)
@@ -506,7 +328,7 @@ class SubworkflowExpander(HorusTask):
             _pin(artifact, run_root / self.id / declared)
 
     def _resolve_in_port(
-        self, wf: "BaseWorkflow", port: SubworkflowPort
+        self, wf: BaseWorkflow, port: SubworkflowPort
     ) -> tuple[str, Any]:
         """
         Decide how the child root artifact behind *port* is fed.
@@ -550,7 +372,7 @@ class SubworkflowExpander(HorusTask):
     def _wire_in_port(
         self,
         root: str,
-        raw: dict[str, Any],
+        raw: WorkflowEdge,
         feeds: dict[str, tuple[str, Any]],
         by_id: dict[str, BaseTask],
         edges: list[WorkflowEdge],
@@ -562,8 +384,8 @@ class SubworkflowExpander(HorusTask):
         Mutates *edges*/*artifacts* in place; see :meth:`_resolve_in_port`
         for the three feeding modes.
         """
-        target = self._prefixed(str(raw.get("target")))
-        target_input = raw.get("target_input")
+        target = self._prefixed(raw.target)
+        target_input = raw.target_input
         mode, payload = feeds.get(root, ("root", None))
 
         if mode == "pinned":
@@ -597,12 +419,7 @@ class SubworkflowExpander(HorusTask):
         prefixed_root = self._prefixed(root)
         if not any(a.id == prefixed_root for a in artifacts):
             entry = next(
-                (
-                    a
-                    for a in _entries(self.body, "artifacts")
-                    if str(a.get("id")) == root
-                ),
-                None,
+                (a for a in self.body.artifacts if a.id == root), None
             )
             if entry is None:
                 raise SubworkflowError(
@@ -612,22 +429,20 @@ class SubworkflowExpander(HorusTask):
                     )
                     % {"id": self.id, "root": root}
                 )
-            artifacts.append(
-                BaseArtifact.model_validate({**entry, "id": prefixed_root})
-            )
+            artifacts.append(entry.model_copy(update={"id": prefixed_root}))
         edges.append(
             WorkflowEdge(
                 source=f"{_ROOT_PREFIX}{prefixed_root}",
                 source_output=prefixed_root,
                 target=target,
                 target_input=target_input,
-                transfer=bool(raw.get("transfer", True)),
-                condition=self._prefixed_condition(raw.get("condition")),
+                transfer=raw.transfer,
+                condition=self._prefixed_condition(raw.condition),
             )
         )
 
     def _out_port_edges(
-        self, wf: "BaseWorkflow", out_ports: list[SubworkflowPort]
+        self, wf: BaseWorkflow, out_ports: list[SubworkflowPort]
     ) -> list[WorkflowEdge]:
         """
         Re-emit every parent edge sourcing an out-port from the real inner
@@ -692,41 +507,8 @@ def _pin(artifact: BaseArtifact, path: Path) -> None:
     artifact.declared_path = path
 
 
-def lower_subworkflow_entry(entry: dict[str, Any]) -> dict[str, Any]:
-    """
-    Lower one raw YAML task-dict carrying a ``sub:`` block into a
-    ``kind: subworkflow`` task-dict.
-
-    Because ports are derived from the body, the sugar is just the child
-    workflow written inline — there is no port or binding block to author.
-
-    Args:
-        entry: The raw task dict as parsed from YAML, carrying ``id`` and a
-            ``sub`` key holding a complete child workflow document.
-
-    Returns:
-        A ``kind: subworkflow`` task dict ready for
-        ``BaseTask.model_validate``.
-    """
-    task_id = entry["id"]
-    data: dict[str, Any] = {
-        "kind": "subworkflow",
-        "id": task_id,
-        "name": entry.get("name") or task_id,
-        "description": entry.get("description", ""),
-        "body": entry["sub"],
-    }
-    if entry.get("port_overrides"):
-        data["port_overrides"] = entry["port_overrides"]
-    if entry.get("max_depth") is not None:
-        data["max_depth"] = entry["max_depth"]
-    if entry.get("target") is not None:
-        data["target"] = entry["target"]
-    return data
-
-
 def subworkflow_task(
-    wf: "BaseWorkflow",
+    wf: BaseWorkflow,
     *,
     id: str,
     body: "BaseWorkflow | dict[str, Any]",
@@ -738,7 +520,8 @@ def subworkflow_task(
     """
     Append a subworkflow task to *wf*.
 
-    Mirrors the YAML ``sub:`` block (see :func:`lower_subworkflow_entry`),
+    Mirrors the YAML ``sub:`` block (see
+    :func:`~horus_builtin.workflow.subworkflow.lowering.lower_subworkflow_entry`),
     so the two authoring paths produce structurally equivalent tasks.
 
     Args:
@@ -769,7 +552,7 @@ def subworkflow_task(
 
     expander = SubworkflowExpander(**kwargs)
     wf.tasks.append(expander)
-    # Boundary edges never carry data themselves (see the module
+    # Boundary edges never carry data themselves (see the package
     # docstring); force any that already exist, as the YAML lowering does.
     for edge in wf.edges:
         if id in (edge.source, edge.target):

--- a/src/horus_builtin/workflow/subworkflow/lowering.py
+++ b/src/horus_builtin/workflow/subworkflow/lowering.py
@@ -1,0 +1,55 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+YAML sugar lowering for the subworkflow construct.
+"""
+
+from typing import Any
+
+
+def lower_subworkflow_entry(entry: dict[str, Any]) -> dict[str, Any]:
+    """
+    Lower one raw YAML task-dict carrying a ``sub:`` block into a
+    ``kind: subworkflow`` task-dict.
+
+    Because ports are derived from the body, the sugar is just the child
+    workflow written inline — there is no port or binding block to author.
+
+    Args:
+        entry: The raw task dict as parsed from YAML, carrying ``id`` and a
+            ``sub`` key holding a complete child workflow document.
+
+    Returns:
+        A ``kind: subworkflow`` task dict ready for
+        ``BaseTask.model_validate``.
+    """
+    task_id = entry["id"]
+    data: dict[str, Any] = {
+        "kind": "subworkflow",
+        "id": task_id,
+        "name": entry.get("name") or task_id,
+        "description": entry.get("description", ""),
+        "body": entry["sub"],
+    }
+    if entry.get("port_overrides"):
+        data["port_overrides"] = entry["port_overrides"]
+    if entry.get("max_depth") is not None:
+        data["max_depth"] = entry["max_depth"]
+    if entry.get("target") is not None:
+        data["target"] = entry["target"]
+    return data

--- a/src/horus_builtin/workflow/subworkflow/lowering.py
+++ b/src/horus_builtin/workflow/subworkflow/lowering.py
@@ -28,7 +28,7 @@ def lower_subworkflow_entry(entry: dict[str, Any]) -> dict[str, Any]:
     ``kind: subworkflow`` task-dict.
 
     Because ports are derived from the body, the sugar is just the child
-    workflow written inline — there is no port or binding block to author.
+    workflow written inline. There is no port or binding block to author.
 
     Args:
         entry: The raw task dict as parsed from YAML, carrying ``id`` and a

--- a/src/horus_builtin/workflow/subworkflow/ports.py
+++ b/src/horus_builtin/workflow/subworkflow/ports.py
@@ -1,0 +1,107 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Port derivation for the subworkflow construct.
+
+Kept separate from :mod:`horus_builtin.workflow.subworkflow.expander` so it
+can be imported (directly, or via the package's ``__init__``) without
+pulling in a real ``BaseWorkflow`` import: this module only ever needs
+``BaseWorkflow`` as a type hint, never to construct or validate one.
+"""
+
+from collections import Counter
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel
+
+if TYPE_CHECKING:
+    from horus_runtime.core.workflow.base import BaseWorkflow
+
+
+class SubworkflowPort(BaseModel):
+    """
+    One derived port of a subworkflow body.
+
+    A port is the parent-visible name of something already present in the
+    child: a root artifact (in-port) or an unconsumed task output
+    (out-port).
+    """
+
+    name: str
+    """Parent-visible port name (post ``port_overrides``)."""
+
+    artifact: str
+    """Artifact id inside the body (root id, or the producer's output id)."""
+
+    task: str | None = None
+    """Inner producer task id; ``None`` for an in-port (a root artifact)."""
+
+
+def derive_ports(
+    body: "BaseWorkflow",
+    port_overrides: dict[str, str] | None = None,
+) -> tuple[list[SubworkflowPort], list[SubworkflowPort]]:
+    """
+    Derive a subworkflow body's input and output ports.
+
+    This is the single definition of a subworkflow's interface, shared by
+    the load-time validator and the runtime expansion. Nothing is declared
+    twice: the protocol lives in the child workflow itself.
+
+    Args:
+        body: A complete ``BaseWorkflow``.
+        port_overrides: Optional ``derived_name -> new_name`` renames,
+            applied last.
+
+    Returns:
+        ``(in_ports, out_ports)``. In-ports are the body's root artifacts
+        (``body.artifacts``), which inner edges reference as
+        ``artifact-<rootId>``. Out-ports are the task outputs no inner edge
+        consumes, named by artifact id and qualified to ``taskid.artifactid``
+        when two of them share an id.
+    """
+    overrides = port_overrides or {}
+
+    def rename(name: str) -> str:
+        return overrides.get(name, name)
+
+    in_ports = [
+        SubworkflowPort(name=rename(art.id), artifact=art.id)
+        for art in body.artifacts
+    ]
+
+    consumed = {(edge.source, edge.source_output) for edge in body.edges}
+    leaves = [
+        (task.id, out.id)
+        for task in body.tasks
+        for out in task.outputs
+        if (task.id, out.id) not in consumed
+    ]
+    seen = Counter(artifact for _task, artifact in leaves)
+    out_ports = [
+        SubworkflowPort(
+            name=rename(
+                artifact if seen[artifact] == 1 else f"{task}.{artifact}"
+            ),
+            artifact=artifact,
+            task=task,
+        )
+        for task, artifact in leaves
+    ]
+
+    return in_ports, out_ports

--- a/src/horus_builtin/workflow/subworkflow/ports.py
+++ b/src/horus_builtin/workflow/subworkflow/ports.py
@@ -17,11 +17,6 @@
 #
 """
 Port derivation for the subworkflow construct.
-
-Kept separate from :mod:`horus_builtin.workflow.subworkflow.expander` so it
-can be imported (directly, or via the package's ``__init__``) without
-pulling in a real ``BaseWorkflow`` import: this module only ever needs
-``BaseWorkflow`` as a type hint, never to construct or validate one.
 """
 
 from collections import Counter

--- a/src/horus_runtime/core/task/base.py
+++ b/src/horus_runtime/core/task/base.py
@@ -37,7 +37,7 @@ from horus_runtime.core.interaction.transport import BaseInteractionTransport
 from horus_runtime.core.resources import ResourceRequest
 from horus_runtime.core.runtime.base import BaseRuntime
 from horus_runtime.core.target.base import BaseTarget
-from horus_runtime.core.task.status import TaskStatus
+from horus_runtime.core.task.status import SkipReason, TaskStatus
 from horus_runtime.i18n import tr as _
 from horus_runtime.logging import horus_logger
 from horus_runtime.middleware.task import TaskMiddleware, TaskMiddlewareContext
@@ -149,6 +149,13 @@ class BaseTask(AutoRegistry, entry_point="task"):
     The current status of the task's execution.
     """
 
+    skip_reason: SkipReason | None = None
+    """
+    Why the task was skipped, set only alongside ``TaskStatus.SKIPPED``. Lets a
+    consumer tell a memoized cache hit apart from a branch that was not taken,
+    which are the same status but mean opposite things to a reader.
+    """
+
     runs: int = 0
     """
     Number of times this task has been run. This can be used for tracking and
@@ -253,6 +260,7 @@ class BaseTask(AutoRegistry, entry_point="task"):
                     )
                 )
                 self.status = TaskStatus.SKIPPED
+                self.skip_reason = SkipReason.COMPLETE
                 horus_logger.log.debug(
                     _("Task %(task_name)s status → SKIPPED")
                     % {"task_name": self.name}
@@ -326,6 +334,7 @@ class BaseTask(AutoRegistry, entry_point="task"):
         reset logic to ``_reset()``.
         """
         self.status = TaskStatus.IDLE
+        self.skip_reason = None
         horus_logger.log.debug(
             _("Task %(task_name)s reset → IDLE") % {"task_name": self.name}
         )

--- a/src/horus_runtime/core/task/status.py
+++ b/src/horus_runtime/core/task/status.py
@@ -59,5 +59,29 @@ class TaskStatus(Enum):
 
     SKIPPED = "skipped"
     """
-    The task was skipped because its outputs already exist.
+    The task did not execute, but counts as satisfied: downstream tasks run.
+    See ``SkipReason`` for why it was skipped.
+    """
+
+
+class SkipReason(Enum):
+    """
+    Why a ``SKIPPED`` task was skipped.
+
+    Both reasons produce the same ``TaskStatus`` because the scheduler treats
+    them identically (a skipped task is "done", so the DAG moves on). They are
+    distinguished here rather than by widening ``TaskStatus`` because that enum
+    is persisted and shared across repositories, and the difference matters
+    only for display: a cache hit and an untaken branch should not look alike.
+    """
+
+    COMPLETE = "complete"
+    """
+    ``skip_if_complete`` was set and the outputs already existed, so the work
+    was memoized away.
+    """
+
+    INACTIVE = "inactive"
+    """
+    No incoming edge was live, so this task is on a branch that was not taken.
     """

--- a/src/horus_runtime/core/workflow/base.py
+++ b/src/horus_runtime/core/workflow/base.py
@@ -34,7 +34,15 @@ from abc import abstractmethod
 from asyncio import CancelledError
 from collections.abc import Awaitable, Callable
 from pathlib import Path
-from typing import Any, ClassVar, Literal, NamedTuple, Self, final
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    ClassVar,
+    Literal,
+    NamedTuple,
+    Self,
+    final,
+)
 from uuid import UUID, uuid4
 
 import yaml
@@ -53,11 +61,7 @@ from horus_builtin.workflow.loop import (
     lower_loop_entry,
 )
 from horus_builtin.workflow.map import MapExpander, lower_map_entry, map_task
-from horus_builtin.workflow.subworkflow import (
-    SubworkflowExpander,
-    lower_subworkflow_entry,
-    subworkflow_task,
-)
+from horus_builtin.workflow.subworkflow.lowering import lower_subworkflow_entry
 from horus_runtime.context import HorusContext, current_task_id
 from horus_runtime.core.artifact.base import BaseArtifact
 from horus_runtime.core.placement import ResourceCapacity
@@ -84,6 +88,9 @@ from horus_runtime.middleware.workflow import (
     WorkflowMiddlewareContext,
 )
 from horus_runtime.registry.auto_registry import AutoRegistry
+
+if TYPE_CHECKING:
+    from horus_builtin.workflow.subworkflow.expander import SubworkflowExpander
 
 
 class _EdgeSource(NamedTuple):
@@ -377,15 +384,24 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
         max_depth: int | None = None,
         name: str | None = None,
         target: BaseTarget | None = None,
-    ) -> SubworkflowExpander:
+    ) -> "SubworkflowExpander":
         """
         Append a subworkflow (inlined child workflow) task to this workflow.
 
         Thin delegate to
-        :func:`horus_builtin.workflow.subworkflow.subworkflow_task`; see its
-        docstring for the full parameter reference. Equivalent to authoring
-        a ``sub:`` block in YAML.
+        :func:`horus_builtin.workflow.subworkflow.expander.subworkflow_task`;
+        see its docstring for the full parameter reference. Equivalent to
+        authoring a ``sub:`` block in YAML.
         """
+        # Local import: `.expander` needs the real `BaseWorkflow` (its
+        # `body` field needs the actual class, not a forward ref), so this
+        # module cannot import it at the top without a cycle. Everything
+        # else in the `subworkflow` package (errors/ports/lowering) needs
+        # no such import and is imported at the top, safely.
+        from horus_builtin.workflow.subworkflow.expander import (  # noqa: PLC0415
+            subworkflow_task,
+        )
+
         return subworkflow_task(
             self,
             id=id,

--- a/src/horus_runtime/core/workflow/base.py
+++ b/src/horus_runtime/core/workflow/base.py
@@ -34,7 +34,7 @@ from abc import abstractmethod
 from asyncio import CancelledError
 from collections.abc import Awaitable, Callable
 from pathlib import Path
-from typing import ClassVar, Literal, NamedTuple, Self, final
+from typing import Any, ClassVar, Literal, NamedTuple, Self, final
 from uuid import UUID, uuid4
 
 import yaml
@@ -53,6 +53,11 @@ from horus_builtin.workflow.loop import (
     lower_loop_entry,
 )
 from horus_builtin.workflow.map import MapExpander, lower_map_entry, map_task
+from horus_builtin.workflow.subworkflow import (
+    SubworkflowExpander,
+    lower_subworkflow_entry,
+    subworkflow_task,
+)
 from horus_runtime.context import HorusContext, current_task_id
 from horus_runtime.core.artifact.base import BaseArtifact
 from horus_runtime.core.placement import ResourceCapacity
@@ -303,6 +308,90 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
             over=over,
             range=range,
             index_input=index_input,
+            name=name,
+            target=target,
+        )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _lower_subworkflow_tasks(cls, data: object) -> object:
+        """
+        Lower any task carrying a ``sub:`` block into a ``subworkflow``
+        task, before normal per-task ``kind``-discriminated parsing runs.
+
+        See :func:`horus_builtin.workflow.subworkflow.
+        lower_subworkflow_entry`. Unlike the ``map:``/``loop:`` lowerings
+        this one also rewrites ``data["edges"]``: every parent edge
+        touching a lowered subworkflow is forced to ``transfer=False``,
+        because the expander re-emits the data-carrying edge onto the real
+        inlined producer/consumer at run time and two ``transfer=True``
+        edges on one input are rejected. This hook is the only place
+        holding both the task list and the edge list.
+
+        A no-op for workflows with no ``sub:`` tasks, including
+        already-lowered, round-tripped ones (``to_yaml`` dumps a
+        :class:`SubworkflowExpander` in its native ``kind: subworkflow``
+        form, not back into ``sub:`` block syntax) and direct Python
+        construction with real task objects.
+        """
+        if not isinstance(data, dict):
+            return data
+        tasks = data.get("tasks")
+        if not isinstance(tasks, list):
+            return data
+        lowered_ids = {
+            t["id"]
+            for t in tasks
+            if isinstance(t, dict) and "sub" in t and "id" in t
+        }
+        if not lowered_ids:
+            return data
+
+        new_tasks: list[object] = [
+            lower_subworkflow_entry(entry)
+            if isinstance(entry, dict) and "sub" in entry
+            else entry
+            for entry in tasks
+        ]
+
+        def _force_ordering(edge: object) -> object:
+            if isinstance(edge, dict) and (
+                edge.get("source") in lowered_ids
+                or edge.get("target") in lowered_ids
+            ):
+                return {**edge, "transfer": False}
+            return edge
+
+        new_edges: list[object] = [
+            _force_ordering(edge) for edge in data.get("edges") or []
+        ]
+
+        return {**data, "tasks": new_tasks, "edges": new_edges}
+
+    def subworkflow(
+        self,
+        *,
+        id: str,
+        body: "BaseWorkflow | dict[str, Any]",
+        port_overrides: dict[str, str] | None = None,
+        max_depth: int | None = None,
+        name: str | None = None,
+        target: BaseTarget | None = None,
+    ) -> SubworkflowExpander:
+        """
+        Append a subworkflow (inlined child workflow) task to this workflow.
+
+        Thin delegate to
+        :func:`horus_builtin.workflow.subworkflow.subworkflow_task`; see its
+        docstring for the full parameter reference. Equivalent to authoring
+        a ``sub:`` block in YAML.
+        """
+        return subworkflow_task(
+            self,
+            id=id,
+            body=body,
+            port_overrides=port_overrides,
+            max_depth=max_depth,
             name=name,
             target=target,
         )

--- a/src/horus_runtime/core/workflow/base.py
+++ b/src/horus_runtime/core/workflow/base.py
@@ -32,7 +32,7 @@ topological (DAG) order, which may differ from the order they are defined.
 
 from abc import abstractmethod
 from asyncio import CancelledError
-from collections.abc import Awaitable
+from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import ClassVar, Literal, NamedTuple, Self, final
 from uuid import UUID, uuid4
@@ -40,6 +40,7 @@ from uuid import UUID, uuid4
 import yaml
 from pydantic import Field, PrivateAttr, model_validator
 
+from horus_builtin.workflow.branch import BranchRouter, branch_task
 from horus_builtin.workflow.dag import (
     CyclicDependencyError,
     build_dependencies,
@@ -363,6 +364,34 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
             until=until,
             max_iterations=max_iterations,
             index_input=index_input,
+            name=name,
+            target=target,
+        )
+
+    def branch(
+        self,
+        *,
+        id: str,
+        func: Callable[..., str | list[str]],
+        routes: list[str],
+        name: str | None = None,
+        target: BaseTarget | None = None,
+    ) -> BranchRouter:
+        """
+        Append a switch-style branch (a router task plus one gated edge per
+        route) to this workflow.
+
+        Thin delegate to :func:`horus_builtin.workflow.branch.branch_task`;
+        see its docstring for the full parameter reference. There is no
+        equivalent YAML block, because a branch lowers to conditioned edges,
+        which YAML can already author directly (see the module docstring of
+        :mod:`horus_builtin.workflow.branch`).
+        """
+        return branch_task(
+            self,
+            id=id,
+            func=func,
+            routes=routes,
             name=name,
             target=target,
         )

--- a/src/horus_runtime/core/workflow/condition.py
+++ b/src/horus_runtime/core/workflow/condition.py
@@ -1,0 +1,214 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Serializable predicates that gate an edge, letting a workflow branch.
+
+Two forms, both attached to a ``WorkflowEdge``:
+
+``EdgeCondition``
+    Declarative data: read a JSON sentinel written by an upstream task, pull a
+    key out of it, compare it to a literal. No code, so it round-trips through
+    YAML and can be authored and edited in the canvas.
+
+``PythonCondition``
+    An arbitrary Python callable, for workflows authored in Python where
+    expressing the predicate as data would be clumsy. The callable itself is
+    excluded from serialization (as ``PythonFunctionRuntime.func`` already is),
+    so a ``module:qualname`` reference and a human-readable label are carried
+    alongside it: that is what survives the dump, what the canvas renders, and
+    what the orchestrator re-imports.
+
+Both are evaluated by ``horus_builtin.workflow.condition``. The model lives in
+core because ``WorkflowEdge`` references it; evaluation lives in builtin
+because it reads from targets.
+"""
+
+from collections.abc import Callable
+from typing import Any, Literal, Self
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from horus_runtime.i18n import tr as _
+
+ConditionOp = Literal[
+    "eq",
+    "ne",
+    "lt",
+    "le",
+    "gt",
+    "ge",
+    "in",
+    "not_in",
+    "truthy",
+    "exists",
+]
+"""
+The closed set of comparisons an ``EdgeCondition`` may apply. Deliberately
+closed: an open expression grammar would be a code-execution surface in a
+document the backend stores verbatim and never validates.
+"""
+
+
+class _SourcedCondition(BaseModel):
+    """
+    Shared field pair: which artifact holds the value being tested.
+
+    Both forms need this, and for the same reason. A branch edge is typically
+    artifact-less (the downstream task depends on the *decision*, not on the
+    decider's data), so the edge's own endpoints supply no default and the
+    condition has to name its sentinel itself.
+    """
+
+    source_task: str | None = None
+    """
+    Task whose output holds the value. Defaults to the edge's own ``source``,
+    which is the common case (test the thing you just depended on).
+    """
+
+    source_output: str | None = None
+    """
+    Output artifact id on ``source_task``, holding a JSON document. Defaults to
+    the edge's own ``source_output``.
+    """
+
+
+class EdgeCondition(_SourcedCondition):
+    """
+    A declarative predicate over an upstream task's JSON output.
+    """
+
+    kind: Literal["declarative"] = "declarative"
+    """Discriminator against ``PythonCondition``."""
+
+    key: str | None = None
+    """
+    Dotted path into the JSON document, e.g. ``metrics.accuracy``. ``None``
+    tests the whole document.
+    """
+
+    op: ConditionOp = "truthy"
+    """The comparison to apply."""
+
+    value: Any = None
+    """
+    JSON-safe literal to compare against. Unused by ``truthy`` and ``exists``;
+    must be a list for ``in`` / ``not_in``.
+    """
+
+    @model_validator(mode="after")
+    def check_value_matches_op(self) -> Self:
+        """
+        Reject operator/value combinations that could never evaluate.
+
+        Caught here rather than at evaluation time because a condition that
+        only explodes mid-run has already cost the user everything upstream of
+        the branch.
+        """
+        if self.op in ("in", "not_in") and not isinstance(
+            self.value, (list, tuple, set, str)
+        ):
+            raise ValueError(
+                _(
+                    "Condition operator '%(op)s' needs a collection to test "
+                    "membership against, got %(value)r."
+                )
+                % {"op": self.op, "value": self.value}
+            )
+        return self
+
+
+class PythonCondition(_SourcedCondition):
+    """
+    A predicate backed by a Python callable, with a serializable reference.
+
+    The callable receives the resolved JSON document of the source output (or
+    ``None`` when there is no source, or it wrote nothing) and returns a bool.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    kind: Literal["python"] = "python"
+    """Discriminator against ``EdgeCondition``."""
+
+    func: Callable[..., bool] | None = Field(default=None, exclude=True)
+    """
+    The in-memory callable. Excluded from serialization: a function cannot be
+    written to YAML, and the backend stores workflows as opaque JSON. Present
+    only within the process that built the workflow.
+    """
+
+    ref: str | None = None
+    """
+    ``module:qualname`` of ``func``, derived automatically when built from a
+    callable. This is what survives ``model_dump``, so it is how a run
+    dispatched to the orchestrator recovers the predicate. Resolvable only if
+    the module is importable in the run's plugin environment.
+    """
+
+    label: str | None = None
+    """
+    Short human-readable summary for display, e.g. ``accuracy > 0.9``. Derived
+    from the callable's docstring when not given. The canvas shows this, since
+    it cannot render the body of a function it does not have.
+    """
+
+    @model_validator(mode="after")
+    def derive_ref_and_label(self) -> Self:
+        """
+        Fill ``ref`` and ``label`` from ``func`` so the dump stays meaningful.
+
+        A lambda has a ``<lambda>`` qualname that cannot be imported back, so
+        it gets no ``ref``: it works in-process and fails loudly elsewhere,
+        which is better than emitting a reference that silently will not
+        resolve.
+        """
+        if self.func is not None and self.ref is None:
+            qualname = getattr(self.func, "__qualname__", "")
+            module = getattr(self.func, "__module__", "")
+            if module and qualname and "<lambda>" not in qualname:
+                self.ref = f"{module}:{qualname}"
+
+        if self.label is None:
+            doc = getattr(self.func, "__doc__", None)
+            if doc and doc.strip():
+                self.label = doc.strip().splitlines()[0].strip()
+            elif self.ref:
+                self.label = self.ref.rsplit(":", 1)[-1]
+
+        return self
+
+    @model_validator(mode="after")
+    def check_resolvable(self) -> Self:
+        """
+        A condition with neither a callable nor a reference can never evaluate.
+        """
+        if self.func is None and self.ref is None:
+            raise ValueError(
+                _(
+                    "A Python condition needs either a callable or a "
+                    "'module:qualname' reference."
+                )
+            )
+        return self
+
+
+Condition = EdgeCondition | PythonCondition
+"""
+Either predicate form. Discriminated on ``kind`` so a dumped condition loads
+back as the right class.
+"""

--- a/src/horus_runtime/core/workflow/condition.py
+++ b/src/horus_runtime/core/workflow/condition.py
@@ -54,6 +54,7 @@ ConditionOp = Literal[
     "ge",
     "in",
     "not_in",
+    "contains",
     "truthy",
     "exists",
 ]
@@ -61,7 +62,37 @@ ConditionOp = Literal[
 The closed set of comparisons an ``EdgeCondition`` may apply. Deliberately
 closed: an open expression grammar would be a code-execution surface in a
 document the backend stores verbatim and never validates.
+
+``in`` and ``contains`` are mirror images, and both are needed because the
+sentinel decides which side holds the collection: ``in`` tests a scalar in the
+document against a literal list, ``contains`` tests a *list* in the document
+against a scalar literal. The latter is what a document shaped
+``{"routes": [...]}`` needs, which is exactly what
+``horus_builtin.workflow.branch.BranchRouter`` writes.
 """
+
+
+def derive_ref(func: Callable[..., Any] | None) -> str | None:
+    """
+    Derive the ``module:qualname`` reference of *func*, or ``None``.
+
+    A lambda has a ``<lambda>`` qualname that cannot be imported back, so it
+    gets no reference: it works in-process and fails loudly elsewhere, which is
+    better than emitting a reference that silently will not resolve. Same for a
+    callable with no module.
+
+    Shared by every construct that carries a Python callable alongside a
+    serializable pointer to it (``PythonCondition``,
+    ``horus_builtin.workflow.branch.BranchRouter``), so "what survives the
+    dump" has one definition rather than one per authoring form.
+    """
+    if func is None:
+        return None
+    qualname = getattr(func, "__qualname__", "")
+    module = getattr(func, "__module__", "")
+    if module and qualname and "<lambda>" not in qualname:
+        return f"{module}:{qualname}"
+    return None
 
 
 class _SourcedCondition(BaseModel):
@@ -172,16 +203,10 @@ class PythonCondition(_SourcedCondition):
         """
         Fill ``ref`` and ``label`` from ``func`` so the dump stays meaningful.
 
-        A lambda has a ``<lambda>`` qualname that cannot be imported back, so
-        it gets no ``ref``: it works in-process and fails loudly elsewhere,
-        which is better than emitting a reference that silently will not
-        resolve.
+        See :func:`derive_ref` for why some callables get no ``ref`` at all.
         """
-        if self.func is not None and self.ref is None:
-            qualname = getattr(self.func, "__qualname__", "")
-            module = getattr(self.func, "__module__", "")
-            if module and qualname and "<lambda>" not in qualname:
-                self.ref = f"{module}:{qualname}"
+        if self.ref is None:
+            self.ref = derive_ref(self.func)
 
         if self.label is None:
             doc = getattr(self.func, "__doc__", None)

--- a/src/horus_runtime/core/workflow/edge.py
+++ b/src/horus_runtime/core/workflow/edge.py
@@ -24,10 +24,14 @@ Omitting both artifact ids makes the edge purely ordering: it needs no
 artifact on either end, so it can order tasks that declare none.
 """
 
-from typing import Self
+from typing import Annotated, Self
 
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, Field, model_validator
 
+from horus_runtime.core.workflow.condition import (
+    Condition,
+    EdgeCondition,
+)
 from horus_runtime.core.workflow.exceptions import IncompleteEdgeError
 
 
@@ -73,6 +77,19 @@ class WorkflowEdge(BaseModel):
     requires both ids to name declared artifacts).
     """
 
+    condition: Annotated[Condition, Field(discriminator="kind")] | None = None
+    """
+    Predicate gating this edge. ``None`` (the default) means the edge is always
+    taken, which is every edge that existed before branching.
+
+    A condition does not change the DAG: the edge still makes ``target``
+    depend on ``source``, and both branches of a fork stay statically present
+    so ``execution_plan`` keeps reasoning about the whole graph and the canvas
+    can draw the paths not taken. It changes only whether the target is
+    *live* (see ``horus_builtin.workflow.condition.compute_liveness``): a task
+    with no live incoming edge is skipped rather than run.
+    """
+
     @model_validator(mode="after")
     def check_endpoints_agree(self) -> Self:
         """
@@ -88,4 +105,22 @@ class WorkflowEdge(BaseModel):
             raise IncompleteEdgeError(self.source, self.target)
         if self.target_input is None:
             self.transfer = False
+        return self
+
+    @model_validator(mode="after")
+    def check_condition_resolves(self) -> Self:
+        """
+        A declarative condition must know which output to read.
+
+        Its ``source_task``/``source_output`` default to this edge's own
+        endpoints, so on an artifact-less ordering edge (where both are
+        ``None``) those defaults resolve to nothing. Require the condition to
+        name its own source in that case, rather than failing mid-run with a
+        confusing "task has no such output".
+        """
+        condition = self.condition
+        if isinstance(condition, EdgeCondition):
+            output = condition.source_output or self.source_output
+            if output is None:
+                raise IncompleteEdgeError(self.source, self.target)
         return self

--- a/tests/unit/workflow/test_branch_router.py
+++ b/tests/unit/workflow/test_branch_router.py
@@ -1,0 +1,479 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Unit tests for BranchRouter: the switch-style authoring form, and the
+property that keeps it honest — it lowers to the declarative conditions the
+scheduler already understands, adding no second evaluation path.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from horus_builtin.artifact.file import FileArtifact
+from horus_builtin.executor.shell import ShellExecutor
+from horus_builtin.runtime.command import CommandRuntime
+from horus_builtin.target.local import LocalTarget
+from horus_builtin.task.horus_task import HorusTask
+from horus_builtin.workflow.branch import (
+    BranchConfigurationError,
+    BranchRouter,
+    route_edge,
+)
+from horus_builtin.workflow.condition import evaluate_condition
+from horus_builtin.workflow.horus_workflow import HorusWorkflow
+from horus_runtime.context import HorusContext
+from horus_runtime.core.task.base import BaseTask
+from horus_runtime.core.task.status import SkipReason, TaskStatus
+from horus_runtime.core.workflow.condition import EdgeCondition
+from horus_runtime.core.workflow.edge import WorkflowEdge
+
+
+def _marker(tmp_path: Path, task_id: str) -> HorusTask:
+    """A task that writes a file, so 'did it run?' is observable on disk."""
+    out = tmp_path / f"{task_id}.done"
+    return HorusTask(
+        id=task_id,
+        name=task_id,
+        runtime=CommandRuntime(command=f"touch {out.as_posix()}"),
+        executor=ShellExecutor(),
+        target=LocalTarget(),
+        outputs=[FileArtifact(id="done", path=out)],
+        skip_if_complete=False,
+    )
+
+
+def _workflow(tmp_path: Path, *tasks: BaseTask) -> HorusWorkflow:
+    """A workflow rooted at *tmp_path*, holding *tasks*."""
+    return HorusWorkflow(
+        name="wf",
+        tasks=list(tasks),
+        orchestrator_target=LocalTarget(working_directory=tmp_path.as_posix()),
+    )
+
+
+def _pick_b() -> str:
+    """Take the b branch."""
+    return "b"
+
+
+def _pick_both() -> list[str]:
+    """Take both branches."""
+    return ["b", "c"]
+
+
+def _pick_none() -> list[str]:
+    """Take no branch at all."""
+    return []
+
+
+def _pick_unknown() -> str:
+    """Name a route that was never declared."""
+    return "nowhere"
+
+
+def _pick_nonsense() -> str:
+    """Return something that is not a route id."""
+    return 42  # type: ignore[return-value]
+
+
+async def _pick_b_async() -> str:
+    """Take the b branch, asynchronously."""
+    return "b"
+
+
+def _pick_own_id(task: BaseTask) -> str:
+    """Decide using the injected router task."""
+    assert isinstance(task, BranchRouter)
+    return task.routes[0]
+
+
+def _sentinel_of(router: BranchRouter) -> object:
+    """The decoded JSON document *router* wrote."""
+    artifact = next(
+        a for a in router.outputs if a.id == router.routes_output_id
+    )
+    return json.loads(Path(router.target.path_on_target(artifact)).read_text())
+
+
+@pytest.mark.unit
+class TestBranchRouterModel:
+    """Model-level behaviour: the sentinel output and the serializable ref."""
+
+    def test_sentinel_output_is_added_automatically(self) -> None:
+        """The router declares the output its edge conditions will read."""
+        router = BranchRouter(id="r", name="r", func=_pick_b, routes=["b"])
+        assert router.routes_output_id == "r.routes"
+        assert [o.id for o in router.outputs] == ["r.routes"]
+
+    def test_sentinel_output_is_not_duplicated_on_reload(self) -> None:
+        """Re-validating an already-dumped router keeps one sentinel."""
+        router = BranchRouter(id="r", name="r", func=_pick_b, routes=["b"])
+        reloaded = BaseTask.model_validate(router.model_dump(mode="json"))
+        assert [o.id for o in reloaded.outputs] == ["r.routes"]
+
+    def test_ref_derives_from_the_callable(self) -> None:
+        """Building from a function fills in the serializable reference."""
+        router = BranchRouter(id="r", name="r", func=_pick_b, routes=["b"])
+        assert router.ref == f"{__name__}:_pick_b"
+
+    def test_lambda_gets_no_reference(self) -> None:
+        """
+        A lambda cannot be imported back, so it carries no ref — the same
+        contract PythonCondition makes, via the same shared helper.
+        """
+        router = BranchRouter(id="r", name="r", func=lambda: "b", routes=["b"])
+        assert router.ref is None
+
+    def test_dump_drops_the_callable_but_keeps_the_reference(self) -> None:
+        """A function cannot be serialized; what survives is the reference."""
+        router = BranchRouter(id="r", name="r", func=_pick_b, routes=["b"])
+        dumped = router.model_dump(mode="json")
+
+        assert "func" not in dumped
+        assert dumped["ref"] == f"{__name__}:_pick_b"
+        assert dumped["kind"] == "branch_router"
+        assert dumped["routes"] == ["b"]
+
+    def test_router_without_callable_or_ref_is_rejected(self) -> None:
+        """A router that could never decide is rejected early."""
+        with pytest.raises(ValueError, match="callable or a"):
+            BranchRouter(id="r", name="r", routes=["b"])
+
+    async def test_is_never_complete(self) -> None:
+        """
+        The router must re-decide every run: a stale sentinel would pin a
+        resumed run to the branch it took last time.
+        """
+        router = BranchRouter(id="r", name="r", func=_pick_b, routes=["b"])
+        assert await router.is_complete() is False
+
+
+@pytest.mark.unit
+class TestLowersToDeclarative:
+    """
+    The property the whole design rests on: a router produces exactly the
+    wiring a hand-written declarative branch would, so there is only ever one
+    evaluation path.
+    """
+
+    def test_generated_edges_match_a_hand_written_branch(
+        self, tmp_path: Path
+    ) -> None:
+        """Router-generated edges are identical to hand-written ones."""
+        wf = _workflow(
+            tmp_path, _marker(tmp_path, "b"), _marker(tmp_path, "c")
+        )
+        wf.branch(id="r", func=_pick_b, routes=["b", "c"])
+
+        hand_written = [
+            WorkflowEdge(
+                source="r",
+                target=route,
+                condition=EdgeCondition(
+                    source_task="r",
+                    source_output="r.routes",
+                    key="routes",
+                    op="contains",
+                    value=route,
+                ),
+            )
+            for route in ("b", "c")
+        ]
+
+        assert [e.model_dump(mode="json") for e in wf.edges] == [
+            e.model_dump(mode="json") for e in hand_written
+        ]
+
+    async def test_sentinel_is_plain_data_a_hand_written_edge_can_read(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """
+        The sentinel carries no router-specific structure: an edge authored
+        by hand, with no knowledge of routers, evaluates it correctly.
+        """
+        del horus_context
+        wf = _workflow(
+            tmp_path, _marker(tmp_path, "b"), _marker(tmp_path, "c")
+        )
+        router = wf.branch(id="r", func=_pick_b, routes=["b", "c"])
+
+        await wf.run(trigger_id="r")
+
+        assert _sentinel_of(router) == {"routes": ["b"]}
+
+        taken = WorkflowEdge(
+            source="r",
+            target="b",
+            condition=EdgeCondition(
+                source_task="r",
+                source_output="r.routes",
+                key="routes",
+                op="contains",
+                value="b",
+            ),
+        )
+        untaken = WorkflowEdge(
+            source="r",
+            target="c",
+            condition=EdgeCondition(
+                source_task="r",
+                source_output="r.routes",
+                key="routes",
+                op="contains",
+                value="c",
+            ),
+        )
+        assert await evaluate_condition(wf, taken) is True
+        assert await evaluate_condition(wf, untaken) is False
+
+    async def test_dumped_router_edges_survive_a_yaml_round_trip(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """
+        Nothing about the branch needs the callable to round-trip: the edges
+        are ordinary declarative conditions.
+        """
+        del horus_context
+        wf = _workflow(
+            tmp_path, _marker(tmp_path, "b"), _marker(tmp_path, "c")
+        )
+        wf.branch(id="r", func=_pick_b, routes=["b", "c"])
+
+        path = tmp_path / "wf.yaml"
+        wf.to_yaml(path)
+        reloaded = HorusWorkflow.from_yaml(path)
+
+        condition = reloaded.edges[0].condition
+        assert isinstance(condition, EdgeCondition)
+        assert (condition.key, condition.op, condition.value) == (
+            "routes",
+            "contains",
+            "b",
+        )
+
+
+@pytest.mark.unit
+class TestDecision:
+    """Calling the function, and validating what it returns."""
+
+    async def _route(
+        self, tmp_path: Path, func: object, routes: list[str]
+    ) -> BranchRouter:
+        wf = _workflow(
+            tmp_path, _marker(tmp_path, "b"), _marker(tmp_path, "c")
+        )
+        router = wf.branch(
+            id="r",
+            func=func,  # type: ignore[arg-type]
+            routes=routes,
+        )
+        await wf.run(trigger_id="r")
+        return router
+
+    async def test_single_id_is_accepted(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """Returning a bare route id takes that one branch."""
+        del horus_context
+        router = await self._route(tmp_path, _pick_b, ["b", "c"])
+        assert _sentinel_of(router) == {"routes": ["b"]}
+
+    async def test_list_of_ids_is_accepted(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """A router may fan out to several branches at once."""
+        del horus_context
+        router = await self._route(tmp_path, _pick_both, ["b", "c"])
+        assert _sentinel_of(router) == {"routes": ["b", "c"]}
+
+    async def test_empty_list_takes_no_branch(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """Choosing nothing is a legal decision, not an error."""
+        del horus_context
+        router = await self._route(tmp_path, _pick_none, ["b", "c"])
+        assert _sentinel_of(router) == {"routes": []}
+
+    async def test_async_function_is_awaited(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """A decision may need to read something remote."""
+        del horus_context
+        router = await self._route(tmp_path, _pick_b_async, ["b", "c"])
+        assert _sentinel_of(router) == {"routes": ["b"]}
+
+    async def test_task_parameter_is_injected(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """A function asking for `task` receives the router itself."""
+        del horus_context
+        router = await self._route(tmp_path, _pick_own_id, ["b", "c"])
+        assert _sentinel_of(router) == {"routes": ["b"]}
+
+    async def test_undeclared_route_is_rejected(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """
+        A typo'd route id must fail loudly: silently taking no branch would
+        look like a deliberate decision and skip the rest of the DAG.
+        """
+        del horus_context
+        with pytest.raises(BranchConfigurationError, match="'nowhere'"):
+            await self._route(tmp_path, _pick_unknown, ["b", "c"])
+
+    async def test_non_string_return_is_rejected(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """A function returning something that is not a route id is a bug."""
+        del horus_context
+        with pytest.raises(BranchConfigurationError, match="must return"):
+            await self._route(tmp_path, _pick_nonsense, ["b", "c"])
+
+    async def test_undeclared_route_names_the_declared_set(
+        self, tmp_path: Path
+    ) -> None:
+        """The error says what was chosen and what was available."""
+        router = BranchRouter(
+            id="r", name="r", func=_pick_unknown, routes=["b", "c"]
+        )
+        del tmp_path
+        with pytest.raises(BranchConfigurationError, match="'nowhere'"):
+            await router._run()
+
+
+@pytest.mark.unit
+class TestBranchBuilder:
+    """`wf.branch(...)` wiring and its construction-time guards."""
+
+    def test_router_and_one_edge_per_route_are_appended(
+        self, tmp_path: Path
+    ) -> None:
+        """One call produces the router plus its whole fan-out."""
+        wf = _workflow(
+            tmp_path, _marker(tmp_path, "b"), _marker(tmp_path, "c")
+        )
+        router = wf.branch(id="r", func=_pick_b, routes=["b", "c"])
+
+        assert wf.tasks[-1] is router
+        assert [(e.source, e.target) for e in wf.edges] == [
+            ("r", "b"),
+            ("r", "c"),
+        ]
+
+    def test_edges_are_ordering_only(self, tmp_path: Path) -> None:
+        """
+        A branch target depends on the decision, not on the sentinel's bytes,
+        so it needs no input to receive them into.
+        """
+        wf = _workflow(tmp_path, _marker(tmp_path, "b"))
+        wf.branch(id="r", func=_pick_b, routes=["b"])
+
+        edge = wf.edges[0]
+        assert (edge.source_output, edge.target_input) == (None, None)
+        assert edge.transfer is False
+
+    def test_unknown_route_is_rejected(self, tmp_path: Path) -> None:
+        """Routing to a task that does not exist is caught at build time."""
+        wf = _workflow(tmp_path, _marker(tmp_path, "b"))
+        with pytest.raises(BranchConfigurationError, match="unknown task"):
+            wf.branch(id="r", func=_pick_b, routes=["b", "ghost"])
+
+    def test_empty_routes_are_rejected(self, tmp_path: Path) -> None:
+        """A branch with nowhere to go is a mistake."""
+        wf = _workflow(tmp_path, _marker(tmp_path, "b"))
+        with pytest.raises(BranchConfigurationError, match="at least one"):
+            wf.branch(id="r", func=_pick_b, routes=[])
+
+    def test_duplicate_routes_are_rejected(self, tmp_path: Path) -> None:
+        """Two identical edges to one target would just be noise."""
+        wf = _workflow(tmp_path, _marker(tmp_path, "b"))
+        with pytest.raises(BranchConfigurationError, match="duplicate"):
+            wf.branch(id="r", func=_pick_b, routes=["b", "b"])
+
+    def test_route_edge_is_the_single_definition_of_the_wiring(self) -> None:
+        """The builder emits exactly what `route_edge` describes."""
+        edge = route_edge("r", "r.routes", "b")
+        assert isinstance(edge.condition, EdgeCondition)
+        assert edge.condition.source_task == "r"
+        assert edge.condition.source_output == "r.routes"
+
+
+@pytest.mark.unit
+class TestBranchEndToEnd:
+    """A real run takes only the chosen branch, and ends completed."""
+
+    def _wf(self, tmp_path: Path) -> HorusWorkflow:
+        wf = _workflow(
+            tmp_path, _marker(tmp_path, "b"), _marker(tmp_path, "c")
+        )
+        wf.branch(id="r", func=_pick_b, routes=["b", "c"])
+        return wf
+
+    async def test_only_the_chosen_branch_runs(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """The untaken branch's command never executes."""
+        del horus_context
+        wf = self._wf(tmp_path)
+
+        await wf.run(trigger_id="r")
+
+        assert (tmp_path / "b.done").exists()
+        assert not (tmp_path / "c.done").exists()
+
+    async def test_untaken_branch_is_skipped_as_inactive(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """The router reuses the scheduler's existing liveness gate."""
+        del horus_context
+        wf = self._wf(tmp_path)
+
+        await wf.run(trigger_id="r")
+
+        by_id = {t.id: t for t in wf.tasks}
+        assert by_id["b"].status is TaskStatus.COMPLETED
+        assert by_id["c"].status is TaskStatus.SKIPPED
+        assert by_id["c"].skip_reason is SkipReason.INACTIVE
+
+    async def test_run_ends_completed_not_failed(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """An untaken branch must not look like a failure."""
+        del horus_context
+        wf = self._wf(tmp_path)
+
+        await wf.run(trigger_id="r")
+
+        assert wf.status.value == "completed"
+
+    async def test_multi_route_branch_runs_every_chosen_arm(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """Returning several ids activates all of them."""
+        del horus_context
+        wf = _workflow(
+            tmp_path, _marker(tmp_path, "b"), _marker(tmp_path, "c")
+        )
+        wf.branch(id="r", func=_pick_both, routes=["b", "c"])
+
+        await wf.run(trigger_id="r")
+
+        assert (tmp_path / "b.done").exists()
+        assert (tmp_path / "c.done").exists()

--- a/tests/unit/workflow/test_conditions.py
+++ b/tests/unit/workflow/test_conditions.py
@@ -1,0 +1,669 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Unit tests for conditional edges: the EdgeCondition / PythonCondition models,
+their evaluation, and the liveness rule the scheduler gates on.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from horus_builtin.artifact.file import FileArtifact
+from horus_builtin.executor.shell import ShellExecutor
+from horus_builtin.runtime.command import CommandRuntime
+from horus_builtin.target.local import LocalTarget
+from horus_builtin.task.horus_task import HorusTask
+from horus_builtin.workflow.condition import (
+    ConditionEvaluationError,
+    compute_liveness,
+    evaluate_condition,
+)
+from horus_builtin.workflow.horus_workflow import HorusWorkflow
+from horus_runtime.context import HorusContext
+from horus_runtime.core.task.status import SkipReason, TaskStatus
+from horus_runtime.core.workflow.base import BaseWorkflow
+from horus_runtime.core.workflow.condition import (
+    EdgeCondition,
+    PythonCondition,
+)
+from horus_runtime.core.workflow.edge import WorkflowEdge
+from horus_runtime.core.workflow.exceptions import IncompleteEdgeError
+
+
+def _decider(
+    tmp_path: Path, payload: object, *, task_id: str = "check"
+) -> HorusTask:
+    """A task whose JSON output already holds *payload*."""
+    path = tmp_path / f"{task_id}.json"
+    path.write_text(json.dumps(payload))
+    return HorusTask(
+        id=task_id,
+        name=task_id,
+        runtime=CommandRuntime(command="true"),
+        executor=ShellExecutor(),
+        target=LocalTarget(),
+        outputs=[FileArtifact(id="decision", path=path)],
+    )
+
+
+def _marker(tmp_path: Path, task_id: str) -> HorusTask:
+    """A task that writes a file, so 'did it run?' is observable on disk."""
+    out = tmp_path / f"{task_id}.done"
+    return HorusTask(
+        id=task_id,
+        name=task_id,
+        runtime=CommandRuntime(command=f"touch {out.as_posix()}"),
+        executor=ShellExecutor(),
+        target=LocalTarget(),
+        outputs=[FileArtifact(id="done", path=out)],
+        skip_if_complete=False,
+    )
+
+
+def _gate(source: str, target: str, **condition: object) -> WorkflowEdge:
+    """
+    An artifact-less ordering edge from *source* to *target*, gated by a
+    condition that names its own sentinel.
+
+    A branch edge deliberately carries no data: the downstream task depends on
+    the *decision*, not on the decider's output, so making it an ordering edge
+    keeps the branch target free of an input it would otherwise have to declare
+    and never receive.
+    """
+    return WorkflowEdge(
+        source=source,
+        target=target,
+        condition=EdgeCondition(
+            source_task="check",
+            source_output="decision",
+            **condition,  # type: ignore[arg-type]
+        ),
+    )
+
+
+@pytest.mark.unit
+class TestEdgeConditionModel:
+    """Model-level validation of the declarative predicate."""
+
+    def test_membership_ops_require_a_collection(self) -> None:
+        """Membership operators need something to test membership against."""
+        with pytest.raises(ValueError, match="membership"):
+            EdgeCondition(key="x", op="in", value=3)
+
+    def test_condition_needs_an_output_to_read(self) -> None:
+        """
+        An artifact-less ordering edge gives the condition no default source,
+        so one must be named explicitly rather than failing mid-run.
+        """
+        with pytest.raises(IncompleteEdgeError):
+            WorkflowEdge(
+                source="a",
+                target="b",
+                condition=EdgeCondition(key="x", op="truthy"),
+            )
+
+    def test_condition_defaults_to_the_edges_own_endpoints(self) -> None:
+        """An unset source falls back to the edge's own endpoints."""
+        edge = WorkflowEdge(
+            source="a",
+            source_output="decision",
+            target="b",
+            target_input="signal",
+            condition=EdgeCondition(key="branch", op="eq", value="x"),
+        )
+        assert edge.condition is not None
+        assert edge.condition.source_task is None
+        assert edge.condition.source_output is None
+
+    def test_plain_edge_has_no_condition(self) -> None:
+        """Every edge that predates branching keeps its old meaning."""
+        assert WorkflowEdge(source="a", target="b").condition is None
+
+
+@pytest.mark.unit
+class TestEvaluateCondition:
+    """Reading the sentinel and applying the operator."""
+
+    async def _wf(self, tmp_path: Path, payload: object) -> BaseWorkflow:
+        return HorusWorkflow(
+            name="wf",
+            tasks=[_decider(tmp_path, payload)],
+            orchestrator_target=LocalTarget(
+                working_directory=tmp_path.as_posix()
+            ),
+        )
+
+    @pytest.mark.parametrize(
+        ("op", "value", "expected"),
+        [
+            ("eq", "retrain", True),
+            ("eq", "skip", False),
+            ("ne", "skip", True),
+            ("in", ["retrain", "other"], True),
+            ("not_in", ["retrain"], False),
+            ("truthy", None, True),
+            ("exists", None, True),
+        ],
+    )
+    async def test_operators(
+        self,
+        tmp_path: Path,
+        horus_context: HorusContext,
+        op: str,
+        value: object,
+        expected: bool,
+    ) -> None:
+        """Each operator in the closed set applies as expected."""
+        del horus_context
+        wf = await self._wf(tmp_path, {"branch": "retrain"})
+        edge = _gate("check", "b", key="branch", op=op, value=value)
+        assert await evaluate_condition(wf, edge) is expected
+
+    async def test_dotted_key_walks_nested_documents(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """A dotted key selects a nested field."""
+        del horus_context
+        wf = await self._wf(tmp_path, {"metrics": {"accuracy": 0.94}})
+        edge = _gate("check", "b", key="metrics.accuracy", op="gt", value=0.9)
+        assert await evaluate_condition(wf, edge) is True
+
+    async def test_missing_key_is_absent_not_an_error(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """
+        A path that does not resolve reads as absent, so ``exists`` can
+        distinguish "no such key" from "key is false".
+        """
+        del horus_context
+        wf = await self._wf(tmp_path, {"branch": "retrain"})
+        edge = _gate("check", "b", key="nope.deeper", op="exists")
+        assert await evaluate_condition(wf, edge) is False
+
+    async def test_unwritten_sentinel_raises(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """
+        A predicate that cannot be read is a broken workflow, not a false
+        branch: failing loudly beats a run that silently skips half the DAG.
+        """
+        del horus_context
+        task = _decider(tmp_path, {"branch": "x"})
+        (tmp_path / "check.json").unlink()
+        wf = HorusWorkflow(
+            name="wf",
+            tasks=[task],
+            orchestrator_target=LocalTarget(
+                working_directory=tmp_path.as_posix()
+            ),
+        )
+        edge = _gate("check", "b", key="branch", op="truthy")
+        with pytest.raises(ConditionEvaluationError, match="never written"):
+            await evaluate_condition(wf, edge)
+
+    async def test_malformed_json_raises(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """A sentinel that is not JSON is a broken workflow."""
+        del horus_context
+        task = _decider(tmp_path, {"branch": "x"})
+        (tmp_path / "check.json").write_text("{not json")
+        wf = HorusWorkflow(
+            name="wf",
+            tasks=[task],
+            orchestrator_target=LocalTarget(
+                working_directory=tmp_path.as_posix()
+            ),
+        )
+        edge = _gate("check", "b", key="branch", op="truthy")
+        with pytest.raises(ConditionEvaluationError, match="not valid JSON"):
+            await evaluate_condition(wf, edge)
+
+    async def test_uncomparable_values_raise(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """Ordering values that cannot be ordered is an error, not `false`."""
+        del horus_context
+        wf = await self._wf(tmp_path, {"branch": "text"})
+        edge = _gate("check", "b", key="branch", op="gt", value=3)
+        with pytest.raises(ConditionEvaluationError, match="Cannot compare"):
+            await evaluate_condition(wf, edge)
+
+    async def test_edge_without_condition_is_always_taken(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """An unconditioned edge keeps its pre-branching meaning."""
+        del horus_context
+        wf = await self._wf(tmp_path, {})
+        edge = WorkflowEdge(source="check", target="b")
+        assert await evaluate_condition(wf, edge) is True
+
+
+@pytest.mark.unit
+class TestLiveness:
+    """The OR-join rule, evaluated directly."""
+
+    async def test_root_task_is_live(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """A task no other task feeds is always live."""
+        del horus_context
+        wf = HorusWorkflow(
+            name="wf",
+            tasks=[_decider(tmp_path, {})],
+            orchestrator_target=LocalTarget(
+                working_directory=tmp_path.as_posix()
+            ),
+        )
+        assert await compute_liveness(wf, "check", {}) is True
+
+    async def test_dead_source_is_not_evaluated(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """
+        A dead task never wrote its sentinel, so a condition reading it would
+        raise. Liveness must short-circuit on the dead source instead.
+        """
+        del horus_context
+        wf = HorusWorkflow(
+            name="wf",
+            tasks=[_decider(tmp_path, {}), _marker(tmp_path, "b")],
+            edges=[_gate("check", "b", key="branch", op="truthy")],
+            orchestrator_target=LocalTarget(
+                working_directory=tmp_path.as_posix()
+            ),
+        )
+        (tmp_path / "check.json").unlink()
+
+        # No raise, despite the sentinel being absent, because `check` is
+        # already known dead.
+        assert await compute_liveness(wf, "b", {"check": False}) is False
+
+
+@pytest.mark.unit
+class TestDiamondBranchEndToEnd:
+    """
+    The shape that decides the whole design: ``A -> (B | C) -> D``.
+
+    Blocking the untaken branch's descendants would also block D, because D is
+    a descendant of C. Marking C skipped-but-completed is what lets the join
+    run.
+    """
+
+    def _diamond(self, tmp_path: Path) -> HorusWorkflow:
+        check = _decider(tmp_path, {"branch": "b"})
+        join = HorusTask(
+            id="d",
+            name="d",
+            runtime=CommandRuntime(
+                command=f"touch {(tmp_path / 'd.done').as_posix()}"
+            ),
+            executor=ShellExecutor(),
+            target=LocalTarget(),
+            outputs=[FileArtifact(id="done", path=tmp_path / "d.done")],
+            skip_if_complete=False,
+        )
+        return HorusWorkflow(
+            name="wf",
+            tasks=[
+                check,
+                _marker(tmp_path, "b"),
+                _marker(tmp_path, "c"),
+                join,
+            ],
+            edges=[
+                _gate("check", "b", key="branch", op="eq", value="b"),
+                _gate("check", "c", key="branch", op="eq", value="c"),
+                WorkflowEdge(source="b", target="d"),
+                WorkflowEdge(source="c", target="d"),
+            ],
+            orchestrator_target=LocalTarget(
+                working_directory=tmp_path.as_posix()
+            ),
+        )
+
+    async def test_join_runs_when_one_branch_is_skipped(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """The join downstream of both branches still runs."""
+        del horus_context
+        wf = self._diamond(tmp_path)
+
+        await wf.run(trigger_id="check")
+
+        by_id = {t.id: t for t in wf.tasks}
+        assert by_id["b"].status is TaskStatus.COMPLETED
+        assert by_id["c"].status is TaskStatus.SKIPPED
+        assert by_id["c"].skip_reason is SkipReason.INACTIVE
+
+        # The whole point: the join is downstream of the skipped branch and
+        # still runs.
+        assert by_id["d"].status is TaskStatus.COMPLETED
+        assert (tmp_path / "d.done").exists()
+
+    async def test_untaken_branch_does_not_execute(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """The dead branch's command never runs."""
+        del horus_context
+        wf = self._diamond(tmp_path)
+
+        await wf.run(trigger_id="check")
+
+        assert (tmp_path / "b.done").exists()
+        assert not (tmp_path / "c.done").exists()
+
+    async def test_run_ends_completed_not_failed(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """
+        A skipped branch must not look like a failure. Guards the path where
+        the scheduler raises WorkflowExecutionError for anything in `failed`.
+        """
+        del horus_context
+        wf = self._diamond(tmp_path)
+
+        await wf.run(trigger_id="check")
+
+        assert wf.status.value == "completed"
+
+
+@pytest.mark.unit
+class TestTransitiveDeactivation:
+    """Deactivation propagates down a chain with no conditions of its own."""
+
+    async def test_task_below_a_dead_branch_is_skipped(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """Deactivation propagates to a task with no condition of its own."""
+        del horus_context
+        chained = _marker(tmp_path, "e")
+        wf = HorusWorkflow(
+            name="wf",
+            tasks=[
+                _decider(tmp_path, {"branch": "b"}),
+                _marker(tmp_path, "c"),
+                chained,
+            ],
+            edges=[
+                _gate("check", "c", key="branch", op="eq", value="c"),
+                WorkflowEdge(source="c", target="e"),
+            ],
+            orchestrator_target=LocalTarget(
+                working_directory=tmp_path.as_posix()
+            ),
+        )
+
+        await wf.run(trigger_id="check")
+
+        by_id = {t.id: t for t in wf.tasks}
+        assert by_id["c"].skip_reason is SkipReason.INACTIVE
+        # `e` carries no condition at all; it is dead purely because its only
+        # parent is.
+        assert by_id["e"].status is TaskStatus.SKIPPED
+        assert by_id["e"].skip_reason is SkipReason.INACTIVE
+        assert not (tmp_path / "e.done").exists()
+
+
+@pytest.mark.unit
+class TestSkipReasonDistinguishesCacheHit:
+    """A memoized skip and an untaken branch must not look alike."""
+
+    async def test_memoized_skip_reports_complete(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """A cache hit records COMPLETE, not INACTIVE."""
+        del horus_context
+        done = tmp_path / "cached.done"
+        done.write_text("already here")
+        task = HorusTask(
+            id="cached",
+            name="cached",
+            runtime=CommandRuntime(command="true"),
+            executor=ShellExecutor(),
+            target=LocalTarget(),
+            outputs=[FileArtifact(id="done", path=done)],
+            skip_if_complete=True,
+        )
+        wf = HorusWorkflow(
+            name="wf",
+            tasks=[task],
+            orchestrator_target=LocalTarget(
+                working_directory=tmp_path.as_posix()
+            ),
+        )
+
+        await wf.run(trigger_id="cached")
+
+        assert task.status is TaskStatus.SKIPPED
+        assert task.skip_reason is SkipReason.COMPLETE
+
+    async def test_reset_clears_the_reason(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """Resetting a task clears any recorded skip reason."""
+        del horus_context
+        task = _marker(tmp_path, "x")
+        task.status = TaskStatus.SKIPPED
+        task.skip_reason = SkipReason.INACTIVE
+
+        await task.reset()
+
+        assert task.status is TaskStatus.IDLE
+        assert task.skip_reason is None
+
+
+@pytest.mark.unit
+class TestConditionYamlRoundTrip:
+    """Conditions are a native edge key, so they survive a dump and reload."""
+
+    async def test_declarative_condition_round_trips(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """A declarative condition survives to_yaml then from_yaml."""
+        del horus_context
+        wf = HorusWorkflow(
+            name="wf",
+            tasks=[
+                _decider(tmp_path, {"branch": "b"}),
+                _marker(tmp_path, "b"),
+            ],
+            edges=[_gate("check", "b", key="branch", op="eq", value="b")],
+            orchestrator_target=LocalTarget(
+                working_directory=tmp_path.as_posix()
+            ),
+        )
+
+        path = tmp_path / "wf.yaml"
+        wf.to_yaml(path)
+        reloaded = BaseWorkflow.from_yaml(path)
+
+        condition = reloaded.edges[0].condition
+        assert isinstance(condition, EdgeCondition)
+        assert (condition.key, condition.op, condition.value) == (
+            "branch",
+            "eq",
+            "b",
+        )
+
+    async def test_condition_is_absent_from_plain_edges(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """A workflow with no branching dumps a null condition and reloads."""
+        del horus_context
+        wf = HorusWorkflow(
+            name="wf",
+            tasks=[_decider(tmp_path, {})],
+            orchestrator_target=LocalTarget(
+                working_directory=tmp_path.as_posix()
+            ),
+        )
+        path = tmp_path / "wf.yaml"
+        wf.to_yaml(path)
+
+        raw = yaml.safe_load(path.read_text())
+        assert raw["edges"] == []
+        assert BaseWorkflow.from_yaml(path).edges == []
+
+
+def _accuracy_is_high(document: object) -> bool:
+    """Accuracy is above the 0.9 threshold."""
+    assert isinstance(document, dict)
+    return bool(document["metrics"]["accuracy"] > 0.9)
+
+
+@pytest.mark.unit
+class TestPythonCondition:
+    """The Python authoring form, and the serialization contract behind it."""
+
+    def test_ref_and_label_derive_from_the_callable(self) -> None:
+        """Building from a function fills in ref and label."""
+        condition = PythonCondition(func=_accuracy_is_high)
+        assert condition.ref == f"{__name__}:_accuracy_is_high"
+        assert condition.label == "Accuracy is above the 0.9 threshold."
+
+    def test_dump_drops_the_callable_but_keeps_the_reference(self) -> None:
+        """
+        The contract the canvas depends on: a function cannot be serialized,
+        so what reaches the UI is the reference and the label.
+        """
+        edge = WorkflowEdge(
+            source="check",
+            source_output="decision",
+            target="b",
+            target_input="signal",
+            transfer=False,
+            condition=PythonCondition(func=_accuracy_is_high),
+        )
+        dumped = edge.model_dump(mode="json")
+
+        assert "func" not in dumped["condition"]
+        assert dumped["condition"]["ref"] == f"{__name__}:_accuracy_is_high"
+        assert dumped["condition"]["kind"] == "python"
+
+    def test_reload_resolves_by_reference(self) -> None:
+        """A reloaded condition keeps its ref but has no callable."""
+        edge = WorkflowEdge(
+            source="check",
+            source_output="decision",
+            target="b",
+            target_input="signal",
+            transfer=False,
+            condition=PythonCondition(func=_accuracy_is_high),
+        )
+        reloaded = WorkflowEdge.model_validate(edge.model_dump(mode="json"))
+
+        assert isinstance(reloaded.condition, PythonCondition)
+        assert reloaded.condition.func is None
+        assert reloaded.condition.ref == f"{__name__}:_accuracy_is_high"
+
+    def test_lambda_gets_no_reference(self) -> None:
+        """
+        A lambda cannot be imported back, so it carries no ref: it works in
+        process and fails loudly elsewhere, rather than emitting a reference
+        that silently will not resolve.
+        """
+        assert PythonCondition(func=lambda _doc: True).ref is None
+
+    def test_condition_without_callable_or_ref_is_rejected(self) -> None:
+        """A condition that could never evaluate is rejected early."""
+        with pytest.raises(ValueError, match="callable or a"):
+            PythonCondition()
+
+    async def test_unresolvable_ref_raises(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """Must not silently read as live."""
+        del horus_context
+        wf = HorusWorkflow(
+            name="wf",
+            tasks=[_decider(tmp_path, {"metrics": {"accuracy": 0.95}})],
+            orchestrator_target=LocalTarget(
+                working_directory=tmp_path.as_posix()
+            ),
+        )
+        edge = WorkflowEdge(
+            source="check",
+            source_output="decision",
+            target="b",
+            target_input="signal",
+            transfer=False,
+            condition=PythonCondition(ref="no.such.module:predicate"),
+        )
+        with pytest.raises(
+            ConditionEvaluationError, match="cannot be imported"
+        ):
+            await evaluate_condition(wf, edge)
+
+    async def test_callable_receives_the_source_document(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """The predicate is handed the decoded sentinel."""
+        del horus_context
+        wf = HorusWorkflow(
+            name="wf",
+            tasks=[_decider(tmp_path, {"metrics": {"accuracy": 0.95}})],
+            orchestrator_target=LocalTarget(
+                working_directory=tmp_path.as_posix()
+            ),
+        )
+        edge = WorkflowEdge(
+            source="check",
+            source_output="decision",
+            target="b",
+            target_input="signal",
+            transfer=False,
+            condition=PythonCondition(func=_accuracy_is_high),
+        )
+        assert await evaluate_condition(wf, edge) is True
+
+    async def test_python_branch_end_to_end(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """A false Python predicate deactivates its branch in a real run."""
+        del horus_context
+        wf = HorusWorkflow(
+            name="wf",
+            tasks=[
+                _decider(tmp_path, {"metrics": {"accuracy": 0.5}}),
+                _marker(tmp_path, "b"),
+            ],
+            edges=[
+                WorkflowEdge(
+                    source="check",
+                    target="b",
+                    condition=PythonCondition(
+                        func=_accuracy_is_high,
+                        source_task="check",
+                        source_output="decision",
+                    ),
+                )
+            ],
+            orchestrator_target=LocalTarget(
+                working_directory=tmp_path.as_posix()
+            ),
+        )
+
+        await wf.run(trigger_id="check")
+
+        by_id = {t.id: t for t in wf.tasks}
+        assert by_id["b"].skip_reason is SkipReason.INACTIVE
+        assert not (tmp_path / "b.done").exists()

--- a/tests/unit/workflow/test_subworkflow.py
+++ b/tests/unit/workflow/test_subworkflow.py
@@ -36,10 +36,10 @@ from horus_builtin.task.horus_task import HorusTask
 from horus_builtin.workflow.horus_workflow import HorusWorkflow
 from horus_builtin.workflow.subworkflow import (
     SubworkflowError,
-    SubworkflowExpander,
     derive_ports,
     lower_subworkflow_entry,
 )
+from horus_builtin.workflow.subworkflow.expander import SubworkflowExpander
 from horus_runtime.context import HorusContext
 from horus_runtime.core.task.status import TaskStatus
 from horus_runtime.core.workflow.base import BaseWorkflow
@@ -210,7 +210,7 @@ class TestDerivePorts:
 
     def test_root_artifacts_become_in_ports(self, tmp_path: Path) -> None:
         """Every standalone root artifact is an input port."""
-        body = _child_workflow(_seed_file(tmp_path)).model_dump(mode="json")
+        body = _child_workflow(_seed_file(tmp_path))
         in_ports, _out = derive_ports(body)
         assert [p.name for p in in_ports] == ["seed"]
         assert in_ports[0].artifact == "seed"
@@ -218,27 +218,29 @@ class TestDerivePorts:
 
     def test_unconsumed_outputs_become_out_ports(self, tmp_path: Path) -> None:
         """Only outputs no inner edge consumes are exposed."""
-        body = _child_workflow(_seed_file(tmp_path)).model_dump(mode="json")
+        body = _child_workflow(_seed_file(tmp_path))
         _in, out_ports = derive_ports(body)
         assert [p.name for p in out_ports] == ["report_out"]
         assert out_ports[0].task == "report"
 
     def test_colliding_output_ids_are_qualified(self) -> None:
         """Two leaves sharing an artifact id get ``taskid.artifactid``."""
-        body = {
-            "kind": "horus_workflow",
-            "name": "child",
-            "tasks": [
-                {"id": "a", "outputs": [{"id": "out"}]},
-                {"id": "b", "outputs": [{"id": "out"}]},
-            ],
-        }
+        body = BaseWorkflow.model_validate(
+            {
+                "kind": "horus_workflow",
+                "name": "child",
+                "tasks": [
+                    _task_dict("a", ["out"]),
+                    _task_dict("b", ["out"]),
+                ],
+            }
+        )
         _in, out_ports = derive_ports(body)
         assert sorted(p.name for p in out_ports) == ["a.out", "b.out"]
 
     def test_port_overrides_rename_derived_ports(self, tmp_path: Path) -> None:
         """``port_overrides`` renames a derived port and nothing else."""
-        body = _child_workflow(_seed_file(tmp_path)).model_dump(mode="json")
+        body = _child_workflow(_seed_file(tmp_path))
         in_ports, out_ports = derive_ports(body, {"report_out": "summary"})
         assert [p.name for p in in_ports] == ["seed"]
         assert [p.name for p in out_ports] == ["summary"]
@@ -249,9 +251,7 @@ class TestDerivePorts:
     ) -> None:
         """The expander declares one never-written artifact per port."""
         child = _child_workflow(_seed_file(tmp_path))
-        sub = SubworkflowExpander(
-            id="sub", name="sub", body=child.model_dump(mode="json")
-        )
+        sub = SubworkflowExpander(id="sub", name="sub", body=child)
         assert [a.id for a in sub.inputs] == ["seed"]
         assert [a.id for a in sub.outputs] == ["report_out"]
 
@@ -260,9 +260,7 @@ class TestDerivePorts:
     ) -> None:
         """Re-validating a dumped expander does not duplicate ports."""
         child = _child_workflow(_seed_file(tmp_path))
-        sub = SubworkflowExpander(
-            id="sub", name="sub", body=child.model_dump(mode="json")
-        )
+        sub = SubworkflowExpander(id="sub", name="sub", body=child)
         again = SubworkflowExpander.model_validate(sub.model_dump(mode="json"))
         assert [a.id for a in again.outputs] == ["report_out"]
 
@@ -283,8 +281,8 @@ class TestExistingWorkflowDropsInUnchanged:
         child = _child_workflow(_seed_file(tmp_path, "abc"))
         wf = _parent(tmp_path)
         sub = wf.subworkflow(id="sub", body=child)
-        assert [t["id"] for t in sub.body["tasks"]] == ["upper", "report"]
-        assert sub.body["edges"] == child.model_dump(mode="json")["edges"]
+        assert [t.id for t in sub.body.tasks] == ["upper", "report"]
+        assert sub.body.edges == child.edges
 
         await wf.run(trigger_id="sub")
 
@@ -619,7 +617,8 @@ class TestConditionInsideSubworkflow:
                 }
             ],
         }
-        sub = SubworkflowExpander(id="sub", name="sub", body=body)
+        sub_wf = BaseWorkflow.model_validate(body)
+        sub = SubworkflowExpander(id="sub", name="sub", body=sub_wf)
         # ``flag`` is consumed by the inner edge only as a condition
         # source, so it stays an out-port alongside ``out``.
         assert {a.id for a in sub.outputs} == {"flag", "out"}
@@ -741,18 +740,21 @@ class TestSubworkflowErrors:
             "name": "child",
             "tasks": [_task_dict("a"), _task_dict("a")],
         }
+        wf = BaseWorkflow.model_validate(body)
         with pytest.raises(TaskIdsAreNotUniqueError):
-            SubworkflowExpander(id="sub", name="sub", body=body)
+            SubworkflowExpander(id="sub", name="sub", body=wf)
 
     def test_slash_in_inner_id_is_rejected(self) -> None:
         """``/`` is reserved for the inlined id prefix."""
         body = {
             "kind": "horus_workflow",
             "name": "child",
-            "tasks": [{"id": "a/b"}],
+            "tasks": [_task_dict("a/b")],
         }
+        wf = BaseWorkflow.model_validate(body)
+
         with pytest.raises(SubworkflowError, match="'/'"):
-            SubworkflowExpander(id="sub", name="sub", body=body)
+            SubworkflowExpander(id="sub", name="sub", body=wf)
 
     def test_unresolved_inner_edge_is_rejected(self) -> None:
         """Existing edge validation is reused, not reimplemented."""
@@ -762,8 +764,9 @@ class TestSubworkflowErrors:
             "tasks": [_task_dict("a")],
             "edges": [{"source": "a", "target": "nope"}],
         }
+        wf = BaseWorkflow.model_validate(body)
         with pytest.raises(UnknownEdgeEndpointError):
-            SubworkflowExpander(id="sub", name="sub", body=body)
+            SubworkflowExpander(id="sub", name="sub", body=wf)
 
     async def test_depth_guard_stops_runaway_nesting(
         self, tmp_path: Path, horus_context: HorusContext

--- a/tests/unit/workflow/test_subworkflow.py
+++ b/tests/unit/workflow/test_subworkflow.py
@@ -740,8 +740,8 @@ class TestSubworkflowErrors:
             "name": "child",
             "tasks": [_task_dict("a"), _task_dict("a")],
         }
-        wf = BaseWorkflow.model_validate(body)
         with pytest.raises(TaskIdsAreNotUniqueError):
+            wf = BaseWorkflow.model_validate(body)
             SubworkflowExpander(id="sub", name="sub", body=wf)
 
     def test_slash_in_inner_id_is_rejected(self) -> None:
@@ -751,9 +751,9 @@ class TestSubworkflowErrors:
             "name": "child",
             "tasks": [_task_dict("a/b")],
         }
-        wf = BaseWorkflow.model_validate(body)
 
         with pytest.raises(SubworkflowError, match="'/'"):
+            wf = BaseWorkflow.model_validate(body)
             SubworkflowExpander(id="sub", name="sub", body=wf)
 
     def test_unresolved_inner_edge_is_rejected(self) -> None:
@@ -764,8 +764,8 @@ class TestSubworkflowErrors:
             "tasks": [_task_dict("a")],
             "edges": [{"source": "a", "target": "nope"}],
         }
-        wf = BaseWorkflow.model_validate(body)
         with pytest.raises(UnknownEdgeEndpointError):
+            wf = BaseWorkflow.model_validate(body)
             SubworkflowExpander(id="sub", name="sub", body=wf)
 
     async def test_depth_guard_stops_runaway_nesting(

--- a/tests/unit/workflow/test_subworkflow.py
+++ b/tests/unit/workflow/test_subworkflow.py
@@ -1,0 +1,826 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Unit tests for the subworkflow construct: port derivation, inlining,
+boundary rewiring, the ``sub:`` YAML lowering hook and the
+``wf.subworkflow(...)`` Python builder.
+"""
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from horus_builtin.artifact.file import FileArtifact
+from horus_builtin.artifact.folder import FolderArtifact
+from horus_builtin.executor.shell import ShellExecutor
+from horus_builtin.runtime.command import CommandRuntime
+from horus_builtin.target.local import LocalTarget
+from horus_builtin.task.horus_task import HorusTask
+from horus_builtin.workflow.horus_workflow import HorusWorkflow
+from horus_builtin.workflow.subworkflow import (
+    SubworkflowError,
+    SubworkflowExpander,
+    derive_ports,
+    lower_subworkflow_entry,
+)
+from horus_runtime.context import HorusContext
+from horus_runtime.core.task.status import TaskStatus
+from horus_runtime.core.workflow.base import BaseWorkflow
+from horus_runtime.core.workflow.condition import EdgeCondition
+from horus_runtime.core.workflow.edge import WorkflowEdge
+from horus_runtime.core.workflow.exceptions import (
+    TaskIdsAreNotUniqueError,
+    UnknownEdgeEndpointError,
+)
+
+
+def _shell_task(
+    task_id: str,
+    command: str,
+    *,
+    inputs: list[Any] | None = None,
+    outputs: list[Any] | None = None,
+) -> HorusTask:
+    """Build a minimal local shell task with the given artifacts."""
+    return HorusTask(
+        id=task_id,
+        name=task_id,
+        runtime=CommandRuntime(command=command),
+        executor=ShellExecutor(),
+        target=LocalTarget(),
+        inputs=inputs or [],
+        outputs=outputs or [],
+    )
+
+
+def _child_workflow(seed: Path) -> HorusWorkflow:
+    """
+    A two-task child workflow with one root artifact and one leaf output.
+
+    Derived interface: in-port ``seed`` (the root artifact), out-port
+    ``report_out`` (``report``'s unconsumed output).
+    """
+    upper = _shell_task(
+        "upper",
+        "tr a-z A-Z < $seed > $upped",
+        inputs=[FileArtifact(id="seed", path=Path("seed_in.txt"))],
+        outputs=[FileArtifact(id="upped", path=Path("upped.txt"))],
+    )
+    report = _shell_task(
+        "report",
+        "cat $upped > $report_out",
+        inputs=[FileArtifact(id="upped", path=Path("upped.txt"))],
+        outputs=[FileArtifact(id="report_out", path=Path("report.txt"))],
+    )
+    return HorusWorkflow(
+        name="child",
+        tasks=[upper, report],
+        artifacts=[FileArtifact(id="seed", path=seed)],
+        edges=[
+            WorkflowEdge(
+                source="artifact-seed",
+                source_output="seed",
+                target="upper",
+                target_input="seed",
+            ),
+            WorkflowEdge(
+                source="upper",
+                source_output="upped",
+                target="report",
+                target_input="upped",
+            ),
+        ],
+    )
+
+
+def _task_dict(task_id: str, outputs: list[str] | None = None) -> Any:
+    """A minimal serialized task dict for hand-built body documents."""
+    return _shell_task(
+        task_id,
+        "true",
+        outputs=[
+            FileArtifact(id=out, path=Path(f"{out}.txt"))
+            for out in outputs or []
+        ],
+    ).model_dump(mode="json")
+
+
+def _yaml_task(
+    task_id: str,
+    command: str,
+    *,
+    inputs: list[tuple[str, str]] | None = None,
+    outputs: list[tuple[str, str]] | None = None,
+) -> dict[str, Any]:
+    """A hand-written task dict, exactly as a YAML author would spell it."""
+    return {
+        "kind": "horus_task",
+        "id": task_id,
+        "name": task_id,
+        "runtime": {"kind": "command", "command": command},
+        "executor": {"kind": "shell"},
+        "target": {"kind": "local"},
+        "inputs": [
+            {"kind": "file", "id": i, "path": p} for i, p in inputs or []
+        ],
+        "outputs": [
+            {"kind": "file", "id": i, "path": p} for i, p in outputs or []
+        ],
+    }
+
+
+def _yaml_child(seed: Path) -> dict[str, Any]:
+    """The YAML spelling of :func:`_child_workflow`."""
+    return {
+        "kind": "horus_workflow",
+        "name": "child",
+        "artifacts": [{"kind": "file", "id": "seed", "path": seed.as_posix()}],
+        "tasks": [
+            _yaml_task(
+                "upper",
+                "tr a-z A-Z < $seed > $upped",
+                inputs=[("seed", "seed_in.txt")],
+                outputs=[("upped", "upped.txt")],
+            ),
+            _yaml_task(
+                "report",
+                "cat $upped > $report_out",
+                inputs=[("upped", "upped.txt")],
+                outputs=[("report_out", "report.txt")],
+            ),
+        ],
+        "edges": [
+            {
+                "source": "artifact-seed",
+                "source_output": "seed",
+                "target": "upper",
+                "target_input": "seed",
+            },
+            {
+                "source": "upper",
+                "source_output": "upped",
+                "target": "report",
+                "target_input": "upped",
+            },
+        ],
+    }
+
+
+def _seed_file(tmp_path: Path, text: str = "hello") -> Path:
+    """Write and return a seed input file."""
+    seed = tmp_path / "seed.txt"
+    seed.write_text(text)
+    return seed
+
+
+def _parent(tmp_path: Path, **kwargs: Any) -> HorusWorkflow:
+    """A parent workflow rooted at *tmp_path*."""
+    return HorusWorkflow(
+        name="parent",
+        orchestrator_target=LocalTarget(working_directory=tmp_path.as_posix()),
+        **kwargs,
+    )
+
+
+def _inner(wf: BaseWorkflow, task_id: str) -> Any:
+    """Fetch an inlined task by its prefixed id."""
+    return next(t for t in wf.tasks if t.id == task_id)
+
+
+@pytest.mark.unit
+class TestDerivePorts:
+    """Ports are derived from the child workflow document itself."""
+
+    def test_root_artifacts_become_in_ports(self, tmp_path: Path) -> None:
+        """Every standalone root artifact is an input port."""
+        body = _child_workflow(_seed_file(tmp_path)).model_dump(mode="json")
+        in_ports, _out = derive_ports(body)
+        assert [p.name for p in in_ports] == ["seed"]
+        assert in_ports[0].artifact == "seed"
+        assert in_ports[0].task is None
+
+    def test_unconsumed_outputs_become_out_ports(self, tmp_path: Path) -> None:
+        """Only outputs no inner edge consumes are exposed."""
+        body = _child_workflow(_seed_file(tmp_path)).model_dump(mode="json")
+        _in, out_ports = derive_ports(body)
+        assert [p.name for p in out_ports] == ["report_out"]
+        assert out_ports[0].task == "report"
+
+    def test_colliding_output_ids_are_qualified(self) -> None:
+        """Two leaves sharing an artifact id get ``taskid.artifactid``."""
+        body = {
+            "kind": "horus_workflow",
+            "name": "child",
+            "tasks": [
+                {"id": "a", "outputs": [{"id": "out"}]},
+                {"id": "b", "outputs": [{"id": "out"}]},
+            ],
+        }
+        _in, out_ports = derive_ports(body)
+        assert sorted(p.name for p in out_ports) == ["a.out", "b.out"]
+
+    def test_port_overrides_rename_derived_ports(self, tmp_path: Path) -> None:
+        """``port_overrides`` renames a derived port and nothing else."""
+        body = _child_workflow(_seed_file(tmp_path)).model_dump(mode="json")
+        in_ports, out_ports = derive_ports(body, {"report_out": "summary"})
+        assert [p.name for p in in_ports] == ["seed"]
+        assert [p.name for p in out_ports] == ["summary"]
+        assert out_ports[0].artifact == "report_out"
+
+    def test_placeholders_are_declared_for_every_port(
+        self, tmp_path: Path
+    ) -> None:
+        """The expander declares one never-written artifact per port."""
+        child = _child_workflow(_seed_file(tmp_path))
+        sub = SubworkflowExpander(
+            id="sub", name="sub", body=child.model_dump(mode="json")
+        )
+        assert [a.id for a in sub.inputs] == ["seed"]
+        assert [a.id for a in sub.outputs] == ["report_out"]
+
+    def test_placeholder_declaration_is_idempotent(
+        self, tmp_path: Path
+    ) -> None:
+        """Re-validating a dumped expander does not duplicate ports."""
+        child = _child_workflow(_seed_file(tmp_path))
+        sub = SubworkflowExpander(
+            id="sub", name="sub", body=child.model_dump(mode="json")
+        )
+        again = SubworkflowExpander.model_validate(sub.model_dump(mode="json"))
+        assert [a.id for a in again.outputs] == ["report_out"]
+
+
+@pytest.mark.unit
+class TestExistingWorkflowDropsInUnchanged:
+    """An existing workflow can be embedded as a body with no edits."""
+
+    async def test_unmodified_workflow_runs_as_a_subworkflow(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """
+        A workflow authored standalone is embedded verbatim: the stored
+        body is byte-identical to its own dump, and running the parent
+        produces the child's output.
+        """
+        del horus_context
+        child = _child_workflow(_seed_file(tmp_path, "abc"))
+        wf = _parent(tmp_path)
+        sub = wf.subworkflow(id="sub", body=child)
+        assert [t["id"] for t in sub.body["tasks"]] == ["upper", "report"]
+        assert sub.body["edges"] == child.model_dump(mode="json")["edges"]
+
+        await wf.run(trigger_id="sub")
+
+        assert wf.status.value == "completed"
+        report = _inner(wf, "sub/report")
+        assert report.outputs[0].path.read_text().strip() == "ABC"
+
+    async def test_child_root_artifact_survives_when_unfed(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """
+        An in-port the parent does not feed keeps the child's own root
+        artifact, re-registered under the prefixed id.
+        """
+        del horus_context
+        child = _child_workflow(_seed_file(tmp_path, "xyz"))
+        wf = _parent(tmp_path)
+        wf.subworkflow(id="sub", body=child)
+
+        await wf.run(trigger_id="sub")
+
+        assert wf.status.value == "completed"
+        assert any(a.id == "sub/seed" for a in wf.artifacts)
+
+
+@pytest.mark.unit
+class TestSubworkflowInliningEndToEnd:
+    """The child's tasks and edges land in the parent's live DAG."""
+
+    async def test_inner_tasks_are_prefixed_and_run(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """Inner ids are ``<sub>/<inner>`` and every one of them runs."""
+        del horus_context
+        child = _child_workflow(_seed_file(tmp_path))
+        wf = _parent(tmp_path)
+        wf.subworkflow(id="sub", body=child)
+
+        await wf.run(trigger_id="sub")
+
+        ids = {t.id for t in wf.tasks}
+        assert {"sub", "sub/upper", "sub/report"} == ids
+        for task in wf.tasks:
+            assert task.status in (TaskStatus.COMPLETED, TaskStatus.SKIPPED)
+
+    async def test_no_ordering_edges_are_emitted_to_inner_tasks(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """
+        Inner roots are gated by ``_gate_new_tasks_behind_creator``'s
+        implicit dependency, not by an edge from the expander.
+        """
+        del horus_context
+        child = _child_workflow(_seed_file(tmp_path))
+        wf = _parent(tmp_path)
+        wf.subworkflow(id="sub", body=child)
+
+        await wf.run(trigger_id="sub")
+
+        assert not [e for e in wf.edges if e.source == "sub"]
+        assert wf.implicit_task_dependencies["sub/upper"] == {"sub"}
+        # ``sub/report`` is ordered by the inner edge instead.
+        assert "sub/report" not in wf.implicit_task_dependencies
+
+    async def test_expander_never_reports_complete(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """Port placeholders are never written, so the expander re-runs."""
+        del horus_context
+        child = _child_workflow(_seed_file(tmp_path))
+        wf = _parent(tmp_path)
+        sub = wf.subworkflow(id="sub", body=child)
+
+        await wf.run(trigger_id="sub")
+
+        assert await sub.is_complete() is False
+
+
+@pytest.mark.unit
+class TestBoundaryWiring:
+    """Parent edges are re-emitted onto the real inner endpoints."""
+
+    async def test_in_port_is_fed_by_a_parent_task(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """A parent producer feeds the child's root artifact."""
+        del horus_context
+        prep = _shell_task(
+            "prep",
+            "printf 'from-parent' > $seed_out",
+            outputs=[FileArtifact(id="seed_out", path=Path("seed_out.txt"))],
+        )
+        child = _child_workflow(_seed_file(tmp_path))
+        wf = _parent(tmp_path, tasks=[prep])
+        wf.subworkflow(id="sub", body=child)
+        wf.edges.append(
+            WorkflowEdge(
+                source="prep",
+                source_output="seed_out",
+                target="sub",
+                target_input="seed",
+                transfer=False,
+            )
+        )
+
+        await wf.run(trigger_id="prep")
+
+        assert wf.status.value == "completed"
+        report = _inner(wf, "sub/report")
+        assert report.outputs[0].path.read_text().strip() == "FROM-PARENT"
+        # The child's own root artifact is dropped: the parent supplies it.
+        assert not any(a.id == "sub/seed" for a in wf.artifacts)
+
+    async def test_out_port_feeds_a_parent_task(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """A parent consumer receives the child's leaf output."""
+        del horus_context
+        final = _shell_task(
+            "final",
+            "cat $res > $final_out",
+            inputs=[FileArtifact(id="res", path=Path("res_in.txt"))],
+            outputs=[FileArtifact(id="final_out", path=Path("final.txt"))],
+        )
+        child = _child_workflow(_seed_file(tmp_path, "tail"))
+        wf = _parent(tmp_path, tasks=[final])
+        wf.subworkflow(id="sub", body=child)
+        wf.edges.append(
+            WorkflowEdge(
+                source="sub",
+                source_output="report_out",
+                target="final",
+                target_input="res",
+                transfer=False,
+            )
+        )
+
+        await wf.run(trigger_id="sub")
+
+        assert wf.status.value == "completed"
+        assert final.outputs[0].path.read_text().strip() == "TAIL"
+        assert any(
+            e.source == "sub/report" and e.target == "final" and e.transfer
+            for e in wf.edges
+        )
+
+    def test_builder_forces_existing_boundary_edges_to_ordering(
+        self, tmp_path: Path
+    ) -> None:
+        """``wf.subworkflow`` downgrades boundary edges it can see."""
+        child = _child_workflow(_seed_file(tmp_path))
+        wf = _parent(tmp_path)
+        # A pre-existing edge object, wired before the builder runs.
+        edge = WorkflowEdge(
+            source="sub",
+            source_output="report_out",
+            target="sub",
+            target_input="seed",
+        )
+        wf.edges.append(edge)
+        wf.subworkflow(id="sub", body=child)
+        assert edge.transfer is False
+
+
+@pytest.mark.unit
+class TestNestedSubworkflows:
+    """A body may itself contain a subworkflow task."""
+
+    async def test_two_levels_expand(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """Ids nest as ``outer/inner/leaf``, one level per iteration."""
+        del horus_context
+        leaf = _child_workflow(_seed_file(tmp_path, "deep"))
+        middle = _parent(tmp_path)
+        middle.name = "middle"
+        middle.subworkflow(id="inner", body=leaf)
+
+        wf = _parent(tmp_path)
+        wf.subworkflow(id="outer", body=middle)
+
+        await wf.run(trigger_id="outer")
+
+        assert wf.status.value == "completed"
+        ids = {t.id for t in wf.tasks}
+        assert "outer/inner" in ids
+        assert "outer/inner/report" in ids
+        report = _inner(wf, "outer/inner/report")
+        assert report.outputs[0].path.read_text().strip() == "DEEP"
+
+
+@pytest.mark.unit
+class TestSubworkflowAsMapTemplate:
+    """A subworkflow validates and expands as a ``map:`` template."""
+
+    async def test_mapped_subworkflow_runs_per_clone(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """
+        Each map clone inlines its own copy of the body, with per-clone
+        paths. Fan-in of a mapped subworkflow's *results* is a known gap:
+        ``MapExpander._pin_path`` pins the port placeholder rather than
+        the inner producer's real output.
+        """
+        del horus_context
+        emit = _shell_task(
+            "emit",
+            "mkdir -p $out && cp $idx $out/idx.json",
+            inputs=[FileArtifact(id="idx", path=Path("idx_in.json"))],
+            outputs=[FolderArtifact(id="out", path=Path("emit_out"))],
+        )
+        body = HorusWorkflow(
+            name="child",
+            tasks=[emit],
+            artifacts=[FileArtifact(id="idx", path=tmp_path / "idx.json")],
+            edges=[
+                WorkflowEdge(
+                    source="artifact-idx",
+                    source_output="idx",
+                    target="emit",
+                    target_input="idx",
+                )
+            ],
+        )
+        template = SubworkflowExpander(id="tpl", name="tpl", body=body)
+        gather = _shell_task(
+            "gather",
+            "true",
+            inputs=[FolderArtifact(id="results", path=Path("gather_in"))],
+            outputs=[FileArtifact(id="done", path=tmp_path / "done.txt")],
+        )
+        wf = _parent(tmp_path, tasks=[gather])
+        wf.map(
+            id="fan",
+            template=template,
+            range=2,
+            index_input="idx",
+            gather=("gather", "results"),
+        )
+
+        await wf.run(trigger_id="fan")
+
+        assert wf.status.value == "completed"
+        for i in range(2):
+            inner = _inner(wf, f"fan[{i}]/emit")
+            assert inner.status is TaskStatus.COMPLETED
+            assert (inner.outputs[0].path / "idx.json").read_text() == str(i)
+
+
+@pytest.mark.unit
+class TestConditionInsideSubworkflow:
+    """A conditional edge inside a body still branches once inlined."""
+
+    async def test_inner_condition_gates_an_inner_task(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """The false branch is skipped, the true branch completes."""
+        del horus_context
+        decide = _shell_task(
+            "decide",
+            "printf '{\"go\": true}' > $verdict",
+            outputs=[FileArtifact(id="verdict", path=Path("verdict.json"))],
+        )
+        taken = _shell_task(
+            "taken",
+            "printf yes > $taken_out",
+            outputs=[FileArtifact(id="taken_out", path=Path("taken.txt"))],
+        )
+        skipped = _shell_task(
+            "skipped",
+            "printf no > $skipped_out",
+            outputs=[FileArtifact(id="skipped_out", path=Path("skip.txt"))],
+        )
+        body = HorusWorkflow(
+            name="child",
+            tasks=[decide, taken, skipped],
+            edges=[
+                WorkflowEdge(
+                    source="decide",
+                    target="taken",
+                    condition=EdgeCondition(
+                        source_task="decide",
+                        source_output="verdict",
+                        key="go",
+                        op="eq",
+                        value=True,
+                    ),
+                ),
+                WorkflowEdge(
+                    source="decide",
+                    target="skipped",
+                    condition=EdgeCondition(
+                        source_task="decide",
+                        source_output="verdict",
+                        key="go",
+                        op="eq",
+                        value=False,
+                    ),
+                ),
+            ],
+        )
+        wf = _parent(tmp_path)
+        wf.subworkflow(id="sub", body=body)
+
+        await wf.run(trigger_id="sub")
+
+        assert _inner(wf, "sub/taken").status is TaskStatus.COMPLETED
+        assert _inner(wf, "sub/skipped").status is TaskStatus.SKIPPED
+
+    def test_inner_conditions_are_carried_through_verbatim(
+        self, tmp_path: Path
+    ) -> None:
+        """The lowered inner edge keeps the body's condition."""
+        del tmp_path
+        body = {
+            "kind": "horus_workflow",
+            "name": "child",
+            "tasks": [
+                _task_dict("a", ["flag"]),
+                _task_dict("b", ["out"]),
+            ],
+            "edges": [
+                {
+                    "source": "a",
+                    "target": "b",
+                    "condition": {
+                        "kind": "declarative",
+                        "source_task": "a",
+                        "source_output": "flag",
+                        "op": "truthy",
+                    },
+                }
+            ],
+        }
+        sub = SubworkflowExpander(id="sub", name="sub", body=body)
+        # ``flag`` is consumed by the inner edge only as a condition
+        # source, so it stays an out-port alongside ``out``.
+        assert {a.id for a in sub.outputs} == {"flag", "out"}
+
+
+@pytest.mark.unit
+class TestYamlLowering:
+    """The ``sub:`` sugar lowers to a native ``kind: subworkflow`` task."""
+
+    def test_sub_block_lowers_to_subworkflow_task(self) -> None:
+        """``lower_subworkflow_entry`` produces a native task dict."""
+        entry = {
+            "id": "sub",
+            "sub": {"kind": "horus_workflow", "name": "child", "tasks": []},
+            "port_overrides": {"a": "b"},
+        }
+        lowered = lower_subworkflow_entry(entry)
+        assert lowered["kind"] == "subworkflow"
+        assert lowered["id"] == "sub"
+        assert lowered["body"]["name"] == "child"
+        assert lowered["port_overrides"] == {"a": "b"}
+
+    async def test_yaml_workflow_with_sub_block_runs(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """A ``sub:`` block loads, forces ordering edges, and runs."""
+        del horus_context
+        child = _yaml_child(_seed_file(tmp_path, "yamlish"))
+        doc: dict[str, Any] = {
+            "kind": "horus_workflow",
+            "name": "parent",
+            "orchestrator_target": {
+                "kind": "local",
+                "working_directory": tmp_path.as_posix(),
+            },
+            "tasks": [
+                _yaml_task(
+                    "final",
+                    "cat $res > $final_out",
+                    inputs=[("res", "res_in.txt")],
+                    outputs=[("final_out", "final.txt")],
+                ),
+                {"id": "sub", "sub": child},
+            ],
+            "edges": [
+                {
+                    "source": "sub",
+                    "source_output": "report_out",
+                    "target": "final",
+                    "target_input": "res",
+                }
+            ],
+        }
+        path = tmp_path / "wf.yaml"
+        with path.open("w") as fh:
+            yaml.safe_dump(doc, fh)
+
+        wf = BaseWorkflow.from_yaml(path)
+        boundary = next(e for e in wf.edges if e.source == "sub")
+        assert boundary.transfer is False
+
+        await wf.run(trigger_id="sub")
+
+        assert wf.status.value == "completed"
+        final = _inner(wf, "final")
+        assert final.outputs[0].path.read_text().strip() == "YAMLISH"
+
+    def test_yaml_round_trip_dumps_native_kind(self, tmp_path: Path) -> None:
+        """``to_yaml`` emits ``kind: subworkflow``, never ``sub:``."""
+        child = _child_workflow(_seed_file(tmp_path))
+        wf = _parent(tmp_path)
+        wf.subworkflow(id="sub", body=child)
+
+        out = tmp_path / "dump.yaml"
+        wf.to_yaml(out)
+        dumped = yaml.safe_load(out.read_text())
+        entry = next(t for t in dumped["tasks"] if t["id"] == "sub")
+        assert "sub" not in entry
+        assert entry["kind"] == "subworkflow"
+
+        wf2 = BaseWorkflow.from_yaml(out)
+        sub2 = next(t for t in wf2.tasks if t.id == "sub")
+        assert isinstance(sub2, SubworkflowExpander)
+        assert [a.id for a in sub2.outputs] == ["report_out"]
+
+
+@pytest.mark.unit
+class TestPythonBuilderParity:
+    """wf.subworkflow(...) and the YAML sugar agree structurally."""
+
+    def test_builder_matches_yaml_lowering_shape(self, tmp_path: Path) -> None:
+        """Both authoring paths produce the same expander fields."""
+        child = _child_workflow(_seed_file(tmp_path))
+
+        wf = _parent(tmp_path)
+        built = wf.subworkflow(id="sub", body=child)
+
+        lowered = lower_subworkflow_entry({"id": "sub", "sub": child})
+        from_yaml_style = SubworkflowExpander.model_validate(lowered)
+
+        assert built.kind == from_yaml_style.kind
+        assert built.body == from_yaml_style.body
+        assert [a.id for a in built.inputs] == [
+            a.id for a in from_yaml_style.inputs
+        ]
+        assert [a.id for a in built.outputs] == [
+            a.id for a in from_yaml_style.outputs
+        ]
+
+
+@pytest.mark.unit
+class TestSubworkflowErrors:
+    """Malformed subworkflows are rejected, mostly at load time."""
+
+    def test_duplicate_inner_task_id_is_rejected(self) -> None:
+        """The body is validated by constructing a real workflow."""
+        body = {
+            "kind": "horus_workflow",
+            "name": "child",
+            "tasks": [_task_dict("a"), _task_dict("a")],
+        }
+        with pytest.raises(TaskIdsAreNotUniqueError):
+            SubworkflowExpander(id="sub", name="sub", body=body)
+
+    def test_slash_in_inner_id_is_rejected(self) -> None:
+        """``/`` is reserved for the inlined id prefix."""
+        body = {
+            "kind": "horus_workflow",
+            "name": "child",
+            "tasks": [{"id": "a/b"}],
+        }
+        with pytest.raises(SubworkflowError, match="'/'"):
+            SubworkflowExpander(id="sub", name="sub", body=body)
+
+    def test_unresolved_inner_edge_is_rejected(self) -> None:
+        """Existing edge validation is reused, not reimplemented."""
+        body = {
+            "kind": "horus_workflow",
+            "name": "child",
+            "tasks": [_task_dict("a")],
+            "edges": [{"source": "a", "target": "nope"}],
+        }
+        with pytest.raises(UnknownEdgeEndpointError):
+            SubworkflowExpander(id="sub", name="sub", body=body)
+
+    async def test_depth_guard_stops_runaway_nesting(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """``max_depth`` fails the run rather than expanding forever."""
+        del horus_context
+        child = _child_workflow(_seed_file(tmp_path))
+        wf = _parent(tmp_path)
+        wf.subworkflow(id="sub", body=child, max_depth=0)
+
+        with pytest.raises(SubworkflowError, match="max_depth"):
+            await wf.run(trigger_id="sub")
+
+    async def test_transferring_boundary_edge_is_rejected(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """A ``transfer=True`` boundary edge would duplicate the data."""
+        del horus_context
+        child = _child_workflow(_seed_file(tmp_path))
+        final = _shell_task(
+            "final",
+            "true",
+            inputs=[FileArtifact(id="res", path=Path("res_in.txt"))],
+            outputs=[FileArtifact(id="final_out", path=Path("final.txt"))],
+        )
+        wf = _parent(tmp_path, tasks=[final])
+        wf.subworkflow(id="sub", body=child)
+        wf.edges.append(
+            WorkflowEdge(
+                source="sub",
+                source_output="report_out",
+                target="final",
+                target_input="res",
+            )
+        )
+
+        with pytest.raises(SubworkflowError, match="transfer=False"):
+            await wf.run(trigger_id="sub")
+
+
+@pytest.mark.unit
+class TestSubworkflowReset:
+    """Reset clears the expander's own (never-written) placeholders."""
+
+    async def test_reset_clears_run_count(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """``_reset`` zeroes ``runs`` and leaves the body untouched."""
+        del horus_context
+        child = _child_workflow(_seed_file(tmp_path))
+        wf = _parent(tmp_path)
+        sub = wf.subworkflow(id="sub", body=child)
+
+        await wf.run(trigger_id="sub")
+        assert sub.runs == 1
+
+        await sub._reset()
+
+        assert sub.runs == 0
+        assert [a.id for a in sub.outputs] == ["report_out"]


### PR DESCRIPTION
Three composable additions to the workflow model, in dependency order. Each commit stands alone and the suite is green at every one.

## 1. Conditional edges (`6b1930d`)

An edge may carry a condition. A task whose incoming edges are all dead is skipped rather than run, and counts as completed so the DAG moves on.

Liveness is an OR-join: *a task is live iff it has no incoming task-edges, or at least one is live.*

The obvious alternative, adding the untaken branch to the scheduler's `blocked` set, silently breaks every diamond. `descendants()` is the full transitive closure, so blocking branch `C` in `A -> (B|C) -> D` also blocks the join `D`. Marking the branch skipped-but-completed avoids that entirely and needs no change to the readiness check, the blocked set, or the failure path, so a branched run still ends `COMPLETED`.

Two authoring forms:
- **`EdgeCondition`** — declarative data over an upstream task's JSON sentinel, following the `LoopController` signal precedent. No eval, no expression grammar, so it round-trips through YAML and is editable in a UI.
- **`PythonCondition`** — an arbitrary callable, for Python-authored workflows. The callable cannot serialize (as `PythonFunctionRuntime.func` already cannot), so a `module:qualname` ref and a human label are derived from it and carried alongside. A lambda deliberately gets no ref: it works in-process and fails loudly elsewhere rather than emitting a reference that will not resolve.

The liveness gate sits in `_execute_ready_task`, not `BaseTask.run`, because inputs are transferred before dispatch and an inactive task's inputs were never produced. `SkipReason` distinguishes a memoized cache hit from an untaken branch; `TaskStatus` is deliberately not widened, since it is persisted across repositories.

## 2. `BranchRouter` (`e295454`)

The switch form: one function returns which path(s) to take. It **lowers onto the conditional edges above** — it writes a `{"routes": [...]}` sentinel and its outgoing edges carry ordinary `EdgeCondition`s. So the scheduler, liveness, YAML round-trip and any future UI need zero extra cases: one evaluation path, three authoring surfaces.

Adds a `contains` operator. `in` could not work here: with `key="routes"` the sentinel holds the *list* and the literal is the scalar, so `in` evaluates `list in str` and raises. `contains` is its mirror and is independently useful.

## 3. Subworkflows (`b3db0ad`)

`SubworkflowExpander` inlines a child workflow's tasks and edges into the parent via a single atomic `wf.expand(...)`, modelled on `MapExpander`. Not nested `BaseWorkflow.run`, which `OneWorkflowAtATimeError` rejects and which would give the child its own `TargetPool`/`PlacementManager`, quietly breaking the parent's `max_concurrency`. Inlining also puts every inner task in `wf.tasks` with a live status, so a UI gets per-child progress for free.

**The interface is the child workflow itself.** `body` is a full `BaseWorkflow` document and ports are *derived*, never declared: in-ports are the child's root artifacts (already defined as "standalone root artifacts with no producer"), out-ports are task outputs no inner edge consumes. One pure `derive_ports()` defines this for the validator, the expander, and a future TypeScript port. An existing workflow drops in unchanged.

No ordering edges are emitted from the expander to inner tasks: `_gate_new_tasks_behind_creator`, which `expand()` already applies, gates inner root tasks behind their creator, and the rest of the inner graph is transitively in scope. Asserted directly by a test.

## Verification

608 unit tests pass from a cold state, and the subworkflow suite passes in isolation, so the result does not depend on test ordering. ruff, ruff format and mypy clean.

The load-bearing regressions: `TestDiamondBranchEndToEnd` (the join runs when one branch is skipped), `TestRunEndsCompletedNotFailed` (a skipped branch must not fail the run), `TestExistingWorkflowDropsInUnchanged`, and `test_no_ordering_edges_are_emitted_to_inner_tasks`.

## Known gaps, deliberately deferred

- **Fan-in of a mapped subworkflow's results** sees the port placeholder rather than real data, because `_pin_path` pins the mapped output on the expander rather than the inner producer. A mapped subworkflow runs correctly per clone; only gathering its results is affected.
- **An implicit protocol between the two expanders.** To make the mapped case work, an absolute `declared_path` on a port placeholder is read as "an enclosing construct owns this port". That infers intent from a path shape and couples the modules through `_pin_path`'s side effect. Documented and tested, but an explicit flag would be the honest fix.
- **A true AND-join** downstream of a branch will run with one input missing. If that shape becomes common the fix is a per-task `join_policy`, not a change to the liveness rule.

## Docs

https://github.com/temple-compute/horus-docs/pull/47