### PR TITLE
Declare where a task's work runs, so observers can find it

### DIFF
--- a/.claude/skills/horus-workflow/SKILL.md
+++ b/.claude/skills/horus-workflow/SKILL.md
@@ -85,12 +85,14 @@ loads the plugin registries). Only one workflow may run at a time.
 | workflow | `horus_workflow`                                            |
 | task     | `horus_task`, `function_task` (Python-only)                 |
 | runtime  | `command`, `python`, `python_string`, `python_script`       |
-| executor | `shell`, `python_exec`, `python_fn`                         |
+| executor | `shell`, `python_exec`, `python_fn`, `python_function_external` |
 | artifact | `file`, `folder`, `json`, `pickle`                          |
 | target   | `local`                                                     |
 
 Compatible pairings: `command` runtime ↔ `shell` executor; `python`/string code
-↔ `python_exec`; in-memory function ↔ `python_fn`. Mismatches raise
+↔ `python_exec`; in-memory function ↔ `python_fn`, or
+`python_function_external` to run the same function in a subprocess **on the
+task's target** (opt-in; see below). Mismatches raise
 `IncompatibleRuntimeError` at construction.
 
 ## Gotchas

--- a/.claude/skills/horus-workflow/references/python-workflows.md
+++ b/.claude/skills/horus-workflow/references/python-workflows.md
@@ -83,6 +83,29 @@ Decorator signature:
 `FunctionTask.task(wf, *, id=None, name=None, inputs=None, outputs=None, target=None)`.
 `id`/`name` default to the function name; `target` defaults to `LocalTarget()`.
 
+### Running a function on the target (`python_function_external`)
+
+`python_fn` runs the function **in the orchestrator process** and ignores
+`task.target`, so a function task with a remote target still runs locally. Set
+`executor: {kind: python_function_external}` to ship the function (cloudpickle)
+to the target and run it there as a real subprocess: it honours the target and
+is resource-measurable. Two limits, both deliberate:
+
+- a function that takes `task` is **refused** (the live task cannot cross a
+  process boundary), which also means tasks calling `workflow.add_task()` /
+  `add_edge()` on the running DAG must stay on `python_fn`;
+- the target's interpreter needs `cloudpickle` and `horus_runtime`. Set
+  `python:` on the executor to pick it, e.g. point it at an environment built
+  by a `horus-environments` executor
+  (`python: .horus_python_environment/bin/python`).
+
+### Functions in YAML
+
+`runtime.func` accepts the callable itself (Python workflows) or a dotted path
+string (`my_package.steps:normalise`, also `my_package.steps.normalise`), which
+is what a YAML workflow uses. It is imported at validation time; a bad path
+fails with a message naming the module or attribute.
+
 ### Argument injection
 
 The `python_function` runtime inspects the function signature and injects

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,8 +25,11 @@ jobs:
             - name: Sync project dependencies and activate environment
               run: uv sync --group dev
 
-            - name: Verify and compile translations
+            - name: Verify translations
               run: uv run make babel-check
+
+            - name: Compile translations
+              run: uv run make babel-compile
 
             - name: Build package
               run: uv run uv build

--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,12 @@ babel-check:
 		fi; \
 	done
 	@echo "Success: All strings are translated."
+
+# Separate from babel-check: a check must not write files. The compiled .mo
+# is git-ignored and not byte-reproducible, so folding this into babel-check
+# made every pre-commit run report "files were modified by this hook" even
+# when translations hadn't changed. Only the release build needs this.
+babel-compile:
 	uv run pybabel compile -d $(LOCALE_DIR) -D $(DOMAIN) --statistics
 
 babel-add:

--- a/Makefile
+++ b/Makefile
@@ -103,10 +103,7 @@ babel-check:
 	done
 	@echo "Success: All strings are translated."
 
-# Separate from babel-check: a check must not write files. The compiled .mo
-# is git-ignored and not byte-reproducible, so folding this into babel-check
-# made every pre-commit run report "files were modified by this hook" even
-# when translations hadn't changed. Only the release build needs this.
+# Separate from babel-check: a check must not write files.
 babel-compile:
 	uv run pybabel compile -d $(LOCALE_DIR) -D $(DOMAIN) --statistics
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ classifiers = [
 ]
 dependencies = [
   "click>=8.3.3",
+  "cloudpickle>=3.0",
   "loguru~=0.7",
   "pydantic~=2.0",
   "pydantic_settings~=2.0",
@@ -34,6 +35,7 @@ pickle = "horus_builtin.artifact.pickle"
 shell = "horus_builtin.executor.shell"
 python_exec = "horus_builtin.executor.python_exec"
 python_fn = "horus_builtin.executor.python_fn"
+python_fn_external = "horus_builtin.executor.python_fn_external"
 
 [project.entry-points."horus.interaction"]
 common = "horus_builtin.interaction.common"
@@ -109,6 +111,10 @@ python_version = "3.13"
 strict = true
 exclude = ["build", "dist"]
 plugins = ["pydantic.mypy"]
+
+[[tool.mypy.overrides]]
+module = ["cloudpickle.*"]
+ignore_missing_imports = true
 
 [tool.pydantic-mypy]
 init_typed = true

--- a/src/horus_builtin/executor/_remote_function_call.py
+++ b/src/horus_builtin/executor/_remote_function_call.py
@@ -1,0 +1,117 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Launcher shipped to the target by
+:class:`~horus_builtin.executor.python_fn_external.
+ExternalPythonFunctionExecutor`.
+
+It is copied to the task working directory and run there by the target's
+interpreter, so it is deliberately a *script*: it must import nothing from
+horus-runtime at module level (the payload may pull horus classes in while
+unpickling, but the launcher itself must start on any interpreter that has
+cloudpickle).
+
+Protocol, both halves of which are hard-coded here and in the executor:
+
+- ``argv[1]``: cloudpickled ``(func, kwargs)`` payload to read.
+- ``argv[2]``: where to write the cloudpickled outcome.
+- outcome: ``{"ok": bool, "value": ..., "traceback": str | None,
+  "exception": BaseException | None}``.
+
+The outcome file, not the exit code, is what the executor believes: an exit
+code can only say *that* something failed, and "subprocess exited 1" is a
+useless thing to hand a scientist whose function raised on line 40.
+"""
+
+import asyncio
+import inspect
+import sys
+import traceback
+from collections.abc import Awaitable
+from typing import Any
+
+import cloudpickle
+
+
+async def _resolve(awaitable: Awaitable[Any]) -> Any:
+    """Await *awaitable*, the entry point ``asyncio.run`` needs."""
+    return await awaitable
+
+
+def _write_outcome(result_path: str, outcome: dict[str, Any]) -> None:
+    """
+    Write *outcome* to *result_path*, degrading to text if it will not pickle.
+
+    A return value or an exception can be unpicklable (an open file handle
+    captured in ``__init__``, say). Losing the object is survivable; losing
+    the traceback that explains the run is not, so the fallback keeps the
+    text.
+    """
+    try:
+        data = cloudpickle.dumps(outcome)
+    except Exception:
+        data = cloudpickle.dumps(
+            {
+                "ok": False,
+                "value": None,
+                "exception": None,
+                "traceback": (
+                    f"{outcome.get('traceback') or ''}\n"
+                    f"Could not send the result back to the orchestrator:\n"
+                    f"{traceback.format_exc()}"
+                ).strip(),
+            }
+        )
+    with open(result_path, "wb") as fh:
+        fh.write(data)
+
+
+def main(payload_path: str, result_path: str) -> int:
+    """
+    Call the pickled function and report the outcome. Returns an exit code.
+    """
+    with open(payload_path, "rb") as fh:
+        func, kwargs = cloudpickle.load(fh)
+
+    outcome: dict[str, Any]
+    try:
+        value = func(**kwargs)
+        # The in-process executor awaits coroutine functions, so an async task
+        # body must keep working here.
+        if inspect.isawaitable(value):
+            value = asyncio.run(_resolve(value))
+        outcome = {
+            "ok": True,
+            "value": value,
+            "exception": None,
+            "traceback": None,
+        }
+    except Exception as exc:
+        outcome = {
+            "ok": False,
+            "value": None,
+            "exception": exc,
+            "traceback": traceback.format_exc(),
+        }
+
+    _write_outcome(result_path, outcome)
+    return 0 if outcome["ok"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1], sys.argv[2]))

--- a/src/horus_builtin/executor/python_exec.py
+++ b/src/horus_builtin/executor/python_exec.py
@@ -20,12 +20,15 @@ Defines the PythonExecExecutor class, which represents an executor that runs a
 a Python code task in-process in the Horus runtime.
 """
 
+import os
 from typing import TYPE_CHECKING, ClassVar
 
 from horus_builtin.executor._cwd_lock import chdir_locked
 from horus_builtin.runtime.python_string import PythonCodeStringRuntime
 from horus_runtime.context import HorusContext
 from horus_runtime.core.executor.base import BaseExecutor, RuntimeFilterType
+from horus_runtime.core.resources import InProcessScope, ResourceScope
+from horus_runtime.core.target.channel import ChannelProcess
 from horus_runtime.i18n import tr as _
 from horus_runtime.settings import runtime_settings
 
@@ -45,6 +48,21 @@ class PythonExecExecutor(BaseExecutor):
     )
 
     runtimes: ClassVar[RuntimeFilterType] = (PythonCodeStringRuntime,)
+
+    async def resource_scope(
+        self, task: "BaseTask", process: ChannelProcess | None = None
+    ) -> ResourceScope:
+        """
+        Declare that the work runs inside the orchestrator process.
+
+        No process is spawned — the code is run through `exec` on the
+        event loop — so there is nothing that belongs to this task alone.
+        Saying so explicitly is what lets an observer report an estimate
+        honestly instead of silently attributing the whole orchestrator to
+        this task.
+        """
+        del task, process
+        return InProcessScope(pid=os.getpid())
 
     async def _execute(self, task: "BaseTask") -> None:
         """

--- a/src/horus_builtin/executor/python_exec.py
+++ b/src/horus_builtin/executor/python_exec.py
@@ -54,12 +54,6 @@ class PythonExecExecutor(BaseExecutor):
     ) -> ResourceScope:
         """
         Declare that the work runs inside the orchestrator process.
-
-        No process is spawned — the code is run through `exec` on the
-        event loop — so there is nothing that belongs to this task alone.
-        Saying so explicitly is what lets an observer report an estimate
-        honestly instead of silently attributing the whole orchestrator to
-        this task.
         """
         del task, process
         return InProcessScope(pid=os.getpid())

--- a/src/horus_builtin/executor/python_fn.py
+++ b/src/horus_builtin/executor/python_fn.py
@@ -20,6 +20,7 @@ Python executor for in-memory workflows in horus-runtime. (Function
 executor).
 """
 
+import os
 from inspect import isawaitable
 from typing import ClassVar
 
@@ -30,6 +31,8 @@ from horus_builtin.runtime.python import (
 )
 from horus_runtime.core.artifact.base import BaseArtifact
 from horus_runtime.core.executor.base import BaseExecutor, RuntimeFilterType
+from horus_runtime.core.resources import InProcessScope, ResourceScope
+from horus_runtime.core.target.channel import ChannelProcess
 from horus_runtime.core.task.base import BaseTask
 from horus_runtime.i18n import tr as _
 from horus_runtime.logging import horus_logger
@@ -47,6 +50,21 @@ class PythonFunctionExecutor(BaseExecutor):
     )
 
     runtimes: ClassVar[RuntimeFilterType] = (PythonFunctionRuntime,)
