### PR TITLE
fix(workflow): wrap WorkflowError in ValueError; reject malformed map/sub blocks

### DIFF
--- a/src/horus_builtin/workflow/map.py
+++ b/src/horus_builtin/workflow/map.py
@@ -665,9 +665,30 @@ def lower_map_entry(
         ``(expander_dict, edges)`` — a ``kind: map_expander`` task dict
         ready for ``BaseTask.model_validate``, and any edges (as plain
         dicts) that must accompany it into the workflow's ``edges`` list.
+
+    Raises:
+        MapConfigurationError: If *entry* is missing the ``id`` key, or its
+            ``map`` block is missing ``template`` or ``gather``, or
+            ``gather`` is missing ``task`` or ``input``.
     """
-    task_id = entry["id"]
+    task_id = entry.get("id")
+    if task_id is None:
+        raise MapConfigurationError(
+            _("A task with a 'map' block is missing required key 'id'.")
+        )
     map_block = entry["map"]
+
+    if "template" not in map_block:
+        raise MapConfigurationError(
+            _("Map task '%(id)s' is missing required key 'map.template'.")
+            % {"id": task_id}
+        )
+    if "gather" not in map_block:
+        raise MapConfigurationError(
+            _("Map task '%(id)s' is missing required key 'map.gather'.")
+            % {"id": task_id}
+        )
+
     over_block = map_block.get("over") or {}
     range_value = map_block.get("range")
     index_input = map_block.get("index_input", over_block.get("index_input"))
@@ -681,6 +702,19 @@ def lower_map_entry(
     }
 
     gather_block = map_block["gather"]
+    if not isinstance(gather_block, dict) or "task" not in gather_block:
+        raise MapConfigurationError(
+            _("Map task '%(id)s' 'map.gather' is missing required key 'task'.")
+            % {"id": task_id}
+        )
+    if "input" not in gather_block:
+        raise MapConfigurationError(
+            _(
+                "Map task '%(id)s' 'map.gather' is missing required "
+                "key 'input'."
+            )
+            % {"id": task_id}
+        )
 
     expander: dict[str, Any] = {
         "kind": "map_expander",

--- a/src/horus_builtin/workflow/subworkflow/lowering.py
+++ b/src/horus_builtin/workflow/subworkflow/lowering.py
@@ -21,6 +21,9 @@ YAML sugar lowering for the subworkflow construct.
 
 from typing import Any
 
+from horus_builtin.workflow.subworkflow.errors import SubworkflowError
+from horus_runtime.i18n import tr as _
+
 
 def lower_subworkflow_entry(entry: dict[str, Any]) -> dict[str, Any]:
     """
@@ -37,8 +40,20 @@ def lower_subworkflow_entry(entry: dict[str, Any]) -> dict[str, Any]:
     Returns:
         A ``kind: subworkflow`` task dict ready for
         ``BaseTask.model_validate``.
+
+    Raises:
+        SubworkflowError: If *entry* is missing the ``id`` or ``sub`` key.
     """
-    task_id = entry["id"]
+    task_id = entry.get("id")
+    if task_id is None:
+        raise SubworkflowError(
+            _("A task with a 'sub' block is missing required key 'id'.")
+        )
+    if "sub" not in entry:
+        raise SubworkflowError(
+            _("Subworkflow task '%(id)s' is missing required key 'sub'.")
+            % {"id": task_id}
+        )
     data: dict[str, Any] = {
         "kind": "subworkflow",
         "id": task_id,

--- a/src/horus_runtime/core/workflow/base.py
+++ b/src/horus_runtime/core/workflow/base.py
@@ -253,12 +253,11 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
     _revision: int = PrivateAttr(default=0)
     """
     Monotonically increasing counter for the workflow's DAG structure
-    (tasks/edges/artifacts). Nothing bumps it yet: today the DAG is fixed for
-    the lifetime of a run, so it is built once and stays at ``0``. It exists
-    so a future dynamic-DAG feature (fan-out/map/loops) can increment it when
-    mutating the graph mid-run, and the scheduler's cached source map (see
-    :meth:`cached_source_map`) picks up the change without any changes to the
-    scheduler itself.
+    (tasks/edges/artifacts). Bumped by :meth:`add_task`, :meth:`add_edge`,
+    :meth:`add_artifact` and :meth:`expand` whenever the graph mutates
+    mid-run (e.g. a dynamic fan-out/map/loop expansion), so the scheduler's
+    cached source map (see :meth:`cached_source_map`) picks up the change
+    without any changes to the scheduler itself.
     """
 
     @model_validator(mode="before")

--- a/src/horus_runtime/core/workflow/exceptions.py
+++ b/src/horus_runtime/core/workflow/exceptions.py
@@ -27,8 +27,15 @@ if TYPE_CHECKING:
     from horus_runtime.core.workflow.base import BaseWorkflow
 
 
-class WorkflowError(Exception):
-    """Base exception for workflow-related errors."""
+class WorkflowError(ValueError):
+    """
+    Base exception for workflow-related errors.
+
+    Derives from :class:`ValueError` so that any subclass raised inside a
+    Pydantic validator (e.g. ``BaseWorkflow``'s ``model_validator`` hooks)
+    is automatically wrapped into a :class:`pydantic.ValidationError` by
+    Pydantic, instead of escaping as a raw, unwrapped exception.
+    """
 
 
 class OneWorkflowAtATimeError(WorkflowError):

--- a/tests/unit/workflow/test_conditions.py
+++ b/tests/unit/workflow/test_conditions.py
@@ -25,6 +25,7 @@ from pathlib import Path
 
 import pytest
 import yaml
+from pydantic import ValidationError
 
 from horus_builtin.artifact.file import FileArtifact
 from horus_builtin.executor.shell import ShellExecutor
@@ -45,7 +46,6 @@ from horus_runtime.core.workflow.condition import (
     PythonCondition,
 )
 from horus_runtime.core.workflow.edge import WorkflowEdge
-from horus_runtime.core.workflow.exceptions import IncompleteEdgeError
 
 
 def _decider(
@@ -113,7 +113,7 @@ class TestEdgeConditionModel:
         An artifact-less ordering edge gives the condition no default source,
         so one must be named explicitly rather than failing mid-run.
         """
-        with pytest.raises(IncompleteEdgeError):
+        with pytest.raises(ValidationError, match="names only one of"):
             WorkflowEdge(
                 source="a",
                 target="b",

--- a/tests/unit/workflow/test_edges.py
+++ b/tests/unit/workflow/test_edges.py
@@ -28,6 +28,7 @@ from typing import cast
 from unittest.mock import patch
 
 import pytest
+from pydantic import ValidationError
 
 from horus_builtin.artifact.file import FileArtifact
 from horus_builtin.executor.shell import ShellExecutor
@@ -43,12 +44,6 @@ from horus_builtin.workflow.horus_workflow import HorusWorkflow
 from horus_runtime.core.artifact.base import BaseArtifact
 from horus_runtime.core.transfer.strategy import BaseTransferStrategy
 from horus_runtime.core.workflow.edge import WorkflowEdge
-from horus_runtime.core.workflow.exceptions import (
-    ArtifactIdsAreNotUniqueError,
-    DuplicateEdgeTargetError,
-    IncompleteEdgeError,
-    UnknownEdgeEndpointError,
-)
 
 
 def _task(
@@ -262,7 +257,7 @@ class TestReusableTasks:
                 FileArtifact(id="dup", path=tmp_path / "b.txt"),
             ],
         )
-        with pytest.raises(ArtifactIdsAreNotUniqueError):
+        with pytest.raises(ValidationError, match="output artifact ID 'dup'"):
             HorusWorkflow(name="bad", tasks=[bad])
 
 
@@ -373,7 +368,9 @@ class TestEdgeValidation:
     def test_unknown_source_output_raises(self, tmp_path: Path) -> None:
         """A typo in source_output is caught instead of silently misrouting."""
         producer, consumer = self._producer_consumer(tmp_path)
-        with pytest.raises(UnknownEdgeEndpointError):
+        with pytest.raises(
+            ValidationError, match="unknown source output 'TYPO'"
+        ):
             HorusWorkflow(
                 name="bad",
                 tasks=[producer, consumer],
@@ -383,7 +380,9 @@ class TestEdgeValidation:
     def test_unknown_source_task_raises(self, tmp_path: Path) -> None:
         """A source that is neither a known task nor a root edge fails."""
         producer, consumer = self._producer_consumer(tmp_path)
-        with pytest.raises(UnknownEdgeEndpointError):
+        with pytest.raises(
+            ValidationError, match="unknown source task 'producr'"
+        ):
             HorusWorkflow(
                 name="bad",
                 tasks=[producer, consumer],
@@ -393,7 +392,9 @@ class TestEdgeValidation:
     def test_unknown_target_input_raises(self, tmp_path: Path) -> None:
         """A target_input that no task input declares is rejected."""
         producer, consumer = self._producer_consumer(tmp_path)
-        with pytest.raises(UnknownEdgeEndpointError):
+        with pytest.raises(
+            ValidationError, match="unknown target input 'in_TYPO'"
+        ):
             HorusWorkflow(
                 name="bad",
                 tasks=[producer, consumer],
@@ -403,7 +404,9 @@ class TestEdgeValidation:
     def test_unknown_target_task_raises(self, tmp_path: Path) -> None:
         """An edge targeting a non-existent task is rejected."""
         producer, consumer = self._producer_consumer(tmp_path)
-        with pytest.raises(UnknownEdgeEndpointError):
+        with pytest.raises(
+            ValidationError, match="unknown target task 'ghost'"
+        ):
             HorusWorkflow(
                 name="bad",
                 tasks=[producer, consumer],
@@ -413,7 +416,9 @@ class TestEdgeValidation:
     def test_unknown_root_artifact_raises(self, tmp_path: Path) -> None:
         """A root-sourced edge whose root id does not exist is rejected."""
         _, consumer = self._producer_consumer(tmp_path)
-        with pytest.raises(UnknownEdgeEndpointError):
+        with pytest.raises(
+            ValidationError, match="unknown root artifact 'nope'"
+        ):
             HorusWorkflow(
                 name="bad",
                 tasks=[consumer],
@@ -439,7 +444,9 @@ class TestEdgeValidation:
             inputs=[FileArtifact(id="in", path=tmp_path / "c.txt")],
             outputs=[],
         )
-        with pytest.raises(DuplicateEdgeTargetError):
+        with pytest.raises(
+            ValidationError, match="Multiple edges feed input 'in'"
+        ):
             HorusWorkflow(
                 name="bad",
                 tasks=[p1, p2, c],
@@ -574,7 +581,9 @@ class TestOrderingOnlyEdges:
             inputs=[FileArtifact(id="in", path=tmp_path / "c.txt")],
             outputs=[],
         )
-        with pytest.raises(DuplicateEdgeTargetError):
+        with pytest.raises(
+            ValidationError, match="Multiple edges feed input 'in'"
+        ):
             HorusWorkflow(
                 name="bad",
                 tasks=[p1, p2, c],
@@ -697,7 +706,9 @@ class TestArtifactLessOrderingEdges:
     def test_unknown_task_still_rejected(self, tmp_path: Path) -> None:
         """Dropping the ids does not drop endpoint validation."""
         producer, bare = self._pair(tmp_path)
-        with pytest.raises(UnknownEdgeEndpointError):
+        with pytest.raises(
+            ValidationError, match="unknown target task 'ghost'"
+        ):
             HorusWorkflow(
                 name="bad",
                 tasks=[producer, bare],
@@ -707,7 +718,7 @@ class TestArtifactLessOrderingEdges:
     def test_root_artifact_source_rejected(self, tmp_path: Path) -> None:
         """A root artifact is not a task: nothing to order against."""
         _, bare = self._pair(tmp_path)
-        with pytest.raises(UnknownEdgeEndpointError):
+        with pytest.raises(ValidationError, match="unknown root artifact"):
             HorusWorkflow(
                 name="bad",
                 tasks=[bare],
@@ -720,7 +731,7 @@ class TestArtifactLessOrderingEdges:
         One id without the other is a typo, not an ordering edge: it must not
         silently stop transferring.
         """
-        with pytest.raises(IncompleteEdgeError):
+        with pytest.raises(ValidationError, match="names only one of"):
             WorkflowEdge(source="a", source_output="o", target="b")
-        with pytest.raises(IncompleteEdgeError):
+        with pytest.raises(ValidationError, match="names only one of"):
             WorkflowEdge(source="a", target="b", target_input="in")

--- a/tests/unit/workflow/test_map.py
+++ b/tests/unit/workflow/test_map.py
@@ -27,6 +27,7 @@ from pathlib import Path
 
 import pytest
 import yaml
+from pydantic import ValidationError
 
 from horus_builtin.artifact.file import FileArtifact
 from horus_builtin.artifact.folder import FolderArtifact
@@ -524,6 +525,109 @@ class TestYamlLowering:
         assert expander["over"]["index_input"] == "idx"
         assert expander["inputs"] == []
         assert edges == []
+
+    def test_lower_entry_missing_gather_raises(self) -> None:
+        """A ``map:`` block missing ``gather`` raises a typed error naming
+        the offending task, not a bare ``KeyError``.
+        """
+        entry = {
+            "id": "score",
+            "map": {"range": 2, "index_input": "i", "template": {}},
+        }
+        with pytest.raises(MapConfigurationError, match="'score'"):
+            lower_map_entry(entry)
+
+    def test_lower_entry_missing_template_raises(self) -> None:
+        """A ``map:`` block missing ``template`` raises a typed error
+        naming the offending task.
+        """
+        entry = {
+            "id": "score",
+            "map": {
+                "range": 2,
+                "index_input": "i",
+                "gather": {"task": "gather", "input": "results"},
+            },
+        }
+        with pytest.raises(MapConfigurationError, match="'score'"):
+            lower_map_entry(entry)
+
+    def test_lower_entry_missing_gather_task_raises(self) -> None:
+        """A ``gather`` block missing ``task`` raises a typed error naming
+        the offending task.
+        """
+        entry = {
+            "id": "score",
+            "map": {
+                "range": 2,
+                "index_input": "i",
+                "template": {},
+                "gather": {"input": "results"},
+            },
+        }
+        with pytest.raises(MapConfigurationError, match="'score'"):
+            lower_map_entry(entry)
+
+    def test_lower_entry_missing_gather_input_raises(self) -> None:
+        """A ``gather`` block missing ``input`` raises a typed error naming
+        the offending task.
+        """
+        entry = {
+            "id": "score",
+            "map": {
+                "range": 2,
+                "index_input": "i",
+                "template": {},
+                "gather": {"task": "gather"},
+            },
+        }
+        with pytest.raises(MapConfigurationError, match="'score'"):
+            lower_map_entry(entry)
+
+    def test_lower_entry_missing_id_raises(self) -> None:
+        """A ``map:`` entry missing ``id`` raises a typed error rather than
+        a bare ``KeyError``.
+        """
+        entry = {
+            "map": {
+                "range": 2,
+                "index_input": "i",
+                "template": {},
+                "gather": {"task": "gather", "input": "results"},
+            }
+        }
+        with pytest.raises(MapConfigurationError, match="'id'"):
+            lower_map_entry(entry)
+
+    def test_malformed_map_block_raises_validation_error(self) -> None:
+        """A malformed ``map:`` block surfaces as a ``ValidationError``
+        naming the offending task when loaded through a workflow, not a
+        bare ``KeyError``.
+
+        This is the exact reproduction from the downstream tc-os incident:
+        a queued validation request that raised a raw ``KeyError`` here hung
+        the whole consumer loop until restart, because ``KeyError`` never
+        reaches pydantic's ``ValidationError`` handler.
+        """
+        with pytest.raises(ValidationError, match="'a'") as exc_info:
+            BaseWorkflow.model_validate(
+                {
+                    "kind": "horus_workflow",
+                    "name": "x",
+                    "tasks": [
+                        {
+                            "kind": "horus_task",
+                            "id": "a",
+                            "map": {
+                                "range": 2,
+                                "index_input": "i",
+                                "template": {},
+                            },
+                        }
+                    ],
+                }
+            )
+        assert not isinstance(exc_info.value, KeyError)
 
     def test_yaml_workflow_loads_and_runs(
         self, tmp_path: Path, horus_context: HorusContext

--- a/tests/unit/workflow/test_subworkflow.py
+++ b/tests/unit/workflow/test_subworkflow.py
@@ -26,6 +26,7 @@ from typing import Any
 
 import pytest
 import yaml
+from pydantic import ValidationError
 
 from horus_builtin.artifact.file import FileArtifact
 from horus_builtin.artifact.folder import FolderArtifact
@@ -45,10 +46,6 @@ from horus_runtime.core.task.status import TaskStatus
 from horus_runtime.core.workflow.base import BaseWorkflow
 from horus_runtime.core.workflow.condition import EdgeCondition
 from horus_runtime.core.workflow.edge import WorkflowEdge
-from horus_runtime.core.workflow.exceptions import (
-    TaskIdsAreNotUniqueError,
-    UnknownEdgeEndpointError,
-)
 
 
 def _shell_task(
@@ -641,6 +638,43 @@ class TestYamlLowering:
         assert lowered["body"]["name"] == "child"
         assert lowered["port_overrides"] == {"a": "b"}
 
+    def test_lower_entry_missing_sub_raises(self) -> None:
+        """A ``sub:`` entry missing the ``sub`` key raises a typed error
+        naming the offending task, not a bare ``KeyError``.
+        """
+        with pytest.raises(SubworkflowError, match="'sub'"):
+            lower_subworkflow_entry({"id": "sub"})
+
+    def test_lower_entry_missing_id_raises(self) -> None:
+        """A ``sub:`` entry missing ``id`` raises a typed error rather
+        than a bare ``KeyError``.
+        """
+        entry = {
+            "sub": {"kind": "horus_workflow", "name": "child", "tasks": []}
+        }
+        with pytest.raises(SubworkflowError, match="'id'"):
+            lower_subworkflow_entry(entry)
+
+    def test_malformed_sub_block_raises_validation_error(self) -> None:
+        """A ``sub:`` task missing ``id`` surfaces as a ``ValidationError``,
+        not a bare ``KeyError``, when loaded through a workflow alongside
+        another, well-formed ``sub:`` task (which is what makes the
+        workflow-level lowering hook fire in the first place).
+        """
+        child = {"kind": "horus_workflow", "name": "child", "tasks": []}
+        with pytest.raises(ValidationError, match="'id'") as exc_info:
+            BaseWorkflow.model_validate(
+                {
+                    "kind": "horus_workflow",
+                    "name": "x",
+                    "tasks": [
+                        {"id": "good", "sub": child},
+                        {"sub": child},
+                    ],
+                }
+            )
+        assert not isinstance(exc_info.value, KeyError)
+
     async def test_yaml_workflow_with_sub_block_runs(
         self, tmp_path: Path, horus_context: HorusContext
     ) -> None:
@@ -740,7 +774,7 @@ class TestSubworkflowErrors:
             "name": "child",
             "tasks": [_task_dict("a"), _task_dict("a")],
         }
-        with pytest.raises(TaskIdsAreNotUniqueError):
+        with pytest.raises(ValidationError, match="share the same ID 'a'"):
             wf = BaseWorkflow.model_validate(body)
             SubworkflowExpander(id="sub", name="sub", body=wf)
 
@@ -752,7 +786,7 @@ class TestSubworkflowErrors:
             "tasks": [_task_dict("a/b")],
         }
 
-        with pytest.raises(SubworkflowError, match="'/'"):
+        with pytest.raises(ValidationError, match="'/'"):
             wf = BaseWorkflow.model_validate(body)
             SubworkflowExpander(id="sub", name="sub", body=wf)
 
@@ -764,7 +798,9 @@ class TestSubworkflowErrors:
             "tasks": [_task_dict("a")],
             "edges": [{"source": "a", "target": "nope"}],
         }
-        with pytest.raises(UnknownEdgeEndpointError):
+        with pytest.raises(
+            ValidationError, match="unknown target task 'nope'"
+        ):
             wf = BaseWorkflow.model_validate(body)
             SubworkflowExpander(id="sub", name="sub", body=wf)
 


### PR DESCRIPTION
## Summary

Two related defects in exception handling around `BaseWorkflow.model_validate`:

**1. `WorkflowError` did not derive from `ValueError`.**

Pydantic only converts an exception raised inside a validator into a `ValidationError` when that exception is a `ValueError` (or `AssertionError`). `WorkflowError` derived from plain `Exception`, so every subclass raised inside `BaseWorkflow`'s `model_validator` hooks (`SubworkflowError`, `CyclicDependencyError`, `TaskIdsAreNotUniqueError`, `UnknownEdgeEndpointError`, `DuplicateEdgeTargetError`, `MapConfigurationError`, etc.) escaped `model_validate` as its own bare exception type instead of a `pydantic.ValidationError`.

Fix: `class WorkflowError(ValueError)`. Pydantic's wrapping mechanism then applies automatically, no other change needed. Confirmed nothing in the codebase (including tests) relied on `WorkflowError` NOT being a `ValueError`; the handful of tests that asserted a bare `WorkflowError` subclass out of a `model_validate`/`BaseModel` construction call were, in effect, asserting the bug. They now assert the `ValidationError` wrapper, still matching on the underlying message.

**2. Malformed `map:` / `sub:` blocks raised a bare `KeyError`.**

`_lower_map_tasks` and `_lower_subworkflow_tasks` (`BaseWorkflow`'s `model_validator(mode="before")` hooks) call `lower_map_entry`/`lower_subworkflow_entry`, which indexed the raw YAML dict unconditionally. A missing key surfaced as a raw `KeyError` naming an internal field (e.g. `KeyError: 'gather'`) instead of a validation error naming the offending task.

Before:
```python
from horus_runtime.context import HorusContext; HorusContext.boot()
from horus_runtime.core.workflow.base import BaseWorkflow
BaseWorkflow.model_validate({'kind':'horus_workflow','name':'x','tasks':[
  {'kind':'horus_task','id':'a','map':{'range':2,'index_input':'i','template':{}}}]})
# -> KeyError: 'gather'
```

After:
```
pydantic_core._pydantic_core.ValidationError: 1 validation error for BaseWorkflow
  Value error, Map task 'a' is missing required key 'map.gather'. [type=value_error, ...]
```

Both `lower_map_entry` and `lower_subworkflow_entry` now validate every key they index unconditionally (`id`, `map.template`, `map.gather`, `map.gather.task`, `map.gather.input` for map; `id`, `sub` for subworkflow) and raise `MapConfigurationError`/`SubworkflowError` naming the task id and the missing key. Since these derive from `WorkflowError` (now a `ValueError`), pydantic wraps them into a `ValidationError` automatically -- no bespoke wrapping code needed.

Also fixed a stale docstring on `BaseWorkflow._revision` claiming "nothing bumps it yet", when `add_task`/`add_edge`/`add_artifact`/`expand` all do, and the scheduler's `cached_source_map` keys off it.

## Why this matters

Any consumer that calls `BaseWorkflow.model_validate` on user-supplied workflow
documents cannot currently rely on catching `ValidationError` to handle a
malformed document. It has to defend against an open-ended set of exception
types instead, and a `KeyError` naming an internal field is not something it can
report usefully to whoever wrote the document.

That matters most for long-lived consumers: a validation service that processes
documents in a loop can be taken down by an unexpected exception type escaping
an iteration, stalling everything queued behind it. Making the hierarchy behave
correctly inside pydantic means a single `except ValidationError` is sufficient,
which is what callers already reasonably expect.

## Test plan
- [x] `tests/unit/workflow/test_map.py` and `test_subworkflow.py`: new tests cover malformed `map:` (missing `gather`, `template`, `gather.task`, `gather.input`, `id`) and malformed `sub:` (missing `sub`, `id`), each asserting a `ValidationError` naming the task, not a `KeyError`.
- [x] Full suite: 643 -> 652 passed (baseline before this change -> after, including 9 new tests).
- [x] `issubclass(WorkflowError, ValueError)` is `True`.
- [x] The exact repro above now raises `ValidationError` naming task `a`, not `KeyError`.
- [x] `ruff check`, `ruff format --check`, `mypy` all clean.
