### PR TITLE
🐛 Make map and subworkflow expanders re-runnable

### DIFF
--- a/src/horus_builtin/workflow/loop.py
+++ b/src/horus_builtin/workflow/loop.py
@@ -534,6 +534,7 @@ class LoopController(HorusTask):
         """
         artifact.path = path
         artifact.declared_path = path
+        artifact.pinned = True
 
 
 def lower_loop_entry(entry: dict[str, Any]) -> dict[str, Any]:

--- a/src/horus_builtin/workflow/map.py
+++ b/src/horus_builtin/workflow/map.py
@@ -578,6 +578,7 @@ class MapExpander(HorusTask):
         """
         artifact.path = path
         artifact.declared_path = path
+        artifact.pinned = True
 
     def _set_input_path(
         self, clone: BaseTask, input_id: str, path: Path
@@ -789,6 +790,21 @@ def lower_map_entry(
             }
         )
 
+    # Gate the gather task behind the expander. Without it the gather task is
+    # ready from the start (its only real dependencies -- the clones -- do not
+    # exist until the expander runs), so the scheduler dispatches it alongside
+    # the expander and its not-yet-pinned fan-in input is mistaken for a root
+    # input and fetched from the orchestrator target.
+    edges.append(
+        {
+            "source": task_id,
+            "source_output": f"{task_id}{_FANOUT_SUFFIX}",
+            "target": gather_block["task"],
+            "target_input": gather_block["input"],
+            "transfer": False,
+        }
+    )
+
     return expander, edges
 
 
@@ -891,6 +907,17 @@ def map_task(
         kwargs["target"] = target
 
     expander = MapExpander(**kwargs)
+
+    # Same ordering edge lower_map_entry emits; see its comment.
+    edges.append(
+        WorkflowEdge(
+            source=id,
+            source_output=expander._fanout_marker_id,  # noqa: SLF001
+            target=gather_task,
+            target_input=gather_input,
+            transfer=False,
+        )
+    )
 
     wf.tasks.append(expander)
     wf.edges.extend(edges)

--- a/src/horus_runtime/core/artifact/base.py
+++ b/src/horus_runtime/core/artifact/base.py
@@ -107,6 +107,16 @@ class BaseArtifact[T: Any = Any](AutoRegistry, entry_point="artifact"):
     :meth:`resolve_path` runs. See ``BaseWorkflow._resolve_run_paths``.
     """
 
+    pinned: bool = Field(default=False, init=False, exclude=True)
+    """
+    Set when some expander (map/loop) has already materialized this
+    artifact's data at ``path`` directly on the workflow's orchestrator
+    filesystem. ``BaseWorkflow.transfer_artifacts`` skips these entirely
+    instead of treating the lack of a ``transfer=True`` producer edge as "root
+    input, fetch from ``orchestrator_target``" -- which would otherwise try
+    (and fail) to fetch data that was never uploaded/registered anywhere.
+    """
+
     kind: str
     """
     Type of the artifact, such as 'file', 'folder', 'dataset', 'model', etc.

--- a/src/horus_runtime/core/workflow/base.py
+++ b/src/horus_runtime/core/workflow/base.py
@@ -853,23 +853,33 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
         wiring them to an existing join task). If any check fails, nothing
         is appended — the workflow is left exactly as it was.
 
-        Validates, in order: task id uniqueness (existing + new), per-task
+        A batch **supersedes** what it re-derives: a new task whose id already
+        exists replaces it, together with every edge touching that id, and a
+        new root artifact replaces an existing one of the same id. This is
+        what makes an expander re-runnable. Every expander re-derives its
+        whole expansion on each trigger (``is_complete`` is hardcoded
+        ``False``), and a run resumed from a snapshot that already carries a
+        previous run's expansion — which is exactly what tc-os freezes when
+        re-running from an earlier run — would otherwise collide with itself.
+        The freshly derived task has to win regardless: its paths are pinned
+        under *this* run's root, while the snapshot's copy names the previous
+        run's directory. Duplicates *within* one batch are still an error.
+
+        Validates, in order: task id uniqueness (kept + new), per-task
         input/output id uniqueness for each new task, root artifact id
-        uniqueness (existing + new), every new edge resolving against the
+        uniqueness (kept + new), every new edge resolving against the
         combined tasks/artifacts with no duplicate ``(target, target_input)``