+
+    async def resource_scope(
+        self, task: "BaseTask", process: ChannelProcess | None = None
+    ) -> ResourceScope:
+        """
+        Declare that the work runs inside the orchestrator process.
+
+        No process is spawned — the function is called directly on the
+        event loop — so there is nothing that belongs to this task alone.
+        Saying so explicitly is what lets an observer report an estimate
+        honestly instead of silently attributing the whole orchestrator to
+        this task.
+        """
+        del task, process
+        return InProcessScope(pid=os.getpid())
 
     async def _execute(self, task: "BaseTask") -> None:
         """

--- a/src/horus_builtin/executor/python_fn.py
+++ b/src/horus_builtin/executor/python_fn.py
@@ -56,12 +56,6 @@ class PythonFunctionExecutor(BaseExecutor):
     ) -> ResourceScope:
         """
         Declare that the work runs inside the orchestrator process.
-
-        No process is spawned — the function is called directly on the
-        event loop — so there is nothing that belongs to this task alone.
-        Saying so explicitly is what lets an observer report an estimate
-        honestly instead of silently attributing the whole orchestrator to
-        this task.
         """
         del task, process
         return InProcessScope(pid=os.getpid())

--- a/src/horus_builtin/executor/python_fn.py
+++ b/src/horus_builtin/executor/python_fn.py
@@ -38,6 +38,42 @@ from horus_runtime.i18n import tr as _
 from horus_runtime.logging import horus_logger
 
 
+async def parse_result_artifacts(
+    task: BaseTask, result: PythonFunctionReturnType
+) -> None:
+    """
+    Parse the result of a Python function execution to extract any declared
+    side-product artifacts.
+
+    Module-level so the out-of-process executor applies the exact same rules
+    to a result that came back over a pipe as the in-process one does to a
+    live return value.
+    """
+    if isawaitable(result):
+        result = await result
+
+    if result is None:
+        return
+    if isinstance(result, BaseArtifact):
+        task.side_artifacts = [result]
+        return
+    if isinstance(result, list) and all(
+        isinstance(r, BaseArtifact) for r in result
+    ):
+        task.side_artifacts = result
+        return
+
+    horus_logger.log.warning(
+        _(
+            "Task %(task_id)s returned an unexpected value from its "
+            "Python function runtime. Expected BaseArtifact, "
+            "list[BaseArtifact], or None; got: %(result)s. Skipping side "
+            "artifact handling."
+        )
+        % {"task_id": task.id, "result": result}
+    )
+
+
 class PythonFunctionExecutor(BaseExecutor):
     """
     Executor for running Python functions in-memory.
@@ -90,26 +126,4 @@ class PythonFunctionExecutor(BaseExecutor):
         Parse the result of a Python function execution to extract any declared
         side-product artifacts.
         """
-        if isawaitable(result):
-            result = await result
-
-        if result is None:
-            return
-        if isinstance(result, BaseArtifact):
-            task.side_artifacts = [result]
-            return
-        if isinstance(result, list) and all(
-            isinstance(r, BaseArtifact) for r in result
-        ):
-            task.side_artifacts = result
-            return
-
-        horus_logger.log.warning(
-            _(
-                "Task %(task_id)s returned an unexpected value from its "
-                "Python function runtime. Expected BaseArtifact, "
-                "list[BaseArtifact], or None; got: %(result)s. Skipping side "
-                "artifact handling."
-            )
-            % {"task_id": task.id, "result": result}
-        )
+        await parse_result_artifacts(task, result)

--- a/src/horus_builtin/executor/python_fn_external.py
+++ b/src/horus_builtin/executor/python_fn_external.py
@@ -1,0 +1,233 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Run a ``python_function`` runtime in a subprocess **on the task's target**
+instead of inside the orchestrator.
+
+Why this exists, given ``python_fn`` already runs functions:
+
+- ``PythonFunctionExecutor`` ignores ``task.target``. A function task with an
+  SSH target runs on the orchestrator, which is a correctness bug and not
+  merely a metrics gap. This executor honours the target like every other
+  executor does, by going through ``target.run_command``.
+- Because the work is a real process, it inherits the default
+  :meth:`BaseExecutor.resource_scope` (a ``ProcessTreeScope`` with a live
+  pid) and becomes measurable with no extra code here.
+
+**Limitation: live DAG mutation does not work here.** A task body may call
+``workflow.add_task()`` / ``add_edge()`` on the running workflow (see
+``core/workflow/base.py``, "Safe to call from inside a running task"). That
+depends on sharing memory with the orchestrator and cannot cross a process
+boundary, so tasks that mutate the DAG must keep using the in-process
+``python_function`` executor. The same reasoning applies to any function that
+takes the live ``task``; rather than hand it a lookalike copy whose mutations
+would silently go nowhere, this executor refuses such a function up front.
+"""
+
+import asyncio
+import shlex
+import sys
+from contextlib import aclosing
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, ClassVar
+
+import cloudpickle
+
+from horus_builtin.executor.python_fn import parse_result_artifacts
+from horus_builtin.runtime.python import PythonFunctionRuntime
+from horus_runtime.core.executor.base import BaseExecutor, RuntimeFilterType
+from horus_runtime.core.task.exceptions import TaskExecutionError
+from horus_runtime.i18n import tr as _
+from horus_runtime.logging import horus_logger
+from horus_runtime.settings import runtime_settings
+
+if TYPE_CHECKING:
+    from horus_runtime.core.task.base import BaseTask
+
+_LAUNCHER_SOURCE = Path(__file__).with_name("_remote_function_call.py")
+_LAUNCHER_NAME = ".horus_function_call.py"
+_PAYLOAD_NAME = ".horus_function_payload.pkl"
+_RESULT_NAME = ".horus_function_result.pkl"
+
+
+class ExternalPythonFunctionExecutor(BaseExecutor):
+    """
+    Execute a Python function in a subprocess on the task's target.
+    """
+
+    kind: str = "python_function_external"
+    kind_name: ClassVar[str] = "External Python Function Executor"
+    kind_description: ClassVar[str] = _(
+        "Executes a Python function in a subprocess on the task's target."
+    )
+
+    runtimes: ClassVar[RuntimeFilterType] = (PythonFunctionRuntime,)
+
+    python: str | None = None
+    """
+    Interpreter used on the target. It needs ``cloudpickle`` importable, plus
+    whatever the function itself imports, including ``horus_runtime`` if the
+    function takes or returns artifacts.
+
+    ``None`` (the default) means: the orchestrator's own interpreter when the
+    target is co-located with it, otherwise plain ``python``. The first is the
+    one interpreter that provably satisfies those requirements, since it is
+    running this code; the second is the only thing that can be assumed about
+    a machine we have never seen.
+
+    Environment management is deliberately *not* reimplemented here. The
+    ``horus-environments`` executors already build conda/uv/virtualenv
+    environments on the target and put the interpreter at a known path, so
+    composing with them is a matter of pointing this field at one, e.g.
+    ``python: .horus_python_environment/bin/python``. Relative paths resolve
+    against the task working directory, which is the command's cwd.
+    """
+
+    def _interpreter(self, task: "BaseTask") -> str:
+        """Return the interpreter command to invoke on the target."""
+        if self.python is not None:
+            return self.python
+        if task.target.is_orchestrator_local:
+            return sys.executable
+        return "python"
+
+    async def _execute(self, task: "BaseTask") -> None:
+        """
+        Ship the function to the target, run it there, bring the result back.
+        """
+        assert isinstance(task.runtime, PythonFunctionRuntime)
+        func, kwargs = await task.runtime.setup_runtime(task)
+
+        if "task" in kwargs:
+            # PythonFunctionRuntime injects the live task whenever the
+            # signature asks for it. A copy of it on the far side of a pipe
+            # would look right and do nothing (mutations, DAG edits and
+            # interactions all die with the subprocess), so fail loudly here
+            # instead of subtly there.
+            raise TaskExecutionError(
+                _(
+                    "Task %(task_id)s uses the '%(kind)s' executor but its "
+                    "function accepts a 'task' argument. The live task object "
+                    "cannot cross a process boundary; use the in-process "
+                    "'python_function' executor, or drop the 'task' parameter "
+                    "(and any **kwargs that would receive it)."
+                )
+                % {"task_id": task.id, "kind": self.kind}
+            )
+
+        await task.target.mkdir(task.working_dir)
+
+        # cloudpickle rather than pickle: closing over local state is a
+        # supported way to build a workflow programmatically, and plain pickle
+        # cannot represent a closure. It also already prefers a by-reference
+        # pickle for anything importable, so the cheap payload is the default
+        # and the expensive one only appears when it is the only option.
+        payload = f"{task.working_dir}/{_PAYLOAD_NAME}"
+        result_path = f"{task.working_dir}/{_RESULT_NAME}"
+        launcher = f"{task.working_dir}/{_LAUNCHER_NAME}"
+        await task.target.put_file(cloudpickle.dumps((func, kwargs)), payload)
+        await task.target.put_file(_LAUNCHER_SOURCE, launcher)
+
+        command = (
+            f"{self._interpreter(task)} {shlex.quote(launcher)} "
+            f"{shlex.quote(payload)} {shlex.quote(result_path)}"
+        )
+        horus_logger.log.debug(
+            _("Executing function for task %(task_id)s: %(command)s")
+            % {"task_id": task.id, "command": command}
+        )
+
+        proc = await task.target.run_command(
+            command,
+            cwd=task.working_dir,
+            env={
+                runtime_settings.SIDE_ARTIFACTS_DIR_ENV: str(
+                    task.side_artifacts_dir
+                ),
+            },
+        )
+        try:
+            async with aclosing(proc.stream()) as stream:
+                async for stream_name, line in stream:
+                    text = line.decode("utf-8", errors="replace").rstrip()
+                    if stream_name == "stdout":
+                        horus_logger.log.info(text)
+                    else:
+                        horus_logger.log.warning(text)
+        except asyncio.CancelledError:
+            proc.kill()
+            await proc.wait()
+            raise
+        await proc.wait()
+
+        outcome = await self._read_outcome(task, result_path, proc.returncode)
+        await parse_result_artifacts(task, outcome["value"])
+
+    async def _read_outcome(
+        self, task: "BaseTask", result_path: str, returncode: int | None
+    ) -> dict[str, Any]:
+        """
+        Read the launcher's outcome file and re-raise a remote failure here.
+
+        The exit code is only a fallback: what the caller needs is the
+        exception the function raised, with its own traceback. When it made it
+        back it is re-raised as itself, so ``except MyError`` around a workflow
+        run still catches what it always caught, with the target-side frames
+        attached as a note.
+        """
+        try:
+            raw = await task.target.get_file(result_path)
+            outcome: dict[str, Any] = cloudpickle.loads(raw)
+        except Exception as exc:
+            # No outcome file at all: the interpreter never got far enough to
+            # write one (missing python, missing cloudpickle, killed job). The
+            # streamed stderr above is the real diagnosis; point at it.
+            raise TaskExecutionError(
+                _(
+                    "Function subprocess for task %(task_id)s produced no "
+                    "result (exit code %(code)s); see the task log for the "
+                    "interpreter's own output. Cause: %(err)s"
+                )
+                % {
+                    "task_id": task.id,
+                    "code": returncode,
+                    "err": exc,
+                }
+            ) from exc
+
+        if outcome["ok"]:
+            return outcome
+
+        remote_traceback = outcome["traceback"] or ""
+        exception = outcome["exception"]
+        if isinstance(exception, BaseException):
+            exception.add_note(
+                _("Raised on target %(target)s:\n%(traceback)s")
+                % {
+                    "target": task.target.location_id,
+                    "traceback": remote_traceback,
+                }
+            )
+            raise exception
+        raise TaskExecutionError(
+            _("Function failed on target %(target)s:\n%(traceback)s")
+            % {
+                "target": task.target.location_id,
+                "traceback": remote_traceback,
+            }
+        )

