### PR TITLE
fix(workflow): correct map fan-in paths, sanitize edge cases, and TUI task counter

### DIFF
--- a/src/horus_builtin/event/tui_subscriber.py
+++ b/src/horus_builtin/event/tui_subscriber.py
@@ -243,8 +243,9 @@ class WorkflowTUISubscriber(BaseEventSubscriber):
     _live: Live | None = PrivateAttr(default=None)
     _workflow: BaseWorkflow | None = PrivateAttr(default=None)
 
-    # Execution scope (planned task ids) for an honest progress total.
-    _scope: set[str] = PrivateAttr(default_factory=set)
+    # Task the run was triggered from; the execution scope behind the
+    # progress total is re-planned from it on every frame (see _scope_ids).
+    _trigger: str | None = PrivateAttr(default=None)
     _started_at: float | None = PrivateAttr(default=None)
 
     # Per-task timing, derived from status transitions / completion events.
@@ -268,18 +269,34 @@ class WorkflowTUISubscriber(BaseEventSubscriber):
         Render *workflow*'s tasks before the run starts.
         """
         self._workflow = workflow
+        self._trigger = trigger_id or (
+            workflow.tasks[0].id if workflow.tasks else None
+        )
+
+    def _scope_ids(self, workflow: BaseWorkflow) -> set[str]:
+        """
+        Ids in the run's execution scope, re-planned from *workflow*'s
+        current tasks and edges.
+
+        A ``map:`` or ``sub:`` expander adds its clones, and the edges that
+        reach the gather task, only when it runs (see
+        :meth:`~horus_runtime.core.workflow.base.BaseWorkflow.expand`), so a
+        plan frozen before the run undercounts every fan-out: a five-clone
+        loop map reported ``1/1 tasks``. Re-planning per frame counts the
+        DAG as it actually is.
+        """
+        if self._trigger is None:
+            return {t.id for t in workflow.tasks}
         try:
-            target = trigger_id or (
-                workflow.tasks[0].id if workflow.tasks else None
-            )
-            if target is not None:
-                self._scope = set(
-                    execution_plan(
-                        workflow.tasks, trigger_id=target, edges=workflow.edges
-                    )
+            return set(
+                execution_plan(
+                    workflow.tasks,
+                    trigger_id=self._trigger,
+                    edges=workflow.edges,
                 )
+            )
         except Exception:
-            self._scope = {t.id for t in workflow.tasks}
+            return {t.id for t in workflow.tasks}
 
     @contextmanager
     def live(self) -> Iterator[None]:
@@ -470,7 +487,7 @@ class WorkflowTUISubscriber(BaseEventSubscriber):
         return Panel(line, border_style=style, padding=(0, 1))
 
     def _render_progress(self, workflow: BaseWorkflow) -> RenderableType:
-        scope = self._scope or {t.id for t in workflow.tasks}
+        scope = self._scope_ids(workflow)
         total = len(scope)
         tasks = [t for t in workflow.tasks if t.id in scope]
         done = sum(1 for t in tasks if t.status in _TERMINAL)
@@ -586,7 +603,7 @@ class WorkflowTUISubscriber(BaseEventSubscriber):
         if workflow is None:
             return Text(_("No workflow ran."), style="dim")
 
-        scope = self._scope or {t.id for t in workflow.tasks}
+        scope = self._scope_ids(workflow)
         tasks = [t for t in workflow.tasks if t.id in scope]
         done = sum(1 for t in tasks if t.status in _TERMINAL)
         elapsed = (

--- a/src/horus_builtin/workflow/map.py
+++ b/src/horus_builtin/workflow/map.py
@@ -334,7 +334,9 @@ class MapExpander(HorusTask):
                 )
                 self._set_input_path(clone, self.over.index_input, index_path)
 
-            self._set_output_path(clone, gathered_root / str(i))
+            await self._set_output_path(
+                clone, gathered_root / str(i), orchestrator
+            )
 
             clones.append(clone)
             edges.append(
@@ -592,8 +594,31 @@ class MapExpander(HorusTask):
             )
         self._pin_path(artifact, path)
 
-    def _set_output_path(self, clone: BaseTask, path: Path) -> None:
-        """Pin *clone*'s (sole) declared output at *path*."""
+    async def _set_output_path(
+        self, clone: BaseTask, slot_dir: Path, orchestrator: BaseTarget
+    ) -> None:
+        """
+        Pin *clone*'s (sole) declared output under its ``{i}/`` slot dir.
+
+        A :class:`.FolderArtifact` output already names a directory, so it
+        is pinned straight at *slot_dir* (the gather task then sees
+        ``{i}/<whatever the clone wrote>``). Any other output keeps its
+        declared filename, pinned at ``slot_dir / <filename>``; since
+        nothing else creates *slot_dir* for a bare file output, it is
+        created here first (only in this branch -- pre-creating it for a
+        folder output would make the clone look already-complete and skip
+        it on resume).
+
+        A :class:`~horus_builtin.workflow.subworkflow.expander.
+        SubworkflowExpander` clone is a third case: its sole declared
+        output is always a never-written ``FileArtifact`` port placeholder,
+        regardless of what the real inner producer's output kind is. Its
+        own ``_run`` re-points that real producer at wherever the
+        placeholder got pinned (see ``SubworkflowExpander._pin_out_port``),
+        so it is pinned straight at *slot_dir* like a folder output,
+        leaving that re-pointing free to hand the real producer's own
+        declared filename onward.
+        """
         if len(clone.outputs) != 1:
             raise MapConfigurationError(
                 _(
@@ -602,7 +627,20 @@ class MapExpander(HorusTask):
                 )
                 % {"id": self.id}
             )