-        (existing or within the batch), and no cycle anywhere in the
-        resulting graph.
+        (kept or within the batch), and no cycle anywhere in the resulting
+        graph.
 
         On success, every new task is anchored exactly like
         :meth:`add_task` anchors a single task, everything is appended, and
         :attr:`_revision` is bumped once for the whole batch.
 
         Raises:
-            TaskIdsAreNotUniqueError: If a new task's id collides with an
-                existing task id or another new task.
+            TaskIdsAreNotUniqueError: If two tasks in the batch share an id.
             ArtifactIdsAreNotUniqueError: If a new task's own inputs/outputs
-                collide, or a new root artifact's id collides with an
-                existing or another new root artifact.
+                collide, or two new root artifacts share an id.
             UnknownEdgeEndpointError: If a new edge's target or source does
                 not resolve against the combined graph.
             DuplicateEdgeTargetError: If a new edge duplicates the
@@ -881,8 +891,25 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
         new_edges = edges or []
         new_artifacts = artifacts or []
 
-        combined_tasks = [*self.tasks, *new_tasks]
-        combined_artifacts = [*self.artifacts, *new_artifacts]
+        # What this batch re-derives, and so replaces (see the docstring).
+        # Edges are dropped by *endpoint* rather than by equality: an expander
+        # re-emits every edge touching the tasks it owns, so any stale edge on
+        # a superseded id is one this batch is about to re-state.
+        superseded_tasks = {task.id for task in new_tasks}
+        superseded_artifacts = {artifact.id for artifact in new_artifacts}
+        kept_tasks = [t for t in self.tasks if t.id not in superseded_tasks]
+        kept_edges = [
+            e
+            for e in self.edges
+            if e.source not in superseded_tasks
+            and e.target not in superseded_tasks
+        ]
+        kept_artifacts = [
+            a for a in self.artifacts if a.id not in superseded_artifacts
+        ]
+
+        combined_tasks = [*kept_tasks, *new_tasks]
+        combined_artifacts = [*kept_artifacts, *new_artifacts]
 
         self._assert_unique_task_ids(combined_tasks)
         for task in new_tasks:
@@ -902,7 +929,7 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
         # many clone -> gather edges onto the same gather input in one
         # batch.
         seen_targets = {
-            (e.target, e.target_input) for e in self.edges if e.transfer
+            (e.target, e.target_input) for e in kept_edges if e.transfer
         }
         for edge in new_edges:
             self._assert_edge_target_resolves(edge, task_inputs)
@@ -923,13 +950,16 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
         # formed only by two-or-more new edges together, so validate the
         # whole resulting graph at once: topological_sort raises
         # CyclicDependencyError itself if any cycle exists anywhere in it.
-        combined_edges = [*self.edges, *new_edges]
+        combined_edges = [*kept_edges, *new_edges]
         dependencies = build_dependencies(combined_tasks, combined_edges)
         topological_sort(set(dependencies.keys()), dependencies)
 
-        self.tasks.extend(new_tasks)
-        self.artifacts.extend(new_artifacts)
-        self.edges.extend(new_edges)
+        # Slice assignment, not rebinding: the model's list objects are handed
+        # out elsewhere (the scheduler reads `workflow.tasks` every loop), and
+        # replacing the field would leave those holding the old list.
+        self.tasks[:] = combined_tasks
+        self.artifacts[:] = combined_artifacts
+        self.edges[:] = combined_edges
         for task in new_tasks:
             self._anchor_task(task)
         # Runs after edges are appended so a new task wired by one of the
@@ -1074,6 +1104,11 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
             source_map = self._build_source_map()
 
         for artifact in task.inputs:
+            if artifact.pinned:
+                # Already materialized in place by an expander (map/loop);
+                # not a transfer edge and not a root input either.
+                continue
+
             source = source_map.get((task.id, artifact.id))
             # Resolve the source target.
             source_target = source.target if source is not None else None

--- a/tests/unit/workflow/test_dynamic_mutation.py
+++ b/tests/unit/workflow/test_dynamic_mutation.py
@@ -294,6 +294,45 @@ class TestExpand:
         # Bumped once for the whole batch, not once per item.
         assert wf._revision == before + 1
 