--- a/src/horus_builtin/runtime/python.py
+++ b/src/horus_builtin/runtime/python.py
@@ -20,10 +20,11 @@ Python runtime implementation for in-memory workflows.
 """
 
 from collections.abc import Awaitable, Callable
+from importlib import import_module
 from inspect import Parameter, signature
-from typing import Any, ClassVar
+from typing import Annotated, Any, ClassVar, cast
 
-from pydantic import ConfigDict, Field
+from pydantic import BeforeValidator, ConfigDict, PlainSerializer
 
 from horus_runtime.core.artifact.base import BaseArtifact
 from horus_runtime.core.runtime.base import BaseRuntime
@@ -41,6 +42,112 @@ PythonFunctionSetupTuple = tuple[
 ]
 
 
+def import_callable(reference: str) -> Callable[..., Any]:
+    """
+    Import the callable named by a dotted *reference*.
+
+    Accepts ``package.module:function`` (preferred, unambiguous) and
+    ``package.module.function``; for the latter the last dotted component is
+    taken as the attribute, and attribute chains
+    (``module:Class.method``) work on either side.
+
+    Security note: importing by name runs the target module's top-level code,
+    so a workflow file can execute arbitrary Python. That is not a new
+    privilege (the same file can already declare a ``command`` runtime or a
+    ``python_string`` one, both of which run whatever they are given), so a
+    workflow document is trusted input either way and an import allowlist here
+    would only give the illusion of a boundary. The guardrail that does pay
+    for itself is a legible error: a typo must say which module or attribute
+    was missing instead of surfacing a bare ``ImportError`` from pydantic.
+
+    Raises:
+        ValueError: If *reference* is malformed, the module cannot be
+            imported, the attribute does not exist, or it is not callable.
+    """
+    module_name, separator, attribute = reference.partition(":")
+    if not separator:
+        module_name, _sep, attribute = reference.rpartition(".")
+    if not module_name or not attribute:
+        raise ValueError(
+            _(
+                "Invalid function reference %(ref)r: expected "
+                "'package.module:function' or 'package.module.function'."
+            )
+            % {"ref": reference}
+        )
+
+    try:
+        obj: Any = import_module(module_name)
+    except ImportError as exc:
+        raise ValueError(
+            _(
+                "Could not import module %(module)r for function reference "
+                "%(ref)r: %(err)s"
+            )
+            % {"module": module_name, "ref": reference, "err": exc}
+        ) from exc
+
+    for part in attribute.split("."):
+        try:
+            obj = getattr(obj, part)
+        except AttributeError as exc:
+            raise ValueError(
+                _(
+                    "Module %(module)r has no attribute %(attr)r "
+                    "(from function reference %(ref)r)."
+                )
+                % {
+                    "module": module_name,
+                    "attr": attribute,
+                    "ref": reference,
+                }
+            ) from exc
+
+    if not callable(obj):
+        raise ValueError(
+            _("Function reference %(ref)r resolved to a non-callable object.")
+            % {"ref": reference}
+        )
+    return cast(Callable[..., Any], obj)
+
+
+def _resolve_func(value: Any) -> Any:
+    """
+    Turn a dotted-path string into the callable it names, pass anything else
+    through untouched so handing over a real function keeps working.
+    """
+    return import_callable(value) if isinstance(value, str) else value
+
+
+def _serialize_func(func: Callable[..., Any]) -> str:
+    """
+    Dump a callable as the dotted path that imports it back.
+
+    A callable with no importable name (a lambda, a closure, a
+    ``functools.partial``) has no honest answer here; ``repr`` is emitted so
+    the dump *fails loudly on load* instead of silently omitting the field and
+    failing with "func is required", which said nothing about the cause.
+    """
+    module = getattr(func, "__module__", None)
+    qualname = getattr(func, "__qualname__", None)
+    if module and qualname:
+        return f"{module}:{qualname}"
+    return repr(func)
+
+
+FunctionReference = Annotated[
+    Callable[..., PythonFunctionReturnType],
+    BeforeValidator(_resolve_func),
+    PlainSerializer(_serialize_func, return_type=str),
+]
+"""
+A callable, or the dotted path of one. Without the string form a function
+task cannot be written in YAML at all (a pydantic ``Callable`` field rejects
+strings), which kept them out of every tool that goes through the document:
+packaging, sanitising, import.
+"""
+
+
 class PythonFunctionRuntime(BaseRuntime[PythonFunctionSetupTuple]):
     """
     Executes a python function.