-        self._pin_path(clone.outputs[0], path)
+        # Imported here, as in BaseWorkflow.sub, to avoid a
+        # base.py <-> map.py <-> expander.py cycle at module load time.
+        from horus_builtin.workflow.subworkflow.expander import (  # noqa: PLC0415
+            SubworkflowExpander,
+        )
+
+        artifact = clone.outputs[0]
+        if isinstance(artifact, FolderArtifact) or isinstance(
+            clone, SubworkflowExpander
+        ):
+            self._pin_path(artifact, slot_dir)
+        else:
+            await orchestrator.mkdir(str(slot_dir))
+            self._pin_path(artifact, slot_dir / artifact.path.name)
 
     @staticmethod
     def _clone_output_id(clone: BaseTask) -> str:

--- a/src/horus_runtime/sanitize.py
+++ b/src/horus_runtime/sanitize.py
@@ -45,6 +45,7 @@ from pathlib import Path
 
 import yaml
 
+from horus_builtin.workflow.map import MapExpander
 from horus_runtime.core.artifact.base import BaseArtifact
 from horus_runtime.core.workflow.base import BaseWorkflow
 
@@ -135,6 +136,14 @@ def find_root_inputs(
         (edge.target, edge.target_input)
         for edge in workflow.edges
         if edge.target_input is not None
+    }
+    # A map's fan-in input is wired by MapExpander at run time, not by a
+    # static edge, so it would otherwise look like an author-supplied root
+    # input and get promoted to one.
+    wired |= {
+        (task.gather_task, task.gather_input)
+        for task in workflow.tasks
+        if isinstance(task, MapExpander)
     }
     # Reuses the runtime's own produced-vs-external rule rather than
     # restating it here, so sanitizing can never drift from packaging.
@@ -260,22 +269,23 @@ def apply_promotions(text: str, root_inputs: list[RootInput]) -> str:
     artifact_lines, edge_lines = _render(root_inputs)
     keys = _top_level_keys(lines)
 
-    if "edges" not in keys:
-        raise SanitizeError(
-            "Workflow has no top-level 'edges:' block to extend."
-        )
-
     # Insert the later block first so the earlier block's index stays valid.
-    edges_at = _block_end(lines, keys["edges"], keys)
-    lines[edges_at:edges_at] = ["", *edge_lines] if edge_lines else []
+    if "edges" in keys:
+        edges_at = _block_end(lines, keys["edges"], keys)
+        lines[edges_at:edges_at] = ["", *edge_lines] if edge_lines else []
+    else:
+        # A map:-only workflow has no top-level edges: block of its own (the
+        # map block describes all its wiring); create one at the end.
+        lines += ["", "edges:", *edge_lines]
 
     if "artifacts" in keys:
         at = _block_end(lines, keys["artifacts"], keys)
         lines[at:at] = artifact_lines
     else:
         # Root inputs read best above the tasks that consume them; fall back
-        # to the edges block for a workflow with no tasks key of its own.
-        anchor = keys.get("tasks", keys["edges"])
+        # to the edges block (just created above if it didn't already
+        # exist) for a workflow with no tasks key of its own.
+        anchor = keys.get("tasks", keys.get("edges", len(lines)))
         lines[anchor:anchor] = ["artifacts:", *artifact_lines]
 
     return "\n".join(lines) + "\n"