+    def test_expand_supersedes_what_it_rederives(self, tmp_path: Path) -> None:
+        """
+        Re-expanding an id replaces the task and drops the stale edges on it,
+        so an expander can re-run against a snapshot that already carries its
+        previous expansion.
+        """
+        root = _task(
+            "root",
+            outputs=[FileArtifact(id="root_out", path=tmp_path / "r.txt")],
+        )
+        wf = HorusWorkflow(name="wf", tasks=[root])
+        mapped = _task(
+            "map1", inputs=[FileArtifact(id="in", path=tmp_path / "m.txt")]
+        )
+        stale_edge = _edge("root", "root_out", "map1", "in")
+        wf.expand(tasks=[mapped], edges=[stale_edge])
+
+        fresh = _task(
+            "map1", inputs=[FileArtifact(id="in", path=tmp_path / "m2.txt")]
+        )
+        fresh_edge = _edge("root", "root_out", "map1", "in")
+        wf.expand(tasks=[fresh], edges=[fresh_edge])
+
+        assert [t.id for t in wf.tasks] == ["root", "map1"]
+        # The freshly derived task wins: its paths belong to this run.
+        assert wf.tasks[1] is fresh
+        assert wf.edges == [fresh_edge]
+
+    def test_expand_duplicate_ids_within_one_batch_still_raise(self) -> None:
+        """Supersession is against the workflow, not within the batch: two
+        new tasks sharing an id is still an authoring error.
+        """
+        wf = HorusWorkflow(name="wf", tasks=[_task("root")])
+
+        with pytest.raises(TaskIdsAreNotUniqueError):
+            wf.expand(tasks=[_task("dup"), _task("dup")])
+
+        assert [t.id for t in wf.tasks] == ["root"]
+
     def test_expand_invalid_batch_commits_nothing(self) -> None:
         """
         One bad edge in the batch (references a task id that isn't part of

--- a/tests/unit/workflow/test_loops.py
+++ b/tests/unit/workflow/test_loops.py
@@ -209,6 +209,38 @@ class TestConditionalLoopEndToEnd:
         assert wf.status.value == "completed"
         assert _body_ids(wf) == ["loop#1"]
 
+    async def test_rerun_from_an_already_expanded_snapshot(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """
+        Re-running from the post-run snapshot re-derives the same body/checker
+        clones instead of colliding with them. Same shape as the map's
+        equivalent test: tc-os freezes a new run from the previous run's
+        snapshot, which already carries the expansion.
+        """
+        del horus_context
+        wf = HorusWorkflow(
+            name="wf",
+            orchestrator_target=LocalTarget(
+                working_directory=tmp_path.as_posix()
+            ),
+        )
+        wf.loop(
+            id="loop",
+            body=_body_task(_STOP_AT_BODY % {"stop": 1}),
+            until="signal",
+            max_iterations=10,
+            index_input="idx",
+        )
+        await wf.run(trigger_id="loop")
+        assert wf.status.value == "completed"
+
+        resumed = HorusWorkflow.model_validate(wf.model_dump(mode="json"))
+        await resumed.run(trigger_id="loop")
+
+        assert resumed.status.value == "completed"
+        assert _body_ids(resumed) == ["loop#1", "loop#2"]
+
 
 @pytest.mark.unit
 class TestMaxIterationsSafetyBound:

--- a/tests/unit/workflow/test_map.py
+++ b/tests/unit/workflow/test_map.py
@@ -48,6 +48,7 @@ from horus_builtin.workflow.map import (
 from horus_runtime.context import HorusContext
 from horus_runtime.core.task.status import TaskStatus
 from horus_runtime.core.workflow.base import BaseWorkflow
+from horus_runtime.core.workflow.edge import WorkflowEdge
 
 
 def _template_task(
@@ -251,6 +252,140 @@ class TestCollectionMapEndToEnd:
         assert wf.status.value == "completed"
         gathered = tmp_path / "score.gathered"
         assert sorted(p.name for p in gathered.iterdir()) == ["0", "1"]
+
+    async def test_gather_wired_to_trigger_still_waits_for_expander(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """
+        A gather task that is reachable from the trigger by something other
+        than the clones still runs *after* the expander.
+
+        The gather task's other tests leave it edge-isolated, so it only
+        enters the scheduler's trigger-reachable scope once expansion wires
+        the clone edges. Wire it to the trigger directly and it is in scope
+        from the start -- without the expander -> gather ordering edge it is
+        dispatched alongside the expander and its unpinned fan-in input is
+        mistaken for a root input.
+        """
+        del horus_context
+        split = _split_task(tmp_path, ["a", "b"])
+        gather = _gather_task(tmp_path)
+        gather.inputs.append(FolderArtifact(id="seed", path=Path("seed_in")))
+
+        wf = HorusWorkflow(
+            name="wf",
+            tasks=[split, gather],
+            edges=[
+                WorkflowEdge(
+                    source="split",
+                    source_output="batches",
+                    target="gather",
+                    target_input="seed",
+                )
+            ],
+            orchestrator_target=LocalTarget(
+                working_directory=tmp_path.as_posix()
+            ),
+        )
+        wf.map(
+            id="score",
+            template=_template_task(),
+            over=("split", "batches", "batch"),
+            gather=("gather", "results"),
+        )
+
+        await wf.run(trigger_id="split")
+
+        assert wf.status.value == "completed"
+        gathered = tmp_path / "score.gathered"
+        assert sorted(p.name for p in gathered.iterdir()) == ["0", "1"]
+
+    async def test_file_output_lands_inside_its_clone_directory(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """
+        A clone whose output is a *file* still gets its own ``{i}/`` directory,
+        with the file inside it under its declared name.
+
+        Pinning the file at ``{i}`` itself made ``{i}`` a file, so a gather
+        task walking per-clone subdirectories (the layout this module
+        documents) found none and silently produced an empty result instead of
+        failing.
+        """
+        del horus_context
+        split = _split_task(tmp_path, ["a", "b"])
+        gather = _gather_task(tmp_path)
+        wf = HorusWorkflow(
+            name="wf",
+            tasks=[split, gather],
+            orchestrator_target=LocalTarget(
+                working_directory=tmp_path.as_posix()
+            ),
+        )
+        wf.map(
+            id="score",
+            template=HorusTask(
+                id="template",
+                name="template",
+                runtime=CommandRuntime(command="cp $batch/data.txt $scored"),
+                executor=ShellExecutor(),
+                target=LocalTarget(),
+                inputs=[FolderArtifact(id="batch", path=Path("batch_in"))],
+                outputs=[FileArtifact(id="scored", path=Path("score.txt"))],
+            ),
+            over=("split", "batches", "batch"),
+            gather=("gather", "results"),
+        )
+
+        await wf.run(trigger_id="split")
+
+        assert wf.status.value == "completed"
+        gathered = tmp_path / "score.gathered"
+        assert sorted(p.name for p in gathered.iterdir()) == ["0", "1"]
+        for i, name in enumerate(("a", "b")):
+            clone_dir = gathered / str(i)
+            assert clone_dir.is_dir()
+            assert (clone_dir / "score.txt").read_text() == name
+
+    async def test_rerun_from_an_already_expanded_snapshot(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """
+        Re-running a workflow *from its own post-run snapshot* re-derives the
+        same clone set rather than colliding with it.
+
+        The resume tests below deliberately start from a fresh workflow
+        object, so nothing covered the shape tc-os actually runs: it PATCHes
+        the whole live workflow back onto the run record (clones included) and
+        freezes the next run from that snapshot, so the expander re-expands on
+        top of its own previous output.
+        """
+        del horus_context
+        split = _split_task(tmp_path, ["a", "b", "c"])
+        gather = _gather_task(tmp_path)
+        wf = HorusWorkflow(
+            name="wf",
+            tasks=[split, gather],
+            orchestrator_target=LocalTarget(
+                working_directory=tmp_path.as_posix()
+            ),
+        )
+        wf.map(
+            id="score",
+            template=_template_task(),
+            over=("split", "batches", "batch"),
+            gather=("gather", "results"),
+        )
+        await wf.run(trigger_id="split")
+        assert wf.status.value == "completed"
+
+        # The round trip a run snapshot makes through the API.
+        resumed = HorusWorkflow.model_validate(wf.model_dump(mode="json"))
+        await resumed.run(trigger_id="split")
+
+        assert resumed.status.value == "completed"
+        clone_ids = [t.id for t in resumed.tasks if t.id.startswith("score[")]
+        assert clone_ids == ["score[0]", "score[1]", "score[2]"]
 
 
 @pytest.mark.unit
@@ -552,12 +687,19 @@ class TestYamlLowering:
                 "target": "score",
                 "target_input": "batches",
                 "transfer": False,
-            }
+            },
+            {
+                "source": "score",
+                "source_output": "score.fanout",
+                "target": "gather",
+                "target_input": "results",
+                "transfer": False,
+            },
         ]
 
     def test_lower_range_entry(self) -> None:
-        """Range-mode ``map:`` lowers with no construction-time edge and no
-        placeholder input.
+        """Range-mode ``map:`` lowers with no source edge and no placeholder
+        input -- only the expander -> gather ordering edge.
         """
         entry = {
             "id": "rmap",
@@ -573,7 +715,15 @@ class TestYamlLowering:
         assert expander["over"]["range"] == 5
         assert expander["over"]["index_input"] == "idx"
         assert expander["inputs"] == []
-        assert edges == []
+        assert edges == [
+            {
+                "source": "rmap",
+                "source_output": "rmap.fanout",
+                "target": "gather",
+                "target_input": "results",
+                "transfer": False,
+            }
+        ]
 
     def test_lower_entry_missing_gather_raises(self) -> None:
         """A ``map:`` block missing ``gather`` raises a typed error naming

--- a/uv.lock
+++ b/uv.lock
@@ -6,6 +6,14 @@ resolution-markers = [
     "python_full_version < '3.15'",
 ]
 
+[options]
+exclude-newer = "2026-07-23T21:55:47.887508Z"
+exclude-newer-span = "P2D"
+
+[options.exclude-newer-package]
+horus-docker = false
+horus-runtime = false
+
 [[package]]
 name = "annotated-types"
 version = "0.7.0"


### PR DESCRIPTION
Rebased onto `main` (which has since gained #136–#138, #142–#148, and now #149 and #155). Three defects, found running the engine showcases (`w01`, `w03`, `w04`) end to end against tc-os.

> **What changed in the rebase.** The original PR carried a fourth fix — giving a file clone output its own `{i}/` directory. `main` has since implemented that in #138, and better: `_set_output_path` is async there, takes the slot dir and the orchestrator, and handles the `SubworkflowExpander` port-placeholder as a third case this PR did not. **That hunk is dropped; main's version is kept verbatim.** It was the only conflict.
>
> The knock-on effect is that this PR's original failing test, `test_mapped_subworkflow_runs_per_clone`, now **passes** — #137 and #138 closed exactly that gap upstream.

## `pinned` artifacts are no longer mistaken for root inputs

An expander materializes clone slices, indices and the fan-in folder directly on the orchestrator filesystem. Those have no `transfer=True` producer edge, so `transfer_artifacts` treated them as root inputs and tried to fetch data that was never uploaded anywhere. They now carry `pinned` and are skipped.

## `map:` orders its gather task behind the expander

The clone → gather edges only exist *after* expansion, so nothing held the gather task back. Any workflow where the gather task is reachable from the trigger by some other path had it dispatched concurrently with the expander, with its fan-in input still unpinned — surfacing as `Input artifact 'results' does not exist` (or a 404 from the S3 transfer strategy in tc-os).

`lower_map_entry` and `map_task` now both emit an ordering-only `expander → gather` edge on the existing `.fanout` marker. Derived on load, so stored workflows get it without migration.

## `expand()` supersedes what a batch re-derives

Every expander re-derives its whole expansion on each trigger (`is_complete` hardcoded `False`), so a run resumed from a snapshot that already carries a previous run's expansion collided with itself:

```
Multiple tasks share the same ID 'score[0]'
```

A batch now replaces same-id tasks, the edges touching them, and same-id root artifacts. The freshly derived task has to win regardless — its paths are pinned under *this* run's root, while the snapshot's copy names the previous run's directory. Duplicates *within* one batch are still `TaskIdsAreNotUniqueError`.

Affects all three expanders (`map.py`, `loop.py`, `subworkflow/expander.py`), which all call `wf.expand(...)` unconditionally.

## Interaction with #149

`transfer_artifacts` is touched by both this PR (the `pinned` skip) and #149 (value-root `materialize()`). They auto-merged and are orthogonal: pinned inputs are expander-materialized fan-in paths and are never value roots, so skipping them ahead of the materialize block is correct.

## Tests

Five added, each confirmed failing before its fix:

- gather wired to the trigger still waits for the expander
- re-run from an already-expanded snapshot, for both `map` and `loop` (via `model_validate(wf.model_dump())`, the round trip a run snapshot actually makes)
- `expand()` supersession replaces the task and drops its stale edges; intra-batch duplicates still raise

The existing resume tests all start from a *fresh* workflow object, which is why none of them covered the re-run path.

`uv run pytest tests/unit` — **726 passed** on the rebased branch. `uv run make lint` clean (ruff, ruff format, mypy strict).

## Known gap

Subworkflow re-runs still fail (`Input artifact 'trimmed' does not exist` when an inlined body task is skipped as already complete and its consumer re-runs). Not addressed here.

---

**horus-docs PR:** https://github.com/temple-compute/horus-docs/pull/52