### PR TITLE
fix(scheduler): propagate workflow cancellation to running tasks

### DIFF
--- a/src/horus_builtin/workflow/scheduler.py
+++ b/src/horus_builtin/workflow/scheduler.py
@@ -182,8 +182,21 @@ async def _execute_ready_task(
             await workflow.transfer_artifacts(task, source_map)
 
             # Execute the task on its target and wait for it to finish.
-            await target.dispatch(task)
-            await target.wait()
+            try:
+                await target.dispatch(task)
+                await target.wait()
+            except asyncio.CancelledError:
+                # Cancelling this wrapper also cancels the inner task future
+                # (cancellation propagates through `target.wait()`'s await),
+                # so by now the task has recorded CANCELED and the future is
+                # done; `target.cancel()` would early-return. Call the
+                # executor's kill hook directly so any external process
+                # (container, remote job) that does not die with the
+                # coroutine is terminated. Shielded so a second cancel
+                # cannot abort the kill mid-flight.
+                if task.status is TaskStatus.CANCELED:
+                    await asyncio.shield(task.executor.cancel_execution())
+                raise
         finally:
             task.target = declared_target
             pool.release(declared_target, target)
@@ -379,9 +392,18 @@ async def run_schedule(workflow: BaseWorkflow, trigger_id: str) -> None:
                 )
                 running[wrapper] = task_id
 
-        done, _pending = await asyncio.wait(
-            running, return_when=asyncio.FIRST_COMPLETED
-        )
+        try:
+            done, _pending = await asyncio.wait(
+                running, return_when=asyncio.FIRST_COMPLETED
+            )
+        except asyncio.CancelledError:
+            # Workflow-level cancellation: `asyncio.wait` does not cancel the
+            # tasks it waits on, so propagate the cancel to every in-flight
+            # wrapper (each one kills its executor via `target.cancel()`, see
+            # `_execute_ready_task`) and wait for them to unwind before
+            # re-raising.
+            await _cancel_running(running)
+            raise
 
         failures = _collect_completions(done, running, completed)
         if failures and workflow.failure_policy == "fail_fast":

--- a/tests/unit/workflow/test_scheduler.py
+++ b/tests/unit/workflow/test_scheduler.py
@@ -345,6 +345,50 @@ class TestConcurrentReadySet:
         assert blocking.status == TaskStatus.CANCELED
         assert sink.runs == 0
 
+    async def test_external_cancel_kills_executor_and_marks_task_canceled(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """
+        Cancelling the workflow run from the outside (as the orchestrator
+        does on a user cancel) must propagate to in-flight tasks: the task
+        ends CANCELED, the workflow ends CANCELED, and the executor's
+        ``cancel_execution`` kill hook fires so external processes
+        (containers, remote jobs) are terminated.
+        """
+        del horus_context
+        started = asyncio.Event()
+        kill_calls: list[str] = []
+
+        class SpyExecutor(ShellExecutor):
+            add_to_registry: ClassVar[bool] = False
+
+            async def cancel_execution(self) -> None:
+                kill_calls.append("killed")
+
+        class HangingTask(HorusTask):
+            add_to_registry: ClassVar[bool] = False
+
+            async def _run(self) -> None:
+                started.set()
+                await asyncio.Event().wait()
+
+        task = _task("hang", tmp_path=tmp_path, task_cls=HangingTask)
+        task.executor = SpyExecutor()
+        wf = HorusWorkflow(name="external_cancel", tasks=[task], edges=[])
+
+        with patch.object(
+            HorusWorkflow, "transfer_artifacts", new=AsyncMock()
+        ):
+            run = asyncio.create_task(wf.run(trigger_id="hang"))
+            await asyncio.wait_for(started.wait(), timeout=5)
+            run.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await asyncio.wait_for(run, timeout=5)
+
+        assert task.status == TaskStatus.CANCELED
+        assert wf.status == WorkflowStatus.CANCELED
+        assert kill_calls == ["killed"]
+
     async def test_cycle_raises_instead_of_stopping_silently(
         self, tmp_path: Path, horus_context: HorusContext
     ) -> None:


### PR DESCRIPTION
## Problem

Cancelling a workflow run left the underlying process/container running, and the affected tasks stayed stuck reporting `RUNNING` in the UI forever.

The kill hook already existed (`BaseExecutor.cancel_execution()`, called by `BaseTarget.cancel()`) but was dead code: nothing ever invoked it.

## Root cause

`run_schedule` dispatches each ready task in its own `asyncio.Task` wrapper and blocks on `asyncio.wait(...)`. `asyncio.wait` does **not** cancel the tasks it waits on, and child tasks are not auto-cancelled with their parent.

So when the orchestrator cancels the top-level task (its response to a user pressing cancel), the `CancelledError` unwound the scheduler and left every in-flight wrapper orphaned and still running:

- `executor.cancel_execution()` never fired, so the external process kept going
- `BaseTask.run()` never reached its `except CancelledError` branch, so no task recorded `CANCELED`
- the task status middleware never pushed a terminal snapshot, so the backend's last word on those tasks stayed `running`

## Fix

- `run_schedule` now catches `CancelledError` around the wait and cancels every in-flight wrapper, reusing the existing `_cancel_running` helper that the fail-fast path already relies on.
- `_execute_ready_task` fires the executor's `cancel_execution()` kill hook as it unwinds, so containers and remote jobs are terminated instead of orphaned. Cancelling a wrapper already propagates into the inner task future (through `target.wait()`'s await), so by that point the task has recorded `CANCELED` and only the external process needs killing. The hook call is `asyncio.shield`ed so a second cancel cannot abort the kill mid-flight.

## Test

Adds `test_external_cancel_kills_executor_and_marks_task_canceled`: cancels a running workflow from the outside the way the orchestrator does, and asserts the task ends `CANCELED`, the workflow ends `CANCELED`, and the executor's kill hook fired.

All 13 tests in `tests/unit/workflow/test_scheduler.py` pass.

## Note

The consuming side (backend reconciling snapshot task statuses on cancel) lands in the matching tc-os PR, which also bumps this submodule pointer.

## Docs
- [x] No documentation update required