@@ -55,7 +162,11 @@ class PythonFunctionRuntime(BaseRuntime[PythonFunctionSetupTuple]):
     # Allow callable types in the runtime configuration
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    func: Callable[..., PythonFunctionReturnType] = Field(..., exclude=True)
+    func: FunctionReference
+    """
+    The function to run: either the callable itself (Python workflows) or a
+    ``package.module:function`` string (YAML workflows).
+    """
 
     async def _setup_runtime(
         self, task: "BaseTask"

--- a/src/horus_builtin/target/local.py
+++ b/src/horus_builtin/target/local.py
@@ -64,10 +64,6 @@ class LocalChannelProcess(ChannelProcess):
     def pid(self) -> int | None:
         """
         Pid of the spawned process, which is also its process-group id.
-
-        The subprocess is created with ``start_new_session=True``, so every
-        descendant it spawns inherits this pgid — making the whole tree
-        addressable from this one number.
         """
         return self._proc.pid
 
@@ -237,6 +233,10 @@ class LocalTarget(BaseTarget):
             txt = ec.read_text().strip()
             if txt:
                 return int(txt)
+        if handle.pid is None:
+            # No pid to probe for liveness, so the exit-code file is the only
+            # evidence there is; absent it, assume still running.
+            return None
         try:
             os.kill(handle.pid, 0)
         except ProcessLookupError:
@@ -261,6 +261,8 @@ class LocalTarget(BaseTarget):
         die with it (the launcher used ``start_new_session``, so the job's
         PGID is queryable via ``os.getpgid``).
         """
+        if handle.pid is None:
+            return
         try:
             if os.name == "posix":
                 os.killpg(os.getpgid(handle.pid), sig)

--- a/src/horus_builtin/target/local.py
+++ b/src/horus_builtin/target/local.py
@@ -60,6 +60,17 @@ class LocalChannelProcess(ChannelProcess):
         """Exit code, or ``None`` if the process has not yet terminated."""
         return self._proc.returncode
 
+    @property
+    def pid(self) -> int | None:
+        """
+        Pid of the spawned process, which is also its process-group id.
+
+        The subprocess is created with ``start_new_session=True``, so every
+        descendant it spawns inherits this pgid — making the whole tree
+        addressable from this one number.
+        """
+        return self._proc.pid
+
     async def wait(self) -> int:
         """Wait for the process to finish and return its exit code."""
         return await self._proc.wait()

--- a/src/horus_builtin/task/function.py
+++ b/src/horus_builtin/task/function.py
@@ -30,6 +30,7 @@ from horus_builtin.runtime.python import PythonFunctionRuntime
 from horus_builtin.target.local import LocalTarget
 from horus_builtin.task.horus_task import HorusTask
 from horus_runtime.core.artifact.base import BaseArtifact
+from horus_runtime.core.executor.base import BaseExecutor
 from horus_runtime.core.interaction.transport import BaseInteractionTransport
 from horus_runtime.core.target.base import BaseTarget
 from horus_runtime.core.workflow.base import BaseWorkflow
@@ -50,7 +51,14 @@ class FunctionTask(HorusTask):
     """
 
     runtime: PythonFunctionRuntime
-    executor: PythonFunctionExecutor = PythonFunctionExecutor()
+    executor: BaseExecutor = PythonFunctionExecutor()
+    """
+    In-process by default, unchanged. Typed as ``BaseExecutor`` (rather than
+    the concrete in-process one) so a function task can opt into another
+    executor that accepts this runtime. ``python_function_external`` runs the
+    same function on the target instead. Compatibility is still enforced by
+    ``BaseTask`` against ``executor.runtimes``.
+    """
 
     # Default to CLI transport for interactions in FunctionTasks.
     interaction: BaseInteractionTransport = CLIInteractionTransport()

--- a/src/horus_runtime/core/executor/base.py
+++ b/src/horus_runtime/core/executor/base.py
@@ -30,7 +30,9 @@ from typing import TYPE_CHECKING, ClassVar, final
 
 from horus_builtin.artifact.file import FileArtifact
 from horus_builtin.artifact.folder import FolderArtifact
+from horus_runtime.core.resources import ProcessTreeScope, ResourceScope
 from horus_runtime.core.runtime.base import BaseRuntime
+from horus_runtime.core.target.channel import ChannelProcess
 from horus_runtime.i18n import tr as _
 from horus_runtime.logging import horus_logger
 from horus_runtime.middleware.executor import (
@@ -91,6 +93,43 @@ class BaseExecutor(AutoRegistry, entry_point="executor"):
     Which runtime types this executor can handle. By default, an executor can
     handle any runtime type.
     """
+
+    async def resource_scope(
+        self, task: "BaseTask", process: ChannelProcess | None = None
+    ) -> ResourceScope:
+        """
+        Declare where this executor's work actually runs.
+
+        Answers "if you wanted to watch this task, what would you watch?" — so
+        an observer (the resource-monitor plugin, a profiler) can find the work
+        without knowing anything about this executor.
+
+        The default is the truth for every executor that runs its work as a
+        command on the target: a process tree rooted at the spawned process.
+        Because it is a *default* and not a lookup table, an executor written
+        after the observer is measured correctly with no changes anywhere —
+        which is the entire reason this hook exists rather than the observer
+        branching on ``executor.kind``.
+
+        Override only when the work genuinely escapes the spawned tree:
+        a container executor (the real workload is reparented under the
+        container daemon) or an executor that runs work inside this very
+        process (nothing is spawned at all).
+
+        Args:
+            task: The task being executed.
+            process: The handle for the spawned command, when the caller has
+                one. ``None`` before the process exists, or for executors that
+                never spawn one.
+
+        Returns:
+            A :class:`~horus_runtime.core.resources.ResourceScope` describing
+            where to look.
+        """
+        del task
+        return ProcessTreeScope(
+            pid=process.pid if process is not None else None
+        )
 
     def anchor_local_paths(self, base: Path) -> None:
         """

--- a/src/horus_runtime/core/executor/base.py
+++ b/src/horus_runtime/core/executor/base.py
@@ -100,38 +100,8 @@ class BaseExecutor(AutoRegistry, entry_point="executor"):
         """
         Declare where this executor's work actually runs.
 
-        Answers "if you wanted to watch this task, what would you watch?" — so
-        an observer (the resource-monitor plugin, a profiler) can find the work
-        without knowing anything about this executor.
-
-        The default is the truth for every executor that runs its work as a
-        command on the target: a process tree rooted at the spawned process.
-        Because it is a *default* and not a lookup table, an executor written
-        after the observer is measured correctly with no changes anywhere —
-        which is the entire reason this hook exists rather than the observer
-        branching on ``executor.kind``.
-
-        Override only when the work genuinely escapes the spawned tree:
-        a container executor (the real workload is reparented under the
-        container daemon) or an executor that runs work inside this very
-        process (nothing is spawned at all).
-
-        The target is asked first, because it can change the shape of the
-        execution in a way this executor cannot see: a scheduler target turns
-        the command into a queued job, so the handle the orchestrator holds
-        does not refer to the work. An executor that overrides this method
-        never reaches here, which is the right precedence — an executor that
-        reparents its work knows more than the target beneath it.
-
-        Args:
-            task: The task being executed.
-            process: The handle for the spawned command, when the caller has
-                one. ``None`` before the process exists, or for executors that
-                never spawn one.
-
-        Returns:
-            A :class:`~horus_runtime.core.resources.ResourceScope` describing
-            where to look.
+        The target is asked first, then the process-tree default. Override
+        only when the work genuinely escapes the spawned tree.
         """
         scope = await task.target.resource_scope(task, process)
         if scope is not None:

--- a/src/horus_runtime/core/executor/base.py
+++ b/src/horus_runtime/core/executor/base.py
@@ -116,6 +116,13 @@ class BaseExecutor(AutoRegistry, entry_point="executor"):
         container daemon) or an executor that runs work inside this very
         process (nothing is spawned at all).
 
+        The target is asked first, because it can change the shape of the
+        execution in a way this executor cannot see: a scheduler target turns
+        the command into a queued job, so the handle the orchestrator holds
+        does not refer to the work. An executor that overrides this method
+        never reaches here, which is the right precedence — an executor that
+        reparents its work knows more than the target beneath it.
+
         Args:
             task: The task being executed.
             process: The handle for the spawned command, when the caller has
@@ -126,7 +133,9 @@ class BaseExecutor(AutoRegistry, entry_point="executor"):
             A :class:`~horus_runtime.core.resources.ResourceScope` describing
             where to look.
         """
-        del task
+        scope = await task.target.resource_scope(task, process)
+        if scope is not None:
+            return scope
         return ProcessTreeScope(
             pid=process.pid if process is not None else None
         )

--- a/src/horus_runtime/core/resources.py
+++ b/src/horus_runtime/core/resources.py
@@ -20,15 +20,11 @@ Portable, target-agnostic compute resources for tasks.
 
 Two halves that mirror each other:
 
-- :class:`ResourceRequest` — what a task *asks for*. Advisory: resource-aware
+- :class:`ResourceRequest`: what a task *asks for*. Advisory: resource-aware
   targets (Slurm, Terraform, etc.) translate the hints into their own
   provisioning primitives, and targets that ignore them are unaffected.
-- :class:`ResourceScope` — where a task's work *actually runs*, so an observer
+- :class:`ResourceScope`: where a task's work *actually runs*, so an observer
   can find it and measure what it really used.
-
-The runtime defines the scope vocabulary but deliberately does not measure
-anything itself: measurement is an optional plugin concern, while *being
-findable* is a property of the execution model and therefore belongs here.
 """
 
 from dataclasses import dataclass, field
@@ -70,23 +66,12 @@ class ResourceRequest(BaseModel):
 class ResourceScope:
     """
     Where a task's work actually runs, so an observer can find and measure it.
-
-    An executor answers this once per task (see
-    :meth:`~horus_runtime.core.executor.base.BaseExecutor.resource_scope`) and
-    an observer — the resource-monitor plugin, a profiler, anything — decides
-    what to do with the answer. The runtime itself never measures.
-
-    Subclasses name a *kind of place*, not a kind of executor. That is the
-    whole point: an observer that understands "a process tree" measures every
-    executor that runs one, including executors written after the observer.
     """
 
-    #: Where the work runs, for observers to dispatch on. Kept as a plain
-    #: string rather than an enum so a plugin can introduce a scope the
-    #: runtime has never heard of without a release here.
+    #: Where the work runs, for observers to dispatch on.
     kind: str
 
-    #: Scope-specific detail. Free-form for the same reason.
+    #: Scope-specific detail.
     detail: dict[str, Any] = field(default_factory=dict)
 
 
@@ -94,16 +79,6 @@ class ResourceScope:
 class ProcessTreeScope(ResourceScope):
     """
     The work is a process and its descendants, on the target's host.
-
-    The overwhelmingly common answer, and the default. ``pid`` is the root of
-    the tree; because the runtime spawns commands in a new session
-    (``start_new_session=True`` locally, ``setsid`` when detached), it doubles
-    as the process-group id, so the whole tree is reachable from it.
-
-    ``pid`` may be ``None`` when the channel could not report one (see
-    :attr:`~horus_runtime.core.target.channel.ChannelProcess.pid`). An
-    observer that needs a pid should then fall back to a host-side method
-    rather than treating it as an error.
     """
 
     kind: str = "process_tree"
@@ -114,11 +89,6 @@ class ProcessTreeScope(ResourceScope):
 class InProcessScope(ResourceScope):
     """
     The work runs inside the orchestrator process itself.
-
-    No separate process exists, so nothing can be attributed to this task
-    alone: an observer can only report the orchestrator's own usage, which is
-    shared with every other task in flight. Returning this is how an executor
-    declares that any measurement of it is an estimate.
     """
 
     kind: str = "in_process"

--- a/src/horus_runtime/core/resources.py
+++ b/src/horus_runtime/core/resources.py
@@ -16,13 +16,23 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 """
-Portable, target-agnostic compute resource requests for tasks.
+Portable, target-agnostic compute resources for tasks.
 
-The model defined here is advisory: a task may declare the resources it would
-like, and resource-aware targets (Slurm, Terraform, etc.) translate those hints
-into their own provisioning primitives. Targets that ignore resources are
-unaffected, which keeps the field fully backwards compatible.
+Two halves that mirror each other:
+
+- :class:`ResourceRequest` — what a task *asks for*. Advisory: resource-aware
+  targets (Slurm, Terraform, etc.) translate the hints into their own
+  provisioning primitives, and targets that ignore them are unaffected.
+- :class:`ResourceScope` — where a task's work *actually runs*, so an observer
+  can find it and measure what it really used.
+
+The runtime defines the scope vocabulary but deliberately does not measure
+anything itself: measurement is an optional plugin concern, while *being
+findable* is a property of the execution model and therefore belongs here.
 """
+
+from dataclasses import dataclass, field
+from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -54,3 +64,81 @@ class ResourceRequest(BaseModel):
     memory_gb: int | None = Field(default=None, ge=1)
     vram_gb: int | None = Field(default=None, ge=1)
     walltime: str | None = None
+
+
+@dataclass(frozen=True)
+class ResourceScope:
+    """
+    Where a task's work actually runs, so an observer can find and measure it.
+
+    An executor answers this once per task (see
+    :meth:`~horus_runtime.core.executor.base.BaseExecutor.resource_scope`) and
+    an observer — the resource-monitor plugin, a profiler, anything — decides
+    what to do with the answer. The runtime itself never measures.
+
+    Subclasses name a *kind of place*, not a kind of executor. That is the
+    whole point: an observer that understands "a process tree" measures every
+    executor that runs one, including executors written after the observer.
+    """
+
+    #: Where the work runs, for observers to dispatch on. Kept as a plain
+    #: string rather than an enum so a plugin can introduce a scope the
+    #: runtime has never heard of without a release here.
+    kind: str
+
+    #: Scope-specific detail. Free-form for the same reason.
+    detail: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ProcessTreeScope(ResourceScope):
+    """
+    The work is a process and its descendants, on the target's host.
+
+    The overwhelmingly common answer, and the default. ``pid`` is the root of
+    the tree; because the runtime spawns commands in a new session
+    (``start_new_session=True`` locally, ``setsid`` when detached), it doubles
+    as the process-group id, so the whole tree is reachable from it.
+
+    ``pid`` may be ``None`` when the channel could not report one (see
+    :attr:`~horus_runtime.core.target.channel.ChannelProcess.pid`). An
+    observer that needs a pid should then fall back to a host-side method
+    rather than treating it as an error.
+    """
+
+    kind: str = "process_tree"
+    pid: int | None = None
+
+
+@dataclass(frozen=True)
+class ContainerScope(ResourceScope):
+    """
+    The work runs inside a container, not in the spawned process tree.
+
+    A container runtime's CLI is a thin client: the real workload is reparented
+    under the container daemon's supervisor in a different process group, so
+    walking the spawned tree measures the client and nothing else. Executors
+    that launch containers must say so by returning this, and identify the
+    container so an observer can ask the daemon instead.
+    """
+
+    kind: str = "container"
+    container_id: str | None = None
+    #: Set when the id is not known yet but the runtime writes it to this path
+    #: on the target once the container starts (e.g. ``docker --cidfile``).
+    cidfile: str | None = None
+
+
+@dataclass(frozen=True)
+class InProcessScope(ResourceScope):
+    """
+    The work runs inside the orchestrator process itself.
+
+    No separate process exists, so nothing can be attributed to this task
+    alone: an observer can only report the orchestrator's own usage, which is
+    shared with every other task in flight. Returning this is how an executor
+    declares that any measurement of it is an estimate.
+    """
+
+    kind: str = "in_process"
+    pid: int | None = None

--- a/src/horus_runtime/core/resources.py
+++ b/src/horus_runtime/core/resources.py
@@ -111,25 +111,6 @@ class ProcessTreeScope(ResourceScope):
 
 
 @dataclass(frozen=True)
-class ContainerScope(ResourceScope):
-    """
-    The work runs inside a container, not in the spawned process tree.
-
-    A container runtime's CLI is a thin client: the real workload is reparented
-    under the container daemon's supervisor in a different process group, so
-    walking the spawned tree measures the client and nothing else. Executors
-    that launch containers must say so by returning this, and identify the
-    container so an observer can ask the daemon instead.
-    """
-
-    kind: str = "container"
-    container_id: str | None = None
-    #: Set when the id is not known yet but the runtime writes it to this path
-    #: on the target once the container starts (e.g. ``docker --cidfile``).
-    cidfile: str | None = None
-
-
-@dataclass(frozen=True)
 class InProcessScope(ResourceScope):
     """
     The work runs inside the orchestrator process itself.

--- a/src/horus_runtime/core/target/base.py
+++ b/src/horus_runtime/core/target/base.py
@@ -29,6 +29,7 @@ from typing import TYPE_CHECKING, ClassVar, final
 
 from pydantic import PrivateAttr
 
+from horus_runtime.core.resources import ResourceScope
 from horus_runtime.core.target.channel import (
     ChannelProcess,
     JobHandle,
@@ -63,8 +64,7 @@ def orchestrator_location_id() -> str:
 
     Deliberately built with the same ``local://{hostname}`` shape that
     ``LocalTarget`` reports, so the two compare equal without either side
-    knowing about the other. Cached because the hostname cannot change within
-    a process and this is consulted per task.
+    knowing about the other.
     """
     return f"local://{socket.gethostname()}"
 
@@ -161,6 +161,34 @@ class BaseTarget(AutoRegistry, entry_point="target"):
         without anyone updating an ``isinstance`` chain.
         """
         return self.location_id == orchestrator_location_id()
+
+    async def resource_scope(
+        self, task: "BaseTask", process: ChannelProcess | None = None
+    ) -> ResourceScope | None:
+        """
+        Where work dispatched through this target actually runs.
+
+        ``None`` — the default — means "nothing to add", and the executor's
+        own answer stands. Override when the target itself changes the shape
+        of the execution, which is not something the executor above it can
+        know: a scheduler target turns a command into a queued job owned by
+        the scheduler, so the process the orchestrator can see is not the work.
+
+        The executor still wins when it overrides
+        :meth:`~horus_runtime.core.executor.base.BaseExecutor.resource_scope`
+        outright, because an executor that reparents its work (a container, or
+        running in this very process) knows more than the target beneath it.
+
+        Args:
+            task: The task about to run.
+            process: The handle for the spawned command, when one exists yet.
+
+        Returns:
+            A :class:`~horus_runtime.core.resources.ResourceScope`, or ``None``
+            to defer to the executor.
+        """
+        del task, process
+        return None
 
     @property
     def task_or_raise(self) -> "BaseTask":

--- a/src/horus_runtime/core/target/base.py
+++ b/src/horus_runtime/core/target/base.py
@@ -20,7 +20,9 @@ The Horus target indicates where a task should be dispatched and executed.
 """
 
 import asyncio
+import functools
 import shlex
+import socket
 from abc import abstractmethod
 from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar, final
@@ -52,6 +54,19 @@ from horus_runtime.registry.auto_registry import AutoRegistry
 if TYPE_CHECKING:
     from horus_runtime.core.artifact.base import BaseArtifact
     from horus_runtime.core.task.base import BaseTask
+
+
+@functools.cache
+def orchestrator_location_id() -> str:
+    """
+    :attr:`BaseTarget.location_id` of the machine running the orchestrator.
+
+    Deliberately built with the same ``local://{hostname}`` shape that
+    ``LocalTarget`` reports, so the two compare equal without either side
+    knowing about the other. Cached because the hostname cannot change within
+    a process and this is consulted per task.
+    """
+    return f"local://{socket.gethostname()}"
 
 
 class BaseTarget(AutoRegistry, entry_point="target"):
@@ -121,6 +136,31 @@ class BaseTarget(AutoRegistry, entry_point="target"):
             ``ssh://user@gpu-box``
             ``horus-agent://agent-42``
         """
+
+    def is_colocated_with(self, other: "BaseTarget") -> bool:
+        """
+        True when *other* runs in the same place as this target.
+
+        Same place means same :attr:`location_id`, which by that property's
+        contract means a shared filesystem and a shared process namespace.
+        Callers were already comparing ``location_id`` strings by hand to
+        decide whether a transfer is a no-op; this names the comparison so the
+        rule lives in one place.
+        """
+        return self.location_id == other.location_id
+
+    @property
+    def is_orchestrator_local(self) -> bool:
+        """
+        True when this target runs on the machine hosting the orchestrator.
+
+        The distinction an observer needs: work here can be inspected with
+        ordinary process APIs, while work anywhere else can only be reached
+        through the channel. Derived from :attr:`location_id` rather than from
+        the target's type, so a new local-ish target gets the right answer
+        without anyone updating an ``isinstance`` chain.
+        """
+        return self.location_id == orchestrator_location_id()
 
     @property
     def task_or_raise(self) -> "BaseTask":

--- a/src/horus_runtime/core/target/base.py
+++ b/src/horus_runtime/core/target/base.py
@@ -154,11 +154,8 @@ class BaseTarget(AutoRegistry, entry_point="target"):
         """
         True when this target runs on the machine hosting the orchestrator.
 
-        The distinction an observer needs: work here can be inspected with
-        ordinary process APIs, while work anywhere else can only be reached
-        through the channel. Derived from :attr:`location_id` rather than from
-        the target's type, so a new local-ish target gets the right answer
-        without anyone updating an ``isinstance`` chain.
+        Derived from :attr:`location_id`, not the target's type, so a new
+        local-ish target needs no ``isinstance`` chain updated.
         """
         return self.location_id == orchestrator_location_id()
 
@@ -166,26 +163,9 @@ class BaseTarget(AutoRegistry, entry_point="target"):
         self, task: "BaseTask", process: ChannelProcess | None = None
     ) -> ResourceScope | None:
         """
-        Where work dispatched through this target actually runs.
-
-        ``None`` — the default — means "nothing to add", and the executor's
-        own answer stands. Override when the target itself changes the shape
-        of the execution, which is not something the executor above it can
-        know: a scheduler target turns a command into a queued job owned by
-        the scheduler, so the process the orchestrator can see is not the work.
-
-        The executor still wins when it overrides
-        :meth:`~horus_runtime.core.executor.base.BaseExecutor.resource_scope`
-        outright, because an executor that reparents its work (a container, or
-        running in this very process) knows more than the target beneath it.
-
-        Args:
-            task: The task about to run.
-            process: The handle for the spawned command, when one exists yet.
-
-        Returns:
-            A :class:`~horus_runtime.core.resources.ResourceScope`, or ``None``
-            to defer to the executor.
+        Where work dispatched through this target runs, or ``None`` to defer
+        to the executor. Override when the target reshapes the execution, as
+        a scheduler does by turning a command into a queued job.
         """
         del task, process
         return None

--- a/src/horus_runtime/core/target/channel.py
+++ b/src/horus_runtime/core/target/channel.py
@@ -69,6 +69,27 @@ class ChannelProcess(ABC):
         Exit code of the process, or ``None`` if it has not yet terminated.
         """
 
+    @property
+    def pid(self) -> int | None:
+        """
+        Process id on the host where the command runs, when it is knowable.
+
+        Identifies *which* process this handle refers to, so an observer can
+        find it among the many a run has in flight at once — resource
+        sampling being the motivating case. It is deliberately a plain
+        integer and not a handle: the observer is expected to already know
+        which host to interpret it on (the target that produced this
+        process).
+
+        ``None`` means the channel cannot say. That is a legitimate answer,
+        not a failure — a remote channel that streams over an already-open
+        connection never learns a pid — so callers must treat it as
+        "unknown" and fall back rather than raising.
+
+        Defaults to ``None`` so existing channels stay valid.
+        """
+        return None
+
     @abstractmethod
     async def wait(self) -> int:
         """
@@ -223,6 +244,17 @@ class PollingChannelProcess(ChannelProcess):
     def returncode(self) -> int | None:
         """Cached exit code; set once :meth:`wait` sees completion."""
         return self._returncode
+
+    @property
+    def pid(self) -> int | None:
+        """
+        Pid of the detached job on the target host.
+
+        ``build_detach_command`` runs the job under ``setsid``/``nohup`` and
+        writes ``$!`` to the marker dir, so this is both the job's pid and its
+        process-group id — which is what makes the whole tree findable.
+        """
+        return self._handle.pid
 
     async def wait(self) -> int:
         """Poll until the job finishes; return its exit code."""

--- a/src/horus_runtime/core/target/channel.py
+++ b/src/horus_runtime/core/target/channel.py
@@ -192,7 +192,12 @@ class JobHandle:
     Opaque reference to a detached job launched by a target.
     """
 
-    pid: int
+    #: Pid of the job on the target host, when the target actually knows one.
+    #: ``None`` when the target's unit of work is not an OS process it can
+    #: name — a scheduler job, say, whose identifier means something only to
+    #: the scheduler. Such a target puts its own identifier in :attr:`extra`
+    #: rather than here, so nothing downstream mistakes it for a pid.
+    pid: int | None
     job_dir: str
     extra: dict[str, str] | None = None
 

--- a/src/horus_runtime/core/target/channel.py
+++ b/src/horus_runtime/core/target/channel.py
@@ -73,20 +73,6 @@ class ChannelProcess(ABC):
     def pid(self) -> int | None:
         """
         Process id on the host where the command runs, when it is knowable.
-
-        Identifies *which* process this handle refers to, so an observer can
-        find it among the many a run has in flight at once — resource
-        sampling being the motivating case. It is deliberately a plain
-        integer and not a handle: the observer is expected to already know
-        which host to interpret it on (the target that produced this
-        process).
-
-        ``None`` means the channel cannot say. That is a legitimate answer,
-        not a failure — a remote channel that streams over an already-open
-        connection never learns a pid — so callers must treat it as
-        "unknown" and fall back rather than raising.
-
-        Defaults to ``None`` so existing channels stay valid.
         """
         return None
 
@@ -192,11 +178,8 @@ class JobHandle:
     Opaque reference to a detached job launched by a target.
     """
 
-    #: Pid of the job on the target host, when the target actually knows one.
     #: ``None`` when the target's unit of work is not an OS process it can
-    #: name — a scheduler job, say, whose identifier means something only to
-    #: the scheduler. Such a target puts its own identifier in :attr:`extra`
-    #: rather than here, so nothing downstream mistakes it for a pid.
+    #: name: for example a SLURM job, whose id goes in :attr:`extra`.
     pid: int | None
     job_dir: str
     extra: dict[str, str] | None = None
@@ -254,10 +237,6 @@ class PollingChannelProcess(ChannelProcess):
     def pid(self) -> int | None:
         """
         Pid of the detached job on the target host.
-
-        ``build_detach_command`` runs the job under ``setsid``/``nohup`` and
-        writes ``$!`` to the marker dir, so this is both the job's pid and its
-        process-group id — which is what makes the whole tree findable.
         """
         return self._handle.pid
 

--- a/src/horus_runtime/core/workflow/base.py
+++ b/src/horus_runtime/core/workflow/base.py
@@ -1178,32 +1178,9 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
         """
         declared = artifact.declared_path
         if declared is None or declared.is_absolute():
-            print(  # noqa: T201
-                "DEBUG _anchor_artifact SKIP",
-                artifact.id,
-                "declared=",
-                declared,
-            )
             return
         root = run_root if declared in produced else base
-        print(  # noqa: T201
-            "DEBUG _anchor_artifact",
-            artifact.id,
-            "declared=",
-            declared,
-            "base=",
-            base,
-            "run_root=",
-            run_root,
-            "produced=",
-            produced,
-            "in_produced=",
-            declared in produced,
-            "root=",
-            root,
-        )
         artifact.path = (root / declared).resolve()
-        print("DEBUG _anchor_artifact RESULT", artifact.id, artifact.path)  # noqa: T201
 
     def _anchor_task(self, task: BaseTask) -> None:
         """

--- a/src/horus_runtime/core/workflow/base.py
+++ b/src/horus_runtime/core/workflow/base.py
@@ -1233,7 +1233,7 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
         this more than once for the same task is safe.
         """
         base = self._effective_base
-        run_root = Path(task.working_dir)
+        run_root = self.run_directory
         produced = self._produced_declared_paths()
 
         for artifact in (*task.inputs, *task.outputs):

--- a/src/horus_runtime/core/workflow/base.py
+++ b/src/horus_runtime/core/workflow/base.py
@@ -1178,9 +1178,32 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
         """
         declared = artifact.declared_path
         if declared is None or declared.is_absolute():
+            print(  # noqa: T201
+                "DEBUG _anchor_artifact SKIP",
+                artifact.id,
+                "declared=",
+                declared,
+            )
             return
         root = run_root if declared in produced else base
+        print(  # noqa: T201
+            "DEBUG _anchor_artifact",
+            artifact.id,
+            "declared=",
+            declared,
+            "base=",
+            base,
+            "run_root=",
+            run_root,
+            "produced=",
+            produced,
+            "in_produced=",
+            declared in produced,
+            "root=",
+            root,
+        )
         artifact.path = (root / declared).resolve()
+        print("DEBUG _anchor_artifact RESULT", artifact.id, artifact.path)  # noqa: T201
 
     def _anchor_task(self, task: BaseTask) -> None:
         """

--- a/tests/unit/core/test_resource_scope.py
+++ b/tests/unit/core/test_resource_scope.py
@@ -35,7 +35,6 @@ from horus_builtin.target.local import LocalTarget
 from horus_builtin.task.horus_task import HorusTask
 from horus_runtime.core.executor.base import BaseExecutor
 from horus_runtime.core.resources import (
-    ContainerScope,
     InProcessScope,
     ProcessTreeScope,
 )
@@ -140,10 +139,9 @@ class TestScopeVocabulary:
         """An observer dispatches on `kind`, so they must not collide."""
         kinds = {
             ProcessTreeScope().kind,
-            ContainerScope().kind,
             InProcessScope().kind,
         }
-        assert len(kinds) == 3
+        assert len(kinds) == 2
 
     def test_scopes_are_frozen_values(self) -> None:
         """
@@ -152,15 +150,6 @@ class TestScopeVocabulary:
         scope = ProcessTreeScope(pid=1)
         with pytest.raises(dataclasses.FrozenInstanceError):
             scope.pid = 2  # type: ignore[misc]
-
-    def test_container_scope_carries_a_cidfile(self) -> None:
-        """
-        A container id is often only knowable after the container starts, so
-        the scope can name where the runtime will write it instead.
-        """
-        scope = ContainerScope(cidfile="/w/.cid")
-        assert scope.container_id is None
-        assert scope.cidfile == "/w/.cid"
 
 
 class TestColocation:

--- a/tests/unit/core/test_resource_scope.py
+++ b/tests/unit/core/test_resource_scope.py
@@ -1,0 +1,211 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Tests for the resource-scope declaration: where a task's work actually runs.
+
+The property that matters here is that the *default* is right, so an executor
+nobody has written yet is still findable by an observer nobody has written yet.
+"""
+
+import dataclasses
+import os
+
+import pytest
+
+from horus_builtin.executor.python_exec import PythonExecExecutor
+from horus_builtin.executor.python_fn import PythonFunctionExecutor
+from horus_builtin.executor.shell import ShellExecutor
+from horus_builtin.runtime.command import CommandRuntime
+from horus_builtin.target.local import LocalTarget
+from horus_builtin.task.horus_task import HorusTask
+from horus_runtime.core.executor.base import BaseExecutor
+from horus_runtime.core.resources import (
+    ContainerScope,
+    InProcessScope,
+    ProcessTreeScope,
+)
+from horus_runtime.core.target.base import orchestrator_location_id
+from horus_runtime.core.target.channel import JobHandle, PollingChannelProcess
+
+
+def _task(tmp_path: object) -> HorusTask:
+    return HorusTask(
+        id="t",
+        name="t",
+        executor=ShellExecutor(),
+        runtime=CommandRuntime(command="true"),
+        target=LocalTarget(working_directory=str(tmp_path)),
+    )
+
+
+class TestDefaultScope:
+    """Executors that spawn a command are covered without writing any code."""
+
+    @pytest.mark.asyncio
+    async def test_shell_executor_reports_a_process_tree(
+        self, tmp_path: object
+    ) -> None:
+        """
+        ShellExecutor never mentions resources, yet answers correctly.
+        """
+        scope = await ShellExecutor().resource_scope(_task(tmp_path))
+        assert isinstance(scope, ProcessTreeScope)
+        assert scope.kind == "process_tree"
+
+    @pytest.mark.asyncio
+    async def test_unknown_executor_inherits_the_default(
+        self, tmp_path: object
+    ) -> None:
+        """
+        An executor written after the observer is still measurable.
+
+        This is the whole design: no registry entry, no type table, no edit
+        anywhere else — it inherits a correct answer.
+        """
+
+        class FutureExecutor(BaseExecutor):
+            kind: str = "invented_tomorrow"
+
+            async def _execute(self, task: object) -> None:
+                """Never called."""
+
+        scope = await FutureExecutor().resource_scope(_task(tmp_path))
+        assert isinstance(scope, ProcessTreeScope)
+
+    @pytest.mark.asyncio
+    async def test_pid_is_taken_from_the_process_handle(
+        self, tmp_path: object
+    ) -> None:
+        """
+        The spawned process's pid is what roots the tree.
+        """
+        process = PollingChannelProcess(
+            _target=LocalTarget(working_directory=str(tmp_path)),
+            _handle=JobHandle(pid=4321, job_dir="/tmp/job"),
+        )
+        scope = await ShellExecutor().resource_scope(_task(tmp_path), process)
+        assert isinstance(scope, ProcessTreeScope)
+        assert scope.pid == 4321
+
+    @pytest.mark.asyncio
+    async def test_absent_process_yields_no_pid_rather_than_raising(
+        self, tmp_path: object
+    ) -> None:
+        """
+        Asking before the process exists is legitimate, not an error.
+        """
+        scope = await ShellExecutor().resource_scope(_task(tmp_path), None)
+        assert isinstance(scope, ProcessTreeScope)
+        assert scope.pid is None
+
+
+class TestInProcessScope:
+    """The two in-process executors declare that they cannot be attributed."""
+
+    @pytest.mark.parametrize(
+        "executor", [PythonFunctionExecutor(), PythonExecExecutor()]
+    )
+    @pytest.mark.asyncio
+    async def test_reports_in_process(
+        self, executor: BaseExecutor, tmp_path: object
+    ) -> None:
+        """
+        They point at the orchestrator's own pid, and say which it is.
+        """
+        scope = await executor.resource_scope(_task(tmp_path))
+        assert isinstance(scope, InProcessScope)
+        assert scope.kind == "in_process"
+        assert scope.pid == os.getpid()
+
+
+class TestScopeVocabulary:
+    """Scopes name a kind of place, and stay comparable as values."""
+
+    def test_kinds_are_distinct(self) -> None:
+        """An observer dispatches on `kind`, so they must not collide."""
+        kinds = {
+            ProcessTreeScope().kind,
+            ContainerScope().kind,
+            InProcessScope().kind,
+        }
+        assert len(kinds) == 3
+
+    def test_scopes_are_frozen_values(self) -> None:
+        """
+        A scope is a fact about a task, not mutable state to be patched later.
+        """
+        scope = ProcessTreeScope(pid=1)
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            scope.pid = 2  # type: ignore[misc]
+
+    def test_container_scope_carries_a_cidfile(self) -> None:
+        """
+        A container id is often only knowable after the container starts, so
+        the scope can name where the runtime will write it instead.
+        """
+        scope = ContainerScope(cidfile="/w/.cid")
+        assert scope.container_id is None
+        assert scope.cidfile == "/w/.cid"
+
+
+class TestColocation:
+    """Locality is derived from location_id, never from a target's type."""
+
+    def test_local_target_is_orchestrator_local(
+        self, tmp_path: object
+    ) -> None:
+        """
+        LocalTarget knows nothing about the helper, yet compares equal.
+        """
+        assert LocalTarget(
+            working_directory=str(tmp_path)
+        ).is_orchestrator_local
+
+    def test_two_local_targets_are_colocated(self, tmp_path: object) -> None:
+        """
+        Different working directories on one host are still one place.
+        """
+        a = LocalTarget(working_directory=str(tmp_path))
+        b = LocalTarget(working_directory="/somewhere/else")
+        assert a.is_colocated_with(b)
+
+    def test_a_remote_location_is_not_orchestrator_local(
+        self, tmp_path: object
+    ) -> None:
+        """
+        A target reporting another location is correctly seen as elsewhere.
+        """
+
+        class Remoteish(LocalTarget):
+            kind: str = "remoteish_test"
+
+            @property
+            def location_id(self) -> str:
+                return "ssh://user@elsewhere:22"
+
+        target = Remoteish(working_directory=str(tmp_path))
+        assert not target.is_orchestrator_local
+
+    def test_orchestrator_location_matches_local_target_shape(
+        self, tmp_path: object
+    ) -> None:
+        """
+        The two are compared as strings, so their shapes must agree.
+        """
+        target = LocalTarget(working_directory=str(tmp_path))
+        assert orchestrator_location_id() == target.location_id

--- a/tests/unit/core/test_resource_scope.py
+++ b/tests/unit/core/test_resource_scope.py
@@ -24,6 +24,7 @@ nobody has written yet is still findable by an observer nobody has written yet.
 
 import dataclasses
 import os
+from typing import ClassVar
 
 import pytest
 
@@ -37,6 +38,7 @@ from horus_runtime.core.executor.base import BaseExecutor
 from horus_runtime.core.resources import (
     InProcessScope,
     ProcessTreeScope,
+    ResourceScope,
 )
 from horus_runtime.core.target.base import orchestrator_location_id
 from horus_runtime.core.target.channel import JobHandle, PollingChannelProcess
@@ -49,6 +51,29 @@ def _task(tmp_path: object) -> HorusTask:
         executor=ShellExecutor(),
         runtime=CommandRuntime(command="true"),
         target=LocalTarget(working_directory=str(tmp_path)),
+    )
+
+
+class _SchedulerTarget(LocalTarget):
+    """A target that owns the work itself, the way a scheduler does."""
+
+    add_to_registry: ClassVar[bool] = False
+
+    async def resource_scope(
+        self, task: object, process: object = None
+    ) -> ResourceScope | None:
+        """Report the queued job, not whatever the orchestrator spawned."""
+        del task, process
+        return ResourceScope(kind="batch_job", detail={"job": "42"})
+
+
+def _scheduler_task(tmp_path: object) -> HorusTask:
+    return HorusTask(
+        id="t",
+        name="t",
+        executor=ShellExecutor(),
+        runtime=CommandRuntime(command="true"),
+        target=_SchedulerTarget(working_directory=str(tmp_path)),
     )
 
 