--- a/tests/unit/event/test_tui_subscriber.py
+++ b/tests/unit/event/test_tui_subscriber.py
@@ -34,6 +34,7 @@ from horus_runtime.core.interaction.transport import (
 )
 from horus_runtime.core.task.base import BaseTask
 from horus_runtime.core.task.status import TaskStatus
+from horus_runtime.core.workflow.edge import WorkflowEdge
 from horus_runtime.event.subscriber import BaseEventSubscriber
 
 
@@ -115,6 +116,37 @@ class TestWorkflowTUISubscriber:
             assert tui._paused is True
             tui.handle(answered)
             assert tui._paused is False
+
+    def test_progress_total_follows_a_growing_dag(self) -> None:
+        """
+        Tasks added after ``track()`` count towards the total.
+
+        A ``map:``/``sub:`` expander only adds its clones once it runs, so a
+        scope planned before the run reported ``1/1 tasks`` for a five-clone
+        loop map.
+        """
+        wf = _workflow()
+        wf.edges.append(WorkflowEdge(source="a", target="b"))
+        tui = WorkflowTUISubscriber()
+        tui.track(wf, trigger_id="a")
+
+        console = Console(record=True, width=120)
+        console.print(tui.render())
+        assert "0/2 " in console.export_text()
+
+        wf.tasks.append(
+            HorusTask(
+                id="c",
+                name="Gamma",
+                runtime=CommandRuntime(command="true"),
+                executor=ShellExecutor(),
+            )
+        )
+        wf.edges.append(WorkflowEdge(source="b", target="c"))
+
+        console = Console(record=True, width=120)
+        console.print(tui.render())
+        assert "0/3 " in console.export_text()
 
     def test_setup_is_noop(self) -> None:
         """setup() is a no-op and must not raise."""

--- a/tests/unit/test_sanitize.py
+++ b/tests/unit/test_sanitize.py
@@ -24,8 +24,14 @@ from pathlib import Path
 import pytest
 import yaml
 
+from horus_builtin.artifact.file import FileArtifact
 from horus_runtime.core.workflow.base import BaseWorkflow
-from horus_runtime.sanitize import find_root_inputs, sanitize_workflow
+from horus_runtime.sanitize import (
+    RootInput,
+    apply_promotions,
+    find_root_inputs,
+    sanitize_workflow,
+)
 
 # `seed` and `config` are unwired inputs (root inputs). `data` is wired by an
 # edge. `shared.yaml` is read by both tasks, so it is one artifact, two edges.
@@ -297,6 +303,133 @@ def test_authored_name_and_description_survive_promotion(
     reloaded_config = next(a for a in reloaded.artifacts if a.id == "config")
     assert reloaded_config.name == "Run configuration"
     assert reloaded_config.description == "Parameters controlling the run."
+
+
+MAP_WORKFLOW = """
+kind: horus_workflow
+name: Map Sanitize Me
+tasks:
+  - kind: horus_task
+    id: split
+    name: Split
+    inputs:
+      - id: items
+        kind: file
+        path: examples/items.json
+    outputs:
+      - id: batches
+        kind: json
+        path: results/batches.json
+    executor:
+      kind: shell
+    runtime:
+      kind: command
+      command: cp ${items} ${batches}
+    target:
+      kind: local
+  - id: score
+    map:
+      over:
+        source_task: split
+        source_output: batches
+        item_input: item
+      template:
+        kind: horus_task
+        inputs:
+          - id: item
+            kind: file
+            path: item_in.json
+        outputs:
+          - id: scored
+            kind: file
+            path: scored.txt
+        executor:
+          kind: shell
+        runtime:
+          kind: command
+          command: cp ${item} ${scored}
+        target:
+          kind: local
+      gather:
+        task: gather
+        input: results
+  - kind: horus_task
+    id: gather
+    name: Gather
+    inputs:
+      - id: results
+        kind: folder
+        path: score.gathered
+    outputs:
+      - id: summary
+        kind: file
+        path: results/summary.txt
+    executor:
+      kind: shell
+    runtime:
+      kind: command
+      command: touch ${summary}
+    target:
+      kind: local
+
+orchestrator_target:
+  kind: local
+"""
+
+
+@pytest.fixture
+def map_workflow_dir(tmp_path: Path) -> Path:
+    """A map: + gather workflow, laid out the way w01 is."""
+    (tmp_path / "examples").mkdir()
+    (tmp_path / "examples" / "items.json").write_text("[]\n")
+    (tmp_path / "workflow.yaml").write_text(MAP_WORKFLOW)
+    return tmp_path
+
+
+@pytest.mark.usefixtures("horus_context")
+def test_map_gather_input_is_not_a_root_input(map_workflow_dir: Path) -> None:
+    """The gather task's fan-in input is wired by MapExpander at run time,
+    not by a static edge, so it must not be mistaken for an author-supplied
+    root input or a missing edge.
+    """
+    workflow = BaseWorkflow.from_yaml(map_workflow_dir / "workflow.yaml")
+    roots, missing = find_root_inputs(workflow)
+
+    assert all(r.path.name != "score.gathered" for r in roots)
+    assert all(m.task_id != "gather" for m in missing)
+    assert {r.path.as_posix() for r in roots} == {"examples/items.json"}
+
+
+def test_apply_promotions_creates_missing_edges_block() -> None:
+    """A map:-only workflow has no top-level edges: block of its own; the
+    rewrite must create one rather than raising.
+    """
+    text = (
+        "kind: horus_workflow\n"
+        "name: No Edges Yet\n"
+        "tasks:\n"
+        "  - kind: horus_task\n"
+        "    id: produce\n"
+    )
+    root = RootInput(
+        root_id="items",
+        artifact=FileArtifact(id="items", path=Path("examples/items.json")),
+        consumers=(("produce", "items"),),
+    )
+
+    result = apply_promotions(text, [root])
+
+    assert "edges:" in result
+    doc = yaml.safe_load(result)
+    assert doc["edges"] == [
+        {
+            "source": "artifact-items",
+            "source_output": "items",
+            "target": "produce",
+            "target_input": "items",
+        }
+    ]
+    assert doc["artifacts"][0]["id"] == "items"
 
 
 @pytest.mark.usefixtures("horus_context")

--- a/tests/unit/workflow/test_map.py
+++ b/tests/unit/workflow/test_map.py
@@ -290,6 +290,47 @@ class TestRangeMapEndToEnd:
             "2",
         ]
 
