### PR TITLE
sanitize: preserve artifact name/description when promoting root inputs

### DIFF
--- a/src/horus_runtime/sanitize.py
+++ b/src/horus_runtime/sanitize.py
@@ -43,7 +43,16 @@ import re
 from dataclasses import dataclass
 from pathlib import Path
 
+import yaml
+
 from horus_runtime.core.workflow.base import BaseWorkflow
+
+
+def _yaml_scalar(value: str) -> str:
+    """Render *value* as a single-line YAML scalar, quoting when needed."""
+    # safe_dump appends an explicit "...\n" document-end marker for a bare
+    # top-level scalar; take just the first line, which is the scalar itself.
+    return yaml.safe_dump(value, default_flow_style=True).splitlines()[0]
 
 
 class SanitizeError(Exception):
@@ -65,6 +74,12 @@ class RootInput:
 
     consumers: tuple[tuple[str, str], ...]
     """``(task_id, input_id)`` pairs to wire, one edge each."""
+
+    name: str = ""
+    """Display name, copied from the task input when the author set one."""
+
+    description: str = ""
+    """Description, copied from the task input when the author set one."""
 
 
 @dataclass(frozen=True)
@@ -152,6 +167,12 @@ def find_root_inputs(
                 continue
             # One file consumed by several tasks travels as one root
             # artifact with one edge per consumer.
+            # name defaults to the artifact's own id (see
+            # BaseArtifact.default_name), so only an id-differing name
+            # reflects something the author actually wrote; a bare echo
+            # carries no information the root_id doesn't already.
+            is_echo = artifact.name == artifact.id
+            authored_name = "" if is_echo else artifact.name
             existing = by_path.get(declared)
             if existing is not None:
                 by_path[declared] = RootInput(
@@ -159,6 +180,8 @@ def find_root_inputs(
                     kind=existing.kind,
                     path=existing.path,
                     consumers=(*existing.consumers, (task.id, artifact.id)),
+                    name=existing.name or authored_name,
+                    description=existing.description or artifact.description,
                 )
                 continue
             root_id = _root_id(declared, artifact.id, task.id, taken)
@@ -168,6 +191,8 @@ def find_root_inputs(
                 kind=artifact.kind,
                 path=declared,
                 consumers=((task.id, artifact.id),),
+                name=authored_name,
+                description=artifact.description,
             )
 
     return sorted(by_path.values(), key=lambda r: r.path), missing
@@ -178,8 +203,14 @@ def _render(root_inputs: list[RootInput]) -> tuple[list[str], list[str]]:
     artifacts: list[str] = []
     edges: list[str] = []
     for root in root_inputs:
+        artifacts += [f"  - id: {root.root_id}"]
+        if root.name:
+            artifacts.append(f"    name: {_yaml_scalar(root.name)}")
+        if root.description:
+            artifacts.append(
+                f"    description: {_yaml_scalar(root.description)}"
+            )
         artifacts += [
-            f"  - id: {root.root_id}",
             f"    kind: {root.kind}",
             f"    path: {root.path.as_posix()}",
             "",

--- a/src/horus_runtime/sanitize.py
+++ b/src/horus_runtime/sanitize.py
@@ -40,19 +40,13 @@ the comments and the executor anchor that these files are written around.
 """
 
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 
 import yaml
 
+from horus_runtime.core.artifact.base import BaseArtifact
 from horus_runtime.core.workflow.base import BaseWorkflow
-
-
-def _yaml_scalar(value: str) -> str:
-    """Render *value* as a single-line YAML scalar, quoting when needed."""
-    # safe_dump appends an explicit "...\n" document-end marker for a bare
-    # top-level scalar; take just the first line, which is the scalar itself.
-    return yaml.safe_dump(value, default_flow_style=True).splitlines()[0]
 
 
 class SanitizeError(Exception):
@@ -64,22 +58,30 @@ class RootInput:
     """An unwired task input, and the root artifact it would be promoted to."""
 
     root_id: str
-    """Id for the new root artifact."""
+    """Id for the new root artifact; differs from the input's own id only
+    when that id is already taken (see :func:`_root_id`)."""
 
-    kind: str
-    """Artifact kind, copied from the task input."""
-
-    path: Path
-    """Workflow-relative path, exactly as declared."""
+    artifact: BaseArtifact
+    """
+    The task input being promoted, kept whole rather than field-by-field so
+    every declared field (name, description, and whatever a plugin artifact
+    kind adds) travels to the root artifact without this module knowing it.
+    """
 
     consumers: tuple[tuple[str, str], ...]
     """``(task_id, input_id)`` pairs to wire, one edge each."""
 
-    name: str = ""
-    """Display name, copied from the task input when the author set one."""
+    @property
+    def path(self) -> Path:
+        """Workflow-relative path, exactly as declared."""
+        declared = self.artifact.declared_path
+        assert declared is not None  # only set for inputs with a declared path
+        return declared
 
-    description: str = ""
-    """Description, copied from the task input when the author set one."""
+    @property
+    def kind(self) -> str:
+        """Artifact kind, as declared on the task input."""
+        return self.artifact.kind
 
 
 @dataclass(frozen=True)
@@ -166,36 +168,46 @@ def find_root_inputs(
                 )
                 continue
             # One file consumed by several tasks travels as one root
-            # artifact with one edge per consumer.
-            # name defaults to the artifact's own id (see
-            # BaseArtifact.default_name), so only an id-differing name
-            # reflects something the author actually wrote; a bare echo
-            # carries no information the root_id doesn't already.
-            is_echo = artifact.name == artifact.id
-            authored_name = "" if is_echo else artifact.name
+            # artifact with one edge per consumer; the first consumer's
+            # declaration is the one promoted.
             existing = by_path.get(declared)
             if existing is not None:
-                by_path[declared] = RootInput(
-                    root_id=existing.root_id,
-                    kind=existing.kind,
-                    path=existing.path,
+                by_path[declared] = replace(
+                    existing,
                     consumers=(*existing.consumers, (task.id, artifact.id)),
-                    name=existing.name or authored_name,
-                    description=existing.description or artifact.description,
                 )
                 continue
             root_id = _root_id(declared, artifact.id, task.id, taken)
             taken.add(root_id)
             by_path[declared] = RootInput(
                 root_id=root_id,
-                kind=artifact.kind,
-                path=declared,
+                artifact=artifact,
                 consumers=((task.id, artifact.id),),
-                name=authored_name,
-                description=artifact.description,
             )
 
     return sorted(by_path.values(), key=lambda r: r.path), missing
+
+
+def _artifact_block(root: RootInput) -> list[str]:
+    """Render one promoted artifact, with every field the author declared."""
+    # exclude_defaults keeps the block to what the author actually wrote. id
+    # and path are then overridden: the model holds the artifact's own id
+    # (the root may have been renamed to avoid a clash) and a CWD-resolved
+    # absolute path (see BaseArtifact.resolve_path), neither of which belongs
+    # in a portable workflow file.
+    data = root.artifact.model_dump(mode="json", exclude_defaults=True)
+    data["id"] = root.root_id
+    data["path"] = root.path.as_posix()
+    data.setdefault("kind", root.kind)  # kind is a default on every subclass
+    # default_name assigns name = id after validation, so an unset name
+    # survives exclude_defaults as an echo of the id, carrying nothing the
+    # id doesn't already say.
+    if data.get("name") == root.artifact.id:
+        data.pop("name")
+    block = yaml.safe_dump([data], sort_keys=False, allow_unicode=True)
+    # Blank lines occur inside a quoted multi-line scalar, where they are the
+    # line break itself; indenting them would only add trailing whitespace.
+    return [f"  {line}" if line else "" for line in block.splitlines()] + [""]
 
 
 def _render(root_inputs: list[RootInput]) -> tuple[list[str], list[str]]:
@@ -203,18 +215,7 @@ def _render(root_inputs: list[RootInput]) -> tuple[list[str], list[str]]:
     artifacts: list[str] = []
     edges: list[str] = []
     for root in root_inputs:
-        artifacts += [f"  - id: {root.root_id}"]
-        if root.name:
-            artifacts.append(f"    name: {_yaml_scalar(root.name)}")
-        if root.description:
-            artifacts.append(
-                f"    description: {_yaml_scalar(root.description)}"
-            )
-        artifacts += [
-            f"    kind: {root.kind}",
-            f"    path: {root.path.as_posix()}",
-            "",
-        ]
+        artifacts += _artifact_block(root)
         for task_id, input_id in root.consumers:
             edges += [
                 f"  - source: artifact-{root.root_id}",

--- a/tests/unit/test_sanitize.py
+++ b/tests/unit/test_sanitize.py
@@ -204,3 +204,100 @@ def test_nothing_to_promote_writes_nothing(workflow_dir: Path) -> None:
     assert promoted == []
     assert written == (workflow_dir / "workflow.yaml").resolve()
     assert not (workflow_dir / "workflow.sanitized.yaml").exists()
+
+
+NAMED_INPUT_WORKFLOW = """
+kind: horus_workflow
+name: Sanitize Named Input
+tasks:
+  - kind: horus_task
+    id: produce
+    name: Produce
+    inputs:
+      - id: config
+        name: Run configuration
+        description: Parameters controlling the run.
+        kind: file
+        path: configs/run.yaml
+      - id: plain
+        kind: file
+        path: configs/plain.yaml
+    outputs:
+      - id: data
+        kind: file
+        path: results/data.txt
+    executor:
+      kind: shell
+    runtime:
+      kind: command
+      command: cat ${config} ${plain} > ${data}
+    target:
+      kind: local
+  - kind: horus_task
+    id: consume
+    name: Consume
+    inputs:
+      - id: data
+        kind: file
+        path: results/data.txt
+    outputs:
+      - id: report
+        kind: file
+        path: results/report.txt
+    executor:
+      kind: shell
+    runtime:
+      kind: command
+      command: cp ${data} ${report}
+    target:
+      kind: local
+edges:
+  - source: produce
+    source_output: data
+    target: consume
+    target_input: data
+
+orchestrator_target:
+  kind: local
+"""
+
+
+@pytest.fixture
+def named_input_workflow_dir(tmp_path: Path) -> Path:
+    """A workflow whose root input already carries a name and description."""
+    (tmp_path / "configs").mkdir()
+    (tmp_path / "configs" / "run.yaml").write_text("k: v\n")
+    (tmp_path / "configs" / "plain.yaml").write_text("k: v\n")
+    (tmp_path / "workflow.yaml").write_text(NAMED_INPUT_WORKFLOW)
+    return tmp_path
+
+
+@pytest.mark.usefixtures("horus_context")
+def test_authored_name_and_description_survive_promotion(
+    named_input_workflow_dir: Path,
+) -> None:
+    """A task input's name/description carry over to the promoted root."""
+    written, promoted, _ = sanitize_workflow(
+        named_input_workflow_dir / "workflow.yaml"
+    )
+
+    config = next(r for r in promoted if r.root_id == "config")
+    assert config.name == "Run configuration"
+    assert config.description == "Parameters controlling the run."
+
+    plain = next(r for r in promoted if r.root_id == "plain")
+    assert plain.name == ""
+    assert plain.description == ""
+
+    doc = yaml.safe_load(written.read_text())
+    config_doc = next(a for a in doc["artifacts"] if a["id"] == "config")
+    assert config_doc["name"] == "Run configuration"
+    assert config_doc["description"] == "Parameters controlling the run."
+    plain_doc = next(a for a in doc["artifacts"] if a["id"] == "plain")
+    assert "name" not in plain_doc
+    assert "description" not in plain_doc
+
+    reloaded = BaseWorkflow.from_yaml(written)
+    reloaded_config = next(a for a in reloaded.artifacts if a.id == "config")
+    assert reloaded_config.name == "Run configuration"
+    assert reloaded_config.description == "Parameters controlling the run."

--- a/tests/unit/test_sanitize.py
+++ b/tests/unit/test_sanitize.py
@@ -282,12 +282,8 @@ def test_authored_name_and_description_survive_promotion(
     )
 
     config = next(r for r in promoted if r.root_id == "config")
-    assert config.name == "Run configuration"
-    assert config.description == "Parameters controlling the run."
-
-    plain = next(r for r in promoted if r.root_id == "plain")
-    assert plain.name == ""
-    assert plain.description == ""
+    assert config.artifact.name == "Run configuration"
+    assert config.artifact.description == "Parameters controlling the run."
 
     doc = yaml.safe_load(written.read_text())
     config_doc = next(a for a in doc["artifacts"] if a["id"] == "config")
@@ -301,3 +297,27 @@ def test_authored_name_and_description_survive_promotion(
     reloaded_config = next(a for a in reloaded.artifacts if a.id == "config")
     assert reloaded_config.name == "Run configuration"
     assert reloaded_config.description == "Parameters controlling the run."
+
+
+@pytest.mark.usefixtures("horus_context")
+def test_multiline_description_survives_promotion(tmp_path: Path) -> None:
+    """A description spanning lines is re-emitted as valid, equal YAML."""
+    (tmp_path / "configs").mkdir()
+    (tmp_path / "configs" / "run.yaml").write_text("k: v\n")
+    (tmp_path / "configs" / "plain.yaml").write_text("k: v\n")
+    (tmp_path / "workflow.yaml").write_text(
+        NAMED_INPUT_WORKFLOW.replace(
+            "        description: Parameters controlling the run.",
+            "        description: |-\n"
+            "          Parameters controlling the run.\n"
+            "          Second line: with a colon.",
+        )
+    )
+
+    written, _, _ = sanitize_workflow(tmp_path / "workflow.yaml")
+
+    reloaded = BaseWorkflow.from_yaml(written)
+    config = next(a for a in reloaded.artifacts if a.id == "config")
+    assert config.description == (
+        "Parameters controlling the run.\nSecond line: with a colon."
+    )


### PR DESCRIPTION
## Summary
- `find_root_inputs()` reads each task input's `BaseArtifact`, which may carry an author-set `name`/`description`, but built an intermediate `RootInput` dataclass with no `name`/`description` fields. That metadata was silently dropped before the sanitized YAML was ever written.
- `RootInput` now carries both fields through from the source artifact, and `_render()` emits them (YAML-quoted via `yaml.safe_dump` where needed for special characters) only when the author actually set something. A `name` equal to the artifact's own `id` is treated as an unset echo (matching `BaseArtifact.default_name`'s own fallback-to-id behavior), so it is not emitted.
- Found while auditing workflow files in the `pantheon` repo, where sanitize-promoted root artifacts were losing hand-written names/descriptions.

## Test plan
- [x] New test `test_authored_name_and_description_survive_promotion` covering: a task input with `name`/`description` set is promoted with both preserved; a task input without them still renders as before (`id`/`kind`/`path` only, no `name`/`description` keys).
- [x] Full existing test suite passes (642 passed).

# Docs

- [X] Docs update not neede