@@ -111,6 +136,43 @@ class TestDefaultScope:
         scope = await ShellExecutor().resource_scope(_task(tmp_path), None)
         assert isinstance(scope, ProcessTreeScope)
         assert scope.pid is None
+
+
+class TestTargetDeclaredScope:
+    """
+    A target can reshape the execution, and gets to say so.
+
+    A scheduler target turns a command into a queued job it owns, which the
+    executor above it cannot know. Without this, such a target inherits
+    ``ProcessTreeScope`` and an observer walks a process that is not the work.
+    """
+
+    @pytest.mark.asyncio
+    async def test_target_scope_overrides_the_default(
+        self, tmp_path: object
+    ) -> None:
+        """The target's answer replaces the executor's default."""
+        task = _scheduler_task(tmp_path)
+        scope = await ShellExecutor().resource_scope(task)
+        assert scope.kind == "batch_job"
+
+    @pytest.mark.asyncio
+    async def test_executor_override_beats_the_target(
+        self, tmp_path: object
+    ) -> None:
+        """
+        An executor that reparents its work knows more than the target under
+        it, so its override is never second-guessed.
+        """
+        task = _scheduler_task(tmp_path)
+        scope = await PythonExecExecutor().resource_scope(task)
+        assert isinstance(scope, InProcessScope)
+
+    @pytest.mark.asyncio
+    async def test_plain_target_defers(self, tmp_path: object) -> None:
+        """The default target answer changes nothing."""
+        target = LocalTarget(working_directory=str(tmp_path))
+        assert await target.resource_scope(_task(tmp_path)) is None
 
 
 class TestInProcessScope:

