### PR TITLE
fix(tui): keep dashboard visible after workflow finishes

### DIFF
--- a/src/horus_builtin/event/tui_subscriber.py
+++ b/src/horus_builtin/event/tui_subscriber.py
@@ -29,7 +29,7 @@ import sys
 import time
 from collections import deque
 from collections.abc import Iterator
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from typing import TYPE_CHECKING, ClassVar, NamedTuple
 
 from pydantic import PrivateAttr
@@ -258,6 +258,7 @@ class WorkflowTUISubscriber(BaseEventSubscriber):
     _last_transfer: tuple[str, float] | None = PrivateAttr(default=None)
     _error: tuple[str, str] | None = PrivateAttr(default=None)
     _paused: bool = PrivateAttr(default=False)
+    _finished: bool = PrivateAttr(default=False)
 
     def setup(self) -> None:
         """No startup work needed."""
@@ -328,6 +329,15 @@ class WorkflowTUISubscriber(BaseEventSubscriber):
                     self._capture_error(exc)
                     raise
                 finally:
+                    # Leave the DAG/table/log view on screen instead of
+                    # tearing it down the instant the run returns, so the
+                    # user can still see final task state. Only wait on an
+                    # interactive TTY, non-interactive runs (CI, pipes)
+                    # would otherwise hang forever on this.
+                    self._finished = True
+                    if sys.stdin.isatty():
+                        with suppress(EOFError, KeyboardInterrupt):
+                            input()
                     self._live = None
         finally:
             horus_logger.restore_terminal()
@@ -459,6 +469,10 @@ class WorkflowTUISubscriber(BaseEventSubscriber):
         ]
         if self._error is not None:
             sections.append(self._render_error())
+        if self._finished:
+            sections.append(
+                Text(_("Workflow finished, press Enter to close"), style="dim")
+            )
         return Group(*sections)
 
     def _render_header(self, workflow: BaseWorkflow) -> RenderableType:

--- a/src/horus_builtin/event/tui_subscriber.py
+++ b/src/horus_builtin/event/tui_subscriber.py
@@ -259,6 +259,7 @@ class WorkflowTUISubscriber(BaseEventSubscriber):
     _error: tuple[str, str] | None = PrivateAttr(default=None)
     _paused: bool = PrivateAttr(default=False)
     _finished: bool = PrivateAttr(default=False)
+    _finished_at: float | None = PrivateAttr(default=None)
 
     def setup(self) -> None:
         """No startup work needed."""
@@ -335,6 +336,7 @@ class WorkflowTUISubscriber(BaseEventSubscriber):
                     # interactive TTY, non-interactive runs (CI, pipes)
                     # would otherwise hang forever on this.
                     self._finished = True
+                    self._finished_at = time.monotonic()
                     if sys.stdin.isatty():
                         with suppress(EOFError, KeyboardInterrupt):
                             input()
@@ -481,7 +483,7 @@ class WorkflowTUISubscriber(BaseEventSubscriber):
         elapsed = (
             None
             if self._started_at is None
-            else time.monotonic() - self._started_at
+            else (self._finished_at or time.monotonic()) - self._started_at
         )
         line = Text.assemble(
             (workflow.name, "bold"),

--- a/src/horus_runtime/cli.py
+++ b/src/horus_runtime/cli.py
@@ -100,6 +100,14 @@ def run(
     if debug:
         horus_logger.set_level("DEBUG")
 
+    if not no_tui:
+        # Log lines should only ever land in the TUI's own log pane, never
+        # on the real terminal (the file sink still captures everything).
+        # tui.live() installs the pane sink once the dashboard starts; this
+        # silences the gap before that, and restore_terminal() (in live()'s
+        # finally) puts stdout logging back once the dashboard tears down.
+        horus_logger.redirect_terminal(lambda _message: None)
+
     ctx = HorusContext.boot()
     try:
         workflow = BaseWorkflow.from_yaml(workflow_yaml)


### PR DESCRIPTION
## Summary
- The Live dashboard tore down the instant `workflow.run()` returned, leaving only a one-line summary in scrollback with no way to see final task state or the DAG.
- Now waits for Enter on an interactive TTY before tearing down the alt screen; non-interactive runs (CI, pipes) skip the wait so they don't hang.
- Elapsed time in the header freezes at the finish timestamp instead of continuing to tick while waiting for Enter.

## Test plan
- [ ] Run a workflow with the TUI, confirm dashboard stays up after completion with new "press Enter to close" footer, and elapsed time is frozen
- [ ] Run a workflow with a failing task, confirm error panel + footer both show
- [ ] Run with stdin piped from /dev/null, confirm no hang