### PR TITLE
fix(workflow): fan in a mapped subworkflow's real output, not its port placeholder

### DIFF
--- a/src/horus_builtin/workflow/subworkflow/expander.py
+++ b/src/horus_builtin/workflow/subworkflow/expander.py
@@ -252,7 +252,7 @@ class SubworkflowExpander(HorusTask):
                     )
                 )
 
-        edges.extend(self._out_port_edges(wf, out_ports))
+        edges.extend(self._out_port_edges(wf, out_ports, by_id))
 
         wf.expand(tasks=tasks, edges=edges, artifacts=artifacts)
         horus_logger.log.debug(
@@ -442,7 +442,10 @@ class SubworkflowExpander(HorusTask):
         )
 
     def _out_port_edges(
-        self, wf: BaseWorkflow, out_ports: list[SubworkflowPort]
+        self,
+        wf: BaseWorkflow,
+        out_ports: list[SubworkflowPort],
+        by_id: dict[str, BaseTask],
     ) -> list[WorkflowEdge]:
         """
         Re-emit every parent edge sourcing an out-port from the real inner
@@ -451,12 +454,16 @@ class SubworkflowExpander(HorusTask):
         """
         edges: list[WorkflowEdge] = []
         for port in out_ports:
-            if port.task is None or _is_pinned(self.outputs, port.name):
+            if port.task is None:
+                continue
+            if _is_pinned(self.outputs, port.name):
                 # An enclosing construct (a MapExpander materializing this
-                # clone's slot) has taken the port over and consumes the
-                # placeholder directly. Known gap: fan-in of a mapped
-                # subworkflow's results therefore sees the placeholder
-                # rather than the inner producer's real output.
+                # clone's slot) has taken the port over and pinned the
+                # placeholder to the slot's absolute path. Point the real
+                # inner producer's output at that same path instead, so
+                # the slot receives the clone's actual result rather than
+                # the never-written placeholder.
+                self._pin_out_port(by_id, port)
                 continue
             for edge in wf.edges:
                 if edge.source != self.id or edge.source_output != port.name:
@@ -486,6 +493,33 @@ class SubworkflowExpander(HorusTask):
                     )
                 )
         return edges
+
+    def _pin_out_port(
+        self, by_id: dict[str, BaseTask], port: SubworkflowPort
+    ) -> None:
+        """
+        Point the real inner producer's output artifact at the absolute
+        path an enclosing construct pinned *port*'s placeholder to.
+
+        Mirrors the "pinned" branch of :meth:`_resolve_in_port`: instead of
+        the placeholder, the actual producer now writes directly to the
+        slot the enclosing construct materialized, so it is filled with
+        the real result rather than staying empty.
+        """
+        assert port.task is not None
+        producer = by_id.get(self._prefixed(port.task))
+        if producer is None:
+            return
+        artifact = next(
+            (a for a in producer.outputs if a.id == port.artifact), None
+        )
+        placeholder = next(
+            (a for a in self.outputs if a.id == port.name), None
+        )
+        if artifact is None or placeholder is None:
+            return
+        assert placeholder.declared_path is not None
+        _pin(artifact, placeholder.declared_path)
 
 
 def _is_pinned(artifacts: list[BaseArtifact], port_name: str) -> bool:

--- a/tests/unit/workflow/test_subworkflow.py
+++ b/tests/unit/workflow/test_subworkflow.py
@@ -483,9 +483,8 @@ class TestSubworkflowAsMapTemplate:
     ) -> None:
         """
         Each map clone inlines its own copy of the body, with per-clone
-        paths. Fan-in of a mapped subworkflow's *results* is a known gap:
-        ``MapExpander._pin_path`` pins the port placeholder rather than
-        the inner producer's real output.
+        paths, and the gather task fans in each clone's real output
+        rather than the never-written port placeholder.
         """
         del horus_context
         emit = _shell_task(
@@ -530,6 +529,10 @@ class TestSubworkflowAsMapTemplate:
             inner = _inner(wf, f"fan[{i}]/emit")
             assert inner.status is TaskStatus.COMPLETED
             assert (inner.outputs[0].path / "idx.json").read_text() == str(i)
+
+        gathered = _inner(wf, "gather").inputs[0].path
+        for i in range(2):
+            assert (gathered / str(i) / "idx.json").read_text() == str(i)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

When a `SubworkflowExpander` is used as the template of a `map:` block, `MapExpander` pins the expander's single declared output (an out-port placeholder, since `SubworkflowExpander` never writes its own outputs) to the clone's gather slot (`{mapId}.gathered/{i}/`). `SubworkflowExpander._out_port_edges` saw that pinned placeholder and, believing an enclosing construct had "taken over" the port, skipped re-emitting the edge from the real inner producer. The gather task ended up fanning in the never-written placeholder path instead of each clone's actual result.

The fix mirrors the symmetric handling already in place for in-ports (`_resolve_in_port`'s `"pinned"` branch, which points the inner *consumer* at an enclosing construct's materialized path): when an out-port's placeholder has been pinned to an absolute path, `_out_port_edges` now points the real inner *producer*'s output artifact at that same path (`SubworkflowExpander._pin_out_port`), so the clone writes its result directly into the slot the map machinery prepared, instead of leaving it empty.

## Mechanism

- `MapExpander._set_output_path` pins `clone.outputs[0]` (for a subworkflow clone, the out-port placeholder built by `SubworkflowExpander._ensure_ports`) to `gathered_root/{i}`.
- Previously, `SubworkflowExpander._out_port_edges` treated `_is_pinned(self.outputs, port.name)` as "nothing to do here", so the actual producer task inside the body kept writing to its own per-clone path under `run_root/{cloneId}/...`, and the pinned gather slot stayed empty.
- Now, when the placeholder is pinned, `_pin_out_port` looks up the inlined producer task (`by_id[self._prefixed(port.task)]`), finds its output artifact matching `port.artifact`, and re-points it (`path`/`declared_path`) at the placeholder's pinned path. No new edge is needed, exactly like the existing pinned in-port case.

## Evidence

Extended the existing `test_mapped_subworkflow_runs_per_clone` test (it previously asserted only that each clone's *inner* task ran and wrote its own copy, not that the gather task actually received it) with an assertion that the gathered folder contains each clone's real content.

**Red, before the fix** (`FileNotFoundError` because nothing had ever written into the clone's pinned gather slot):

```
FileNotFoundError: [Errno 2] No such file or directory:
'.../test_mapped_subworkflow_runs_p0/fan.gathered/0/idx.json'
```

**Green, after the fix:**

```
tests/unit/workflow/test_subworkflow.py ............................ [ 51%]
tests/unit/workflow/test_map.py .......................... [100%]
======================== 54 passed, 2 warnings in 1.28s ========================
```

Full suite: 643 passed before and after (same count; the new assertion extends an existing test rather than adding one). `ruff check`, `ruff format --check`, and `mypy .` are clean.

## Test plan

- [x] `pytest tests/unit/workflow/test_subworkflow.py tests/unit/workflow/test_map.py` passes (54 passed)
- [x] Full suite: `pytest --no-cov -q` -> 643 passed
- [x] `ruff check` / `ruff format --check` clean
- [x] `mypy .` clean (176 source files)
- [x] No documentation update required (internal fan-in wiring fix; no new/changed user-facing YAML, CLI, or GUI surface)