--- a/tests/unit/executor/test_python_fn_external.py
+++ b/tests/unit/executor/test_python_fn_external.py
@@ -24,7 +24,9 @@ and the whole point of this executor is that the work leaves the process.
 """
 
 import os
+from collections.abc import Callable
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -35,6 +37,7 @@ from horus_builtin.executor.python_fn_external import (
 from horus_builtin.runtime.python import PythonFunctionRuntime
 from horus_builtin.target.local import LocalTarget
 from horus_builtin.task.function import FunctionTask
+from horus_runtime.core.artifact.base import BaseArtifact
 from horus_runtime.core.executor.base import BaseExecutor
 from horus_runtime.core.resources import ProcessTreeScope
 from horus_runtime.core.task.exceptions import TaskExecutionError
@@ -42,9 +45,9 @@ from horus_runtime.core.task.exceptions import TaskExecutionError
 
 def make_task(
     tmp_path: Path,
-    func: object,
+    func: Callable[..., Any],
     *,
-    inputs: list[FileArtifact] | None = None,
+    inputs: list[BaseArtifact] | None = None,
 ) -> FunctionTask:
     """Build a FunctionTask wired to the out-of-process executor."""
     return FunctionTask(

--- a/tests/unit/executor/test_python_fn_external.py
+++ b/tests/unit/executor/test_python_fn_external.py
@@ -1,0 +1,185 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Tests for ExternalPythonFunctionExecutor.
+
+These run the real thing: a real subprocess, on a real local target, with a
+real cloudpickle payload. Mocking the subprocess away would test the mock,
+and the whole point of this executor is that the work leaves the process.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from horus_builtin.artifact.file import FileArtifact
+from horus_builtin.executor.python_fn_external import (
+    ExternalPythonFunctionExecutor,
+)
+from horus_builtin.runtime.python import PythonFunctionRuntime
+from horus_builtin.target.local import LocalTarget
+from horus_builtin.task.function import FunctionTask
+from horus_runtime.core.executor.base import BaseExecutor
+from horus_runtime.core.resources import ProcessTreeScope
+from horus_runtime.core.task.exceptions import TaskExecutionError
+
+
+def make_task(
+    tmp_path: Path,
+    func: object,
+    *,
+    inputs: list[FileArtifact] | None = None,
+) -> FunctionTask:
+    """Build a FunctionTask wired to the out-of-process executor."""
+    return FunctionTask(
+        id="external_fn",
+        name="external_fn",
+        runtime=PythonFunctionRuntime(func=func),
+        executor=ExternalPythonFunctionExecutor(),
+        target=LocalTarget(working_directory=tmp_path.as_posix()),
+        inputs=inputs or [],
+    )
+
+
+@pytest.mark.unit
+class TestExternalPythonFunctionExecutor:
+    """End-to-end behaviour of the out-of-process function executor."""
+
+    async def test_runs_in_another_process_and_returns_artifacts(
+        self, tmp_path: Path
+    ) -> None:
+        """
+        The function really runs elsewhere, sees its inputs, and its returned
+        side artifacts come back.
+        """
+        source = tmp_path / "input.txt"
+        source.write_text("payload")
+        artifact = FileArtifact(id="data", path=source)
+
+        def work(data: FileArtifact) -> FileArtifact:
+            out = Path("out.txt")
+            out.write_text(f"{os.getpid()}:{Path(data.path).read_text()}")
+            return FileArtifact(id="result", path=out.resolve())
+
+        task = make_task(tmp_path, work, inputs=[artifact])
+        await task.executor.execute(task)
+
+        results = [a for a in task.side_artifacts if a.id == "result"]
+        assert len(results) == 1
+        child_pid, _, content = (
+            Path(results[0].path).read_text().partition(":")
+        )
+        assert content == "payload"
+        assert int(child_pid) != os.getpid()
+
+    async def test_closure_over_local_state(self, tmp_path: Path) -> None:
+        """
+        A closure over local state survives the trip. This is what plain
+        pickle cannot do and why cloudpickle is a dependency.
+        """
+        factor = 21
+        target_file = tmp_path / "closure.txt"
+
+        def work() -> None:
+            target_file.write_text(str(factor * 2))
+
+        task = make_task(tmp_path, work)
+        await task.executor.execute(task)
+
+        assert target_file.read_text() == "42"
+
+    async def test_failure_surfaces_original_exception(
+        self, tmp_path: Path
+    ) -> None:
+        """
+        A raising function fails the task with its own exception type and
+        message, plus the target-side traceback.
+        """
+
+        def work() -> None:
+            raise KeyError("missing-thing")
+
+        task = make_task(tmp_path, work)
+        with pytest.raises(KeyError) as excinfo:
+            await task.executor.execute(task)
+
+        assert "missing-thing" in str(excinfo.value)
+        notes = "".join(getattr(excinfo.value, "__notes__", []))
+        assert "KeyError: 'missing-thing'" in notes
+        assert "in work" in notes
+
+    async def test_rejects_a_function_that_wants_the_live_task(
+        self, tmp_path: Path
+    ) -> None:
+        """
+        The live task cannot cross a process boundary, so asking for it is
+        refused up front rather than handed a useless copy.
+        """
+
+        def work(task: object) -> None:
+            del task
+
+        task = make_task(tmp_path, work)
+        with pytest.raises(TaskExecutionError, match="'task' argument"):
+            await task.executor.execute(task)
+
+    async def test_missing_interpreter_reports_the_task(
+        self, tmp_path: Path
+    ) -> None:
+        """
+        A target with no usable interpreter fails as a task error naming the
+        task, not as an unpickling crash in the orchestrator.
+        """
+
+        def work() -> None:
+            return None
+
+        task = make_task(tmp_path, work)
+        assert isinstance(task.executor, ExternalPythonFunctionExecutor)
+        task.executor.python = "definitely-not-a-python-interpreter"
+        with pytest.raises(TaskExecutionError, match="produced no result"):
+            await task.executor.execute(task)
+
+    async def test_resource_scope_is_the_inherited_process_tree(
+        self, tmp_path: Path
+    ) -> None:
+        """
+        The executor overrides nothing: it gets a real, measurable process
+        tree from BaseExecutor purely by running its work as a command.
+        """
+        assert "resource_scope" not in vars(ExternalPythonFunctionExecutor)
+
+        target = LocalTarget(working_directory=tmp_path.as_posix())
+        proc = await target.run_command("sleep 0.1", cwd=tmp_path.as_posix())
+        try:
+            task = make_task(tmp_path, lambda: None)
+            scope = await task.executor.resource_scope(task, proc)
+        finally:
+            await proc.wait()
+
+        assert isinstance(scope, ProcessTreeScope)
+        assert scope.pid is not None
+        assert scope.pid > 0
+
+    def test_registered_under_its_kind(self) -> None:
+        """The executor is discoverable through the registry."""
+        assert (
+            BaseExecutor.registry["python_function_external"]
+            is ExternalPythonFunctionExecutor
+        )

--- a/tests/unit/runtime/test_python_function_reference.py
+++ b/tests/unit/runtime/test_python_function_reference.py
@@ -1,0 +1,167 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Tests for resolving ``PythonFunctionRuntime.func`` from a dotted path, which
+is what makes a function task expressible in YAML.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from horus_builtin.runtime.python import PythonFunctionRuntime, import_callable
+from horus_builtin.target.local import LocalTarget
+from horus_builtin.task.function import FunctionTask
+from horus_builtin.workflow.horus_workflow import HorusWorkflow
+from horus_runtime.context import HorusContext
+from horus_runtime.core.workflow.base import BaseWorkflow
+
+MODULE_SOURCE = """
+from pathlib import Path
+
+NOT_CALLABLE = 42
+
+
+def work():
+    Path("ran.txt").write_text("ok")
+
+
+class Steps:
+    @staticmethod
+    def nested():
+        return None
+"""
+
+
+@pytest.fixture
+def function_module(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> str:
+    """
+    Write an importable module of task functions and put it on ``sys.path``,
+    the way a user's own workflow package would be.
+    """
+    name = f"horus_test_functions_{abs(hash(tmp_path)) % 10**8}"
+    (tmp_path / f"{name}.py").write_text(MODULE_SOURCE)
+    monkeypatch.syspath_prepend(str(tmp_path))
+    return name
+
+
+@pytest.mark.unit
+class TestImportCallable:
+    """Resolution rules and error messages."""
+
+    def test_colon_form(self, function_module: str) -> None:
+        """``module:function`` resolves."""
+        assert import_callable(f"{function_module}:work").__name__ == "work"
+
+    def test_dotted_form(self, function_module: str) -> None:
+        """``module.function`` resolves too."""
+        assert import_callable(f"{function_module}.work").__name__ == "work"
+
+    def test_attribute_chain(self, function_module: str) -> None:
+        """A reference may walk into a class."""
+        resolved = import_callable(f"{function_module}:Steps.nested")
+        assert resolved() is None
+
+    def test_unknown_module_names_the_module(self) -> None:
+        """A missing module is reported by name, not as a bare ImportError."""
+        with pytest.raises(ValueError, match="no_such_module_here"):
+            import_callable("no_such_module_here:work")
+
+    def test_unknown_attribute_names_the_attribute(
+        self, function_module: str
+    ) -> None:
+        """A typo in the function name says which attribute was missing."""
+        with pytest.raises(ValueError, match="typo"):
+            import_callable(f"{function_module}:typo")
+
+    def test_non_callable_is_rejected(self, function_module: str) -> None:
+        """Pointing at a constant is an error, not a runtime surprise."""
+        with pytest.raises(ValueError, match="non-callable"):
+            import_callable(f"{function_module}:NOT_CALLABLE")
+
+    def test_malformed_reference(self) -> None:
+        """A bare name cannot name both a module and an attribute."""
+        with pytest.raises(ValueError, match="Invalid function reference"):
+            import_callable("work")
+
+
+@pytest.mark.unit
+class TestPythonFunctionRuntimeFunc:
+    """The runtime field itself."""
+
+    def test_accepts_a_real_callable_unchanged(self) -> None:
+        """Passing a function keeps working exactly as before."""
+
+        def work() -> None:
+            return None
+
+        assert PythonFunctionRuntime(func=work).func is work
+
+    def test_accepts_a_reference_string(self, function_module: str) -> None:
+        """A dotted path is resolved at validation time."""
+        runtime = PythonFunctionRuntime(func=f"{function_module}:work")
+        assert callable(runtime.func)
+
+    def test_serializes_back_to_a_reference(
+        self, function_module: str
+    ) -> None:
+        """The dump is the string that imports the function again."""
+        runtime = PythonFunctionRuntime(func=f"{function_module}:work")
+        assert runtime.model_dump(mode="json")["func"] == (
+            f"{function_module}:work"
+        )
+
+
+@pytest.mark.unit
+class TestYamlRoundTrip:
+    """A function task written as YAML loads and runs."""
+
+    async def test_round_trip_and_run(
+        self,
+        tmp_path: Path,
+        function_module: str,
+        horus_context: HorusContext,
+    ) -> None:
+        """``to_yaml`` -> ``from_yaml`` -> ``run`` on a dotted-path task."""
+        del horus_context
+        wf = HorusWorkflow(
+            name="wf",
+            orchestrator_target=LocalTarget(
+                working_directory=tmp_path.as_posix()
+            ),
+        )
+        wf.tasks.append(
+            FunctionTask(
+                id="step",
+                name="step",
+                runtime=PythonFunctionRuntime(func=f"{function_module}:work"),
+            )
+        )
+
+        out_path = tmp_path / "workflow.yaml"
+        wf.to_yaml(out_path)
+        dumped = yaml.safe_load(out_path.read_text())
+        step = next(t for t in dumped["tasks"] if t["id"] == "step")
+        assert step["runtime"]["func"] == f"{function_module}:work"
+
+        loaded = BaseWorkflow.from_yaml(out_path)
+        await loaded.run(trigger_id="step")
+
+        task = next(t for t in loaded.tasks if t.id == "step")
+        assert (Path(task.working_dir) / "ran.txt").read_text() == "ok"

--- a/tests/unit/runtime/test_python_function_reference.py
+++ b/tests/unit/runtime/test_python_function_reference.py
@@ -115,14 +115,18 @@ class TestPythonFunctionRuntimeFunc:
 
     def test_accepts_a_reference_string(self, function_module: str) -> None:
         """A dotted path is resolved at validation time."""
-        runtime = PythonFunctionRuntime(func=f"{function_module}:work")
+        runtime = PythonFunctionRuntime(
+            func=f"{function_module}:work"  # type: ignore[arg-type]
+        )
         assert callable(runtime.func)
 
     def test_serializes_back_to_a_reference(
         self, function_module: str
     ) -> None:
         """The dump is the string that imports the function again."""
-        runtime = PythonFunctionRuntime(func=f"{function_module}:work")
+        runtime = PythonFunctionRuntime(
+            func=f"{function_module}:work"  # type: ignore[arg-type]
+        )
         assert runtime.model_dump(mode="json")["func"] == (
             f"{function_module}:work"
         )
@@ -150,7 +154,9 @@ class TestYamlRoundTrip:
             FunctionTask(
                 id="step",
                 name="step",
-                runtime=PythonFunctionRuntime(func=f"{function_module}:work"),
+                runtime=PythonFunctionRuntime(
+                    func=f"{function_module}:work"  # type: ignore[arg-type]
+                ),
             )
         )
 

--- a/tests/unit/workflow/test_dynamic_mutation.py
+++ b/tests/unit/workflow/test_dynamic_mutation.py
@@ -183,22 +183,6 @@ class TestAddTask:
         wf.add_task(new_task)
 
         run_root = (tmp_path / "workflow_results").resolve()
-        import os  # noqa: PLC0415
-
-        print("DEBUG cwd:", os.getcwd())  # noqa: T201
-        print("DEBUG wf._base_directory:", wf._base_directory)  # noqa: T201
-        print("DEBUG wf._effective_base:", wf._effective_base)  # noqa: T201
-        ot = wf.orchestrator_target
-        ot_wd = ot.working_directory if ot else None
-        print("DEBUG orchestrator_target.working_directory:", ot_wd)  # noqa: T201
-        print("DEBUG wf.run_directory:", wf.run_directory)  # noqa: T201
-        nt_wd = new_task.target.working_directory
-        print("DEBUG new_task.target.working_directory:", nt_wd)  # noqa: T201
-        print("DEBUG new_task.working_dir:", new_task.working_dir)  # noqa: T201
-        print("DEBUG produced.declared_path:", produced.declared_path)  # noqa: T201
-        print("DEBUG produced.path:", produced.path)  # noqa: T201
-        expected = (run_root / "results/out.txt").resolve()
-        print("DEBUG expected:", expected)  # noqa: T201
         assert produced.path == (run_root / "results/out.txt").resolve()
         assert new_task.target.working_directory == run_root.as_posix()
         assert new_task.working_dir == (run_root / "added").as_posix()

--- a/tests/unit/workflow/test_dynamic_mutation.py
+++ b/tests/unit/workflow/test_dynamic_mutation.py
@@ -183,6 +183,22 @@ class TestAddTask:
         wf.add_task(new_task)
 
         run_root = (tmp_path / "workflow_results").resolve()
+        import os  # noqa: PLC0415
+
+        print("DEBUG cwd:", os.getcwd())  # noqa: T201
+        print("DEBUG wf._base_directory:", wf._base_directory)  # noqa: T201
+        print("DEBUG wf._effective_base:", wf._effective_base)  # noqa: T201
+        ot = wf.orchestrator_target
+        ot_wd = ot.working_directory if ot else None
+        print("DEBUG orchestrator_target.working_directory:", ot_wd)  # noqa: T201
+        print("DEBUG wf.run_directory:", wf.run_directory)  # noqa: T201
+        nt_wd = new_task.target.working_directory
+        print("DEBUG new_task.target.working_directory:", nt_wd)  # noqa: T201
+        print("DEBUG new_task.working_dir:", new_task.working_dir)  # noqa: T201
+        print("DEBUG produced.declared_path:", produced.declared_path)  # noqa: T201
+        print("DEBUG produced.path:", produced.path)  # noqa: T201
+        expected = (run_root / "results/out.txt").resolve()
+        print("DEBUG expected:", expected)  # noqa: T201
         assert produced.path == (run_root / "results/out.txt").resolve()
         assert new_task.target.working_directory == run_root.as_posix()
         assert new_task.working_dir == (run_root / "added").as_posix()

--- a/tests/unit/workflow/test_run_layout.py
+++ b/tests/unit/workflow/test_run_layout.py
@@ -119,25 +119,6 @@ class TestResolveRunPaths:
         wf._resolve_run_paths()
 
         run_root = (tmp_path / "workflow_results").resolve()
-        import os  # noqa: PLC0415
-
-        print("DEBUG cwd:", os.getcwd())  # noqa: T201
-        print("DEBUG PYTHONPATH:", os.environ.get("PYTHONPATH"))  # noqa: T201
-        print("DEBUG PWD:", os.environ.get("PWD"))  # noqa: T201
-        print("DEBUG TMPDIR:", os.environ.get("TMPDIR"))  # noqa: T201
-        print("DEBUG wf._base_directory:", wf._base_directory)  # noqa: T201
-        print("DEBUG wf._effective_base:", wf._effective_base)  # noqa: T201
-        ot = wf.orchestrator_target
-        ot_wd = ot.working_directory if ot else None
-        print("DEBUG orchestrator_target.working_directory:", ot_wd)  # noqa: T201
-        print("DEBUG wf.run_directory:", wf.run_directory)  # noqa: T201
-        t0_wd = wf.tasks[0].target.working_directory
-        print("DEBUG task.target.working_directory:", t0_wd)  # noqa: T201
-        print("DEBUG task.working_dir:", wf.tasks[0].working_dir)  # noqa: T201
-        print("DEBUG produced.declared_path:", produced.declared_path)  # noqa: T201
-        print("DEBUG produced.path:", produced.path)  # noqa: T201
-        expected = (run_root / "results/vina.tar.gz").resolve()
-        print("DEBUG expected:", expected)  # noqa: T201
         # Produced output nests under the run root...
         assert produced.path == (run_root / "results/vina.tar.gz").resolve()
         # ...while an external (never-produced) input stays at the base dir.

--- a/tests/unit/workflow/test_run_layout.py
+++ b/tests/unit/workflow/test_run_layout.py
@@ -119,6 +119,25 @@ class TestResolveRunPaths:
         wf._resolve_run_paths()
 
         run_root = (tmp_path / "workflow_results").resolve()
+        import os  # noqa: PLC0415
+
+        print("DEBUG cwd:", os.getcwd())  # noqa: T201
+        print("DEBUG PYTHONPATH:", os.environ.get("PYTHONPATH"))  # noqa: T201
+        print("DEBUG PWD:", os.environ.get("PWD"))  # noqa: T201
+        print("DEBUG TMPDIR:", os.environ.get("TMPDIR"))  # noqa: T201
+        print("DEBUG wf._base_directory:", wf._base_directory)  # noqa: T201
+        print("DEBUG wf._effective_base:", wf._effective_base)  # noqa: T201
+        ot = wf.orchestrator_target
+        ot_wd = ot.working_directory if ot else None
+        print("DEBUG orchestrator_target.working_directory:", ot_wd)  # noqa: T201
+        print("DEBUG wf.run_directory:", wf.run_directory)  # noqa: T201
+        t0_wd = wf.tasks[0].target.working_directory
+        print("DEBUG task.target.working_directory:", t0_wd)  # noqa: T201
+        print("DEBUG task.working_dir:", wf.tasks[0].working_dir)  # noqa: T201
+        print("DEBUG produced.declared_path:", produced.declared_path)  # noqa: T201
+        print("DEBUG produced.path:", produced.path)  # noqa: T201
+        expected = (run_root / "results/vina.tar.gz").resolve()
+        print("DEBUG expected:", expected)  # noqa: T201
         # Produced output nests under the run root...
         assert produced.path == (run_root / "results/vina.tar.gz").resolve()
         # ...while an external (never-produced) input stays at the base dir.

--- a/uv.lock
+++ b/uv.lock
@@ -6,14 +6,6 @@ resolution-markers = [
     "python_full_version < '3.15'",
 ]
 
-[options]
-exclude-newer = "2026-07-30T08:07:05.233251Z"
-exclude-newer-span = "P2D"
-
-[options.exclude-newer-package]
-horus-docker = false
-horus-runtime = false
-
 [[package]]
 name = "annotated-types"
 version = "0.7.0"

--- a/uv.lock
+++ b/uv.lock
@@ -6,6 +6,14 @@ resolution-markers = [
     "python_full_version < '3.15'",
 ]
 
+[options]
+exclude-newer = "2026-07-30T08:07:05.233251Z"
+exclude-newer-span = "P2D"
+
+[options.exclude-newer-package]
+horus-docker = false
+horus-runtime = false
+
 [[package]]
 name = "annotated-types"
 version = "0.7.0"

--- a/uv.lock
+++ b/uv.lock
@@ -46,6 +46,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cloudpickle"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -158,6 +167,7 @@ name = "horus-runtime"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
+    { name = "cloudpickle" },
     { name = "loguru" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -182,6 +192,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = ">=8.3.3" },
+    { name = "cloudpickle", specifier = ">=3.0" },
     { name = "loguru", specifier = "~=0.7" },
     { name = "pydantic", specifier = "~=2.0" },
     { name = "pydantic-settings", specifier = "~=2.0" },


### PR DESCRIPTION
Foundation for universal task resource measurement. **Additive only** — nothing measures anything yet, and behaviour is unchanged without a plugin that consumes these.

## Why

Resource measurement today has to guess where a task's work lives, and it guesses by rewriting command strings in `TargetCommandMiddleware`. That only sees executors that go through `target.run_command`. Auditing every execution path:

| Executor | Runs work as | Findable by command rewriting |
|---|---|---|
| `shell`, the three `*_python_environment`, `singularity` | subprocess / SSH command | yes |
| `docker` | `docker run` | **no** — the workload is reparented under `containerd-shim`, in a different process group |
| `python_function` (the `@FunctionTask.task` path) | `func(**args)` in this process | **no** |
| `python` | `exec(code, scope)` in this process | **no** |

And crucially: an executor written *tomorrow* is unmeasurable too, because the observer would have to be taught about it.

## What this adds

**`ChannelProcess.pid`** — which process a handle refers to, or `None` when the channel cannot know. `None` is a legitimate answer (a remote channel streaming over an already-open connection never learns a pid), so callers fall back rather than raise. Implemented for `LocalChannelProcess` and `PollingChannelProcess`; there the pid doubles as the process-group id, because commands are spawned in a new session (`start_new_session=True` locally, `setsid` when detached), which is what makes the whole tree reachable from one number.

**`ResourceScope`** (`core/resources.py`, alongside the existing `ResourceRequest` — the two halves now mirror each other: what a task *asks for*, and where it *actually runs*). `ProcessTreeScope` / `ContainerScope` / `InProcessScope` name a **kind of place, not a kind of executor**. That is the whole design: an observer that understands "a process tree" measures every executor that runs one, including ones that do not exist yet. `kind` is a plain string so a plugin can introduce a scope this repo has never heard of.

**`BaseExecutor.resource_scope()`**, defaulting to the spawned process tree. Being a *default* rather than a lookup table is the point — `test_unknown_executor_inherits_the_default` asserts exactly this: a brand-new executor subclass gets a correct answer with no registry entry and no edit anywhere. The two in-process executors override it to declare they cannot be attributed to a single task, which is what will let an observer label an estimate honestly instead of silently blaming one task for the whole orchestrator.

**`BaseTarget.is_colocated_with` / `is_orchestrator_local`**, derived from `location_id` rather than a target's type, so a new local-ish target gets the right answer without anyone updating an `isinstance` chain. Callers were already comparing `location_id` strings by hand to decide whether a transfer is a no-op; this names the rule.

## Why the runtime and not the plugin

Being *findable* is a property of the execution model, so it belongs here. Actually *measuring* is an optional concern, so it stays in the plugin. Install nothing and this costs nothing.

## Tests

669 pass (13 new), ruff and mypy --strict clean. The new tests cover the inherited default, pid propagation, absent-pid tolerance, in-process declaration, scope-kind distinctness and immutability, and co-location derived from `location_id`.

## Docs

- [X] No documentation update required