+    async def test_range_fans_out_with_file_output_keeps_filename(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """
+        A non-folder (FileArtifact) clone output keeps its declared
+        filename under the ``{i}/`` slot dir, rather than collapsing to a
+        bare file named ``0``/``1``/``2`` (the w03-loop-map regression).
+        """
+        del horus_context
+        gather = _gather_task(tmp_path)
+        wf = HorusWorkflow(
+            name="wf",
+            tasks=[gather],
+            orchestrator_target=LocalTarget(
+                working_directory=tmp_path.as_posix()
+            ),
+        )
+        template = HorusTask(
+            id="template",
+            name="template",
+            runtime=CommandRuntime(command="echo $idx > $square"),
+            executor=ShellExecutor(),
+            target=LocalTarget(),
+            inputs=[FileArtifact(id="idx", path=Path("idx_in"))],
+            outputs=[FileArtifact(id="square", path=Path("square.txt"))],
+        )
+        wf.map(
+            id="rmap",
+            template=template,
+            range=3,
+            index_input="idx",
+            gather=("gather", "results"),
+        )
+
+        await wf.run(trigger_id="rmap")
+
+        assert wf.status.value == "completed"
+        gathered = tmp_path / "rmap.gathered"
+        for i in range(3):
+            assert (gathered / str(i) / "square.txt").exists()
+
 
 @pytest.mark.unit
 class TestPartialCompletion:


### PR DESCRIPTION
## Summary
- Fix `MapExpander` fan-in: a non-folder clone output was collapsed to a bare
  file named `<i>` instead of `<i>/<declared filename>`, silently zeroing out
  any bounded-range or collection map whose template produces a `FileArtifact`
  (e.g. pantheon's `w03-loop-map` showcase summed to 0 instead of 30).
- Fix `sanitize`: a map's gather-task fan-in input (wired by `MapExpander` at
  run time, not by a static edge) was misdetected as an author-supplied root
  input; and workflows with no top-level `edges:` block (map-only workflows)
  raised instead of having one created.
- Fix the TUI's task counter: the execution scope was planned once before the
  run started, so any task an expander adds later (map clones, the gather
  task, subworkflow-inlined tasks) never counted — a 5-clone loop map showed
  `1/1 tasks`. The scope is now re-planned from the workflow's current tasks
  and edges on every frame.

## Test plan
- `pytest` (655 passed; 1 pre-existing environmental failure unrelated to
  this change — `test_main_script_execution` shells out to a `horus` binary
  not installed in this venv)
- `ruff check`, `ruff format --check`, `mypy` all clean
- End-to-end against pantheon's `engine-showcases` workflows (w01, w03, w04):
  correct outputs, correct sanitize behavior, correct TUI counters (7/7, 7/7,
  8/8)