### PR TITLE
Run function tasks on their target, not the orchestrator

### DIFF
--- a/.claude/skills/horus-workflow/SKILL.md
+++ b/.claude/skills/horus-workflow/SKILL.md
@@ -85,12 +85,14 @@ loads the plugin registries). Only one workflow may run at a time.
 | workflow | `horus_workflow`                                            |
 | task     | `horus_task`, `function_task` (Python-only)                 |
 | runtime  | `command`, `python`, `python_string`, `python_script`       |
-| executor | `shell`, `python_exec`, `python_fn`                         |
+| executor | `shell`, `python_exec`, `python_fn`, `python_function_external` |
 | artifact | `file`, `folder`, `json`, `pickle`                          |
 | target   | `local`                                                     |
 
 Compatible pairings: `command` runtime ↔ `shell` executor; `python`/string code
-↔ `python_exec`; in-memory function ↔ `python_fn`. Mismatches raise
+↔ `python_exec`; in-memory function ↔ `python_fn`, or
+`python_function_external` to run the same function in a subprocess **on the
+task's target** (opt-in; see below). Mismatches raise
 `IncompatibleRuntimeError` at construction.
 
 ## Gotchas

--- a/.claude/skills/horus-workflow/references/python-workflows.md
+++ b/.claude/skills/horus-workflow/references/python-workflows.md
@@ -83,6 +83,29 @@ Decorator signature:
 `FunctionTask.task(wf, *, id=None, name=None, inputs=None, outputs=None, target=None)`.
 `id`/`name` default to the function name; `target` defaults to `LocalTarget()`.
 
+### Running a function on the target (`python_function_external`)
+
+`python_fn` runs the function **in the orchestrator process** and ignores
+`task.target`, so a function task with a remote target still runs locally. Set
+`executor: {kind: python_function_external}` to ship the function (cloudpickle)
+to the target and run it there as a real subprocess: it honours the target and
+is resource-measurable. Two limits, both deliberate:
+
+- a function that takes `task` is **refused** (the live task cannot cross a
+  process boundary), which also means tasks calling `workflow.add_task()` /
+  `add_edge()` on the running DAG must stay on `python_fn`;
+- the target's interpreter needs `cloudpickle` and `horus_runtime`. Set
+  `python:` on the executor to pick it, e.g. point it at an environment built
+  by a `horus-environments` executor
+  (`python: .horus_python_environment/bin/python`).
+
+### Functions in YAML
+
+`runtime.func` accepts the callable itself (Python workflows) or a dotted path
+string (`my_package.steps:normalise`, also `my_package.steps.normalise`), which
+is what a YAML workflow uses. It is imported at validation time; a bad path
+fails with a message naming the module or attribute.
+
 ### Argument injection
 
 The `python_function` runtime inspects the function signature and injects

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ classifiers = [
 ]
 dependencies = [
   "click>=8.3.3",
+  "cloudpickle>=3.0",
   "loguru~=0.7",
   "pydantic~=2.0",
   "pydantic_settings~=2.0",
@@ -34,6 +35,7 @@ pickle = "horus_builtin.artifact.pickle"
 shell = "horus_builtin.executor.shell"
 python_exec = "horus_builtin.executor.python_exec"
 python_fn = "horus_builtin.executor.python_fn"
+python_fn_external = "horus_builtin.executor.python_fn_external"
 
 [project.entry-points."horus.interaction"]
 common = "horus_builtin.interaction.common"
@@ -109,6 +111,10 @@ python_version = "3.13"
 strict = true
 exclude = ["build", "dist"]
 plugins = ["pydantic.mypy"]
+
+[[tool.mypy.overrides]]
+module = ["cloudpickle.*"]
+ignore_missing_imports = true
 
 [tool.pydantic-mypy]
 init_typed = true

--- a/src/horus_builtin/executor/_remote_function_call.py
+++ b/src/horus_builtin/executor/_remote_function_call.py
@@ -1,0 +1,117 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Launcher shipped to the target by
+:class:`~horus_builtin.executor.python_fn_external.
+ExternalPythonFunctionExecutor`.
+
+It is copied to the task working directory and run there by the target's
+interpreter, so it is deliberately a *script*: it must import nothing from
+horus-runtime at module level (the payload may pull horus classes in while
+unpickling, but the launcher itself must start on any interpreter that has
+cloudpickle).
+
+Protocol, both halves of which are hard-coded here and in the executor:
+
+- ``argv[1]``: cloudpickled ``(func, kwargs)`` payload to read.
+- ``argv[2]``: where to write the cloudpickled outcome.
+- outcome: ``{"ok": bool, "value": ..., "traceback": str | None,
+  "exception": BaseException | None}``.
+
+The outcome file, not the exit code, is what the executor believes: an exit
+code can only say *that* something failed, and "subprocess exited 1" is a
+useless thing to hand a scientist whose function raised on line 40.
+"""
+
+import asyncio
+import inspect
+import sys
+import traceback
+from collections.abc import Awaitable
+from typing import Any
+
+import cloudpickle
+
+
+async def _resolve(awaitable: Awaitable[Any]) -> Any:
+    """Await *awaitable*, the entry point ``asyncio.run`` needs."""
+    return await awaitable
+
+
+def _write_outcome(result_path: str, outcome: dict[str, Any]) -> None:
+    """
+    Write *outcome* to *result_path*, degrading to text if it will not pickle.
+
+    A return value or an exception can be unpicklable (an open file handle
+    captured in ``__init__``, say). Losing the object is survivable; losing
+    the traceback that explains the run is not, so the fallback keeps the
+    text.
+    """
+    try:
+        data = cloudpickle.dumps(outcome)
+    except Exception:
+        data = cloudpickle.dumps(
+            {
+                "ok": False,
+                "value": None,
+                "exception": None,
+                "traceback": (
+                    f"{outcome.get('traceback') or ''}\n"
+                    f"Could not send the result back to the orchestrator:\n"
+                    f"{traceback.format_exc()}"
+                ).strip(),
+            }
+        )
+    with open(result_path, "wb") as fh:
+        fh.write(data)
+
+
+def main(payload_path: str, result_path: str) -> int:
+    """
+    Call the pickled function and report the outcome. Returns an exit code.
+    """
+    with open(payload_path, "rb") as fh:
+        func, kwargs = cloudpickle.load(fh)
+
+    outcome: dict[str, Any]
+    try:
+        value = func(**kwargs)
+        # The in-process executor awaits coroutine functions, so an async task
+        # body must keep working here.
+        if inspect.isawaitable(value):
+            value = asyncio.run(_resolve(value))
+        outcome = {
+            "ok": True,
+            "value": value,
+            "exception": None,
+            "traceback": None,
+        }
+    except Exception as exc:
+        outcome = {
+            "ok": False,
+            "value": None,
+            "exception": exc,
+            "traceback": traceback.format_exc(),
+        }
+
+    _write_outcome(result_path, outcome)
+    return 0 if outcome["ok"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1], sys.argv[2]))

--- a/src/horus_builtin/executor/python_fn.py
+++ b/src/horus_builtin/executor/python_fn.py
@@ -38,6 +38,42 @@ from horus_runtime.i18n import tr as _
 from horus_runtime.logging import horus_logger
 
 
+async def parse_result_artifacts(
+    task: BaseTask, result: PythonFunctionReturnType
+) -> None:
+    """
+    Parse the result of a Python function execution to extract any declared
+    side-product artifacts.
+
+    Module-level so the out-of-process executor applies the exact same rules
+    to a result that came back over a pipe as the in-process one does to a
+    live return value.
+    """
+    if isawaitable(result):
+        result = await result
+
+    if result is None:
+        return
+    if isinstance(result, BaseArtifact):
+        task.side_artifacts = [result]
+        return
+    if isinstance(result, list) and all(
+        isinstance(r, BaseArtifact) for r in result
+    ):
+        task.side_artifacts = result
+        return
+
+    horus_logger.log.warning(
+        _(
+            "Task %(task_id)s returned an unexpected value from its "
+            "Python function runtime. Expected BaseArtifact, "
+            "list[BaseArtifact], or None; got: %(result)s. Skipping side "
+            "artifact handling."
+        )
+        % {"task_id": task.id, "result": result}
+    )
+
+
 class PythonFunctionExecutor(BaseExecutor):
     """
     Executor for running Python functions in-memory.
@@ -96,26 +132,4 @@ class PythonFunctionExecutor(BaseExecutor):
         Parse the result of a Python function execution to extract any declared
         side-product artifacts.
         """
-        if isawaitable(result):
-            result = await result
-
-        if result is None:
-            return
-        if isinstance(result, BaseArtifact):
-            task.side_artifacts = [result]
-            return
-        if isinstance(result, list) and all(
-            isinstance(r, BaseArtifact) for r in result
-        ):
-            task.side_artifacts = result
-            return
-
-        horus_logger.log.warning(
-            _(
-                "Task %(task_id)s returned an unexpected value from its "
-                "Python function runtime. Expected BaseArtifact, "
-                "list[BaseArtifact], or None; got: %(result)s. Skipping side "
-                "artifact handling."
-            )
-            % {"task_id": task.id, "result": result}
-        )
+        await parse_result_artifacts(task, result)

--- a/src/horus_builtin/executor/python_fn_external.py
+++ b/src/horus_builtin/executor/python_fn_external.py
@@ -1,0 +1,233 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Run a ``python_function`` runtime in a subprocess **on the task's target**
+instead of inside the orchestrator.
+
+Why this exists, given ``python_fn`` already runs functions:
+
+- ``PythonFunctionExecutor`` ignores ``task.target``. A function task with an
+  SSH target runs on the orchestrator, which is a correctness bug and not
+  merely a metrics gap. This executor honours the target like every other
+  executor does, by going through ``target.run_command``.
+- Because the work is a real process, it inherits the default
+  :meth:`BaseExecutor.resource_scope` (a ``ProcessTreeScope`` with a live
+  pid) and becomes measurable with no extra code here.
+
+**Limitation: live DAG mutation does not work here.** A task body may call
+``workflow.add_task()`` / ``add_edge()`` on the running workflow (see
+``core/workflow/base.py``, "Safe to call from inside a running task"). That
+depends on sharing memory with the orchestrator and cannot cross a process
+boundary, so tasks that mutate the DAG must keep using the in-process
+``python_function`` executor. The same reasoning applies to any function that
+takes the live ``task``; rather than hand it a lookalike copy whose mutations
+would silently go nowhere, this executor refuses such a function up front.
+"""
+
+import asyncio
+import shlex
+import sys
+from contextlib import aclosing
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, ClassVar
+
+import cloudpickle
+
+from horus_builtin.executor.python_fn import parse_result_artifacts
+from horus_builtin.runtime.python import PythonFunctionRuntime
+from horus_runtime.core.executor.base import BaseExecutor, RuntimeFilterType
+from horus_runtime.core.task.exceptions import TaskExecutionError
+from horus_runtime.i18n import tr as _
+from horus_runtime.logging import horus_logger
+from horus_runtime.settings import runtime_settings
+
+if TYPE_CHECKING:
+    from horus_runtime.core.task.base import BaseTask
+
+_LAUNCHER_SOURCE = Path(__file__).with_name("_remote_function_call.py")
+_LAUNCHER_NAME = ".horus_function_call.py"
+_PAYLOAD_NAME = ".horus_function_payload.pkl"
+_RESULT_NAME = ".horus_function_result.pkl"
+
+
+class ExternalPythonFunctionExecutor(BaseExecutor):
+    """
+    Execute a Python function in a subprocess on the task's target.
+    """
+
+    kind: str = "python_function_external"
+    kind_name: ClassVar[str] = "External Python Function Executor"
+    kind_description: ClassVar[str] = _(
+        "Executes a Python function in a subprocess on the task's target."
+    )
+
+    runtimes: ClassVar[RuntimeFilterType] = (PythonFunctionRuntime,)
+
+    python: str | None = None
+    """
+    Interpreter used on the target. It needs ``cloudpickle`` importable, plus
+    whatever the function itself imports, including ``horus_runtime`` if the
+    function takes or returns artifacts.
+
+    ``None`` (the default) means: the orchestrator's own interpreter when the
+    target is co-located with it, otherwise plain ``python``. The first is the
+    one interpreter that provably satisfies those requirements, since it is
+    running this code; the second is the only thing that can be assumed about
+    a machine we have never seen.
+
+    Environment management is deliberately *not* reimplemented here. The
+    ``horus-environments`` executors already build conda/uv/virtualenv
+    environments on the target and put the interpreter at a known path, so
+    composing with them is a matter of pointing this field at one, e.g.
+    ``python: .horus_python_environment/bin/python``. Relative paths resolve
+    against the task working directory, which is the command's cwd.
+    """
+
+    def _interpreter(self, task: "BaseTask") -> str:
+        """Return the interpreter command to invoke on the target."""
+        if self.python is not None:
+            return self.python
+        if task.target.is_orchestrator_local:
+            return sys.executable
+        return "python"
+
+    async def _execute(self, task: "BaseTask") -> None:
+        """
+        Ship the function to the target, run it there, bring the result back.
+        """
+        assert isinstance(task.runtime, PythonFunctionRuntime)
+        func, kwargs = await task.runtime.setup_runtime(task)
+
+        if "task" in kwargs:
+            # PythonFunctionRuntime injects the live task whenever the
+            # signature asks for it. A copy of it on the far side of a pipe
+            # would look right and do nothing (mutations, DAG edits and
+            # interactions all die with the subprocess), so fail loudly here
+            # instead of subtly there.
+            raise TaskExecutionError(
+                _(
+                    "Task %(task_id)s uses the '%(kind)s' executor but its "
+                    "function accepts a 'task' argument. The live task object "
+                    "cannot cross a process boundary; use the in-process "
+                    "'python_function' executor, or drop the 'task' parameter "
+                    "(and any **kwargs that would receive it)."
+                )
+                % {"task_id": task.id, "kind": self.kind}
+            )
+
+        await task.target.mkdir(task.working_dir)
+
+        # cloudpickle rather than pickle: closing over local state is a
+        # supported way to build a workflow programmatically, and plain pickle
+        # cannot represent a closure. It also already prefers a by-reference
+        # pickle for anything importable, so the cheap payload is the default
+        # and the expensive one only appears when it is the only option.
+        payload = f"{task.working_dir}/{_PAYLOAD_NAME}"
+        result_path = f"{task.working_dir}/{_RESULT_NAME}"
+        launcher = f"{task.working_dir}/{_LAUNCHER_NAME}"
+        await task.target.put_file(cloudpickle.dumps((func, kwargs)), payload)
+        await task.target.put_file(_LAUNCHER_SOURCE, launcher)
+
+        command = (
+            f"{self._interpreter(task)} {shlex.quote(launcher)} "
+            f"{shlex.quote(payload)} {shlex.quote(result_path)}"
+        )
+        horus_logger.log.debug(
+            _("Executing function for task %(task_id)s: %(command)s")
+            % {"task_id": task.id, "command": command}
+        )
+
+        proc = await task.target.run_command(
+            command,
+            cwd=task.working_dir,
+            env={
+                runtime_settings.SIDE_ARTIFACTS_DIR_ENV: str(
+                    task.side_artifacts_dir
+                ),
+            },
+        )
+        try:
+            async with aclosing(proc.stream()) as stream:
+                async for stream_name, line in stream:
+                    text = line.decode("utf-8", errors="replace").rstrip()
+                    if stream_name == "stdout":
+                        horus_logger.log.info(text)
+                    else:
+                        horus_logger.log.warning(text)
+        except asyncio.CancelledError:
+            proc.kill()
+            await proc.wait()
+            raise
+        await proc.wait()
+
+        outcome = await self._read_outcome(task, result_path, proc.returncode)
+        await parse_result_artifacts(task, outcome["value"])
+
+    async def _read_outcome(
+        self, task: "BaseTask", result_path: str, returncode: int | None
+    ) -> dict[str, Any]:
+        """
+        Read the launcher's outcome file and re-raise a remote failure here.
+
+        The exit code is only a fallback: what the caller needs is the
+        exception the function raised, with its own traceback. When it made it
+        back it is re-raised as itself, so ``except MyError`` around a workflow
+        run still catches what it always caught, with the target-side frames
+        attached as a note.
+        """
+        try:
+            raw = await task.target.get_file(result_path)
+            outcome: dict[str, Any] = cloudpickle.loads(raw)
+        except Exception as exc:
+            # No outcome file at all: the interpreter never got far enough to
+            # write one (missing python, missing cloudpickle, killed job). The
+            # streamed stderr above is the real diagnosis; point at it.
+            raise TaskExecutionError(
+                _(
+                    "Function subprocess for task %(task_id)s produced no "
+                    "result (exit code %(code)s); see the task log for the "
+                    "interpreter's own output. Cause: %(err)s"
+                )
+                % {
+                    "task_id": task.id,
+                    "code": returncode,
+                    "err": exc,
+                }
+            ) from exc
+
+        if outcome["ok"]:
+            return outcome
+
+        remote_traceback = outcome["traceback"] or ""
+        exception = outcome["exception"]
+        if isinstance(exception, BaseException):
+            exception.add_note(
+                _("Raised on target %(target)s:\n%(traceback)s")
+                % {
+                    "target": task.target.location_id,
+                    "traceback": remote_traceback,
+                }
+            )
+            raise exception
+        raise TaskExecutionError(
+            _("Function failed on target %(target)s:\n%(traceback)s")
+            % {
+                "target": task.target.location_id,
+                "traceback": remote_traceback,
+            }
+        )

--- a/src/horus_builtin/runtime/python.py
+++ b/src/horus_builtin/runtime/python.py
@@ -20,10 +20,11 @@ Python runtime implementation for in-memory workflows.
 """
 
 from collections.abc import Awaitable, Callable
+from importlib import import_module
 from inspect import Parameter, signature
-from typing import Any, ClassVar
+from typing import Annotated, Any, ClassVar, cast
 
-from pydantic import ConfigDict, Field
+from pydantic import BeforeValidator, ConfigDict, PlainSerializer
 
 from horus_runtime.core.artifact.base import BaseArtifact
 from horus_runtime.core.runtime.base import BaseRuntime
@@ -41,6 +42,112 @@ PythonFunctionSetupTuple = tuple[
 ]
 
 
+def import_callable(reference: str) -> Callable[..., Any]:
+    """
+    Import the callable named by a dotted *reference*.
+
+    Accepts ``package.module:function`` (preferred, unambiguous) and
+    ``package.module.function``; for the latter the last dotted component is
+    taken as the attribute, and attribute chains
+    (``module:Class.method``) work on either side.
+
+    Security note: importing by name runs the target module's top-level code,
+    so a workflow file can execute arbitrary Python. That is not a new
+    privilege (the same file can already declare a ``command`` runtime or a
+    ``python_string`` one, both of which run whatever they are given), so a
+    workflow document is trusted input either way and an import allowlist here
+    would only give the illusion of a boundary. The guardrail that does pay
+    for itself is a legible error: a typo must say which module or attribute
+    was missing instead of surfacing a bare ``ImportError`` from pydantic.
+
+    Raises:
+        ValueError: If *reference* is malformed, the module cannot be
+            imported, the attribute does not exist, or it is not callable.
+    """
+    module_name, separator, attribute = reference.partition(":")
+    if not separator:
+        module_name, _sep, attribute = reference.rpartition(".")
+    if not module_name or not attribute:
+        raise ValueError(
+            _(
+                "Invalid function reference %(ref)r: expected "
+                "'package.module:function' or 'package.module.function'."
+            )
+            % {"ref": reference}
+        )
+
+    try:
+        obj: Any = import_module(module_name)
+    except ImportError as exc:
+        raise ValueError(
+            _(
+                "Could not import module %(module)r for function reference "
+                "%(ref)r: %(err)s"
+            )
+            % {"module": module_name, "ref": reference, "err": exc}
+        ) from exc
+
+    for part in attribute.split("."):
+        try:
+            obj = getattr(obj, part)
+        except AttributeError as exc:
+            raise ValueError(
+                _(
+                    "Module %(module)r has no attribute %(attr)r "
+                    "(from function reference %(ref)r)."
+                )
+                % {
+                    "module": module_name,
+                    "attr": attribute,
+                    "ref": reference,
+                }
+            ) from exc
+
+    if not callable(obj):
+        raise ValueError(
+            _("Function reference %(ref)r resolved to a non-callable object.")
+            % {"ref": reference}
+        )
+    return cast(Callable[..., Any], obj)
+
+
+def _resolve_func(value: Any) -> Any:
+    """
+    Turn a dotted-path string into the callable it names, pass anything else
+    through untouched so handing over a real function keeps working.
+    """
+    return import_callable(value) if isinstance(value, str) else value
+
+
+def _serialize_func(func: Callable[..., Any]) -> str:
+    """
+    Dump a callable as the dotted path that imports it back.
+
+    A callable with no importable name (a lambda, a closure, a
+    ``functools.partial``) has no honest answer here; ``repr`` is emitted so
+    the dump *fails loudly on load* instead of silently omitting the field and
+    failing with "func is required", which said nothing about the cause.
+    """
+    module = getattr(func, "__module__", None)
+    qualname = getattr(func, "__qualname__", None)
+    if module and qualname:
+        return f"{module}:{qualname}"
+    return repr(func)
+
+
+FunctionReference = Annotated[
+    Callable[..., PythonFunctionReturnType],
+    BeforeValidator(_resolve_func),
+    PlainSerializer(_serialize_func, return_type=str),
+]
+"""
+A callable, or the dotted path of one. Without the string form a function
+task cannot be written in YAML at all (a pydantic ``Callable`` field rejects
+strings), which kept them out of every tool that goes through the document:
+packaging, sanitising, import.
+"""
+
+
 class PythonFunctionRuntime(BaseRuntime[PythonFunctionSetupTuple]):
     """
     Executes a python function.
@@ -55,7 +162,11 @@ class PythonFunctionRuntime(BaseRuntime[PythonFunctionSetupTuple]):
     # Allow callable types in the runtime configuration
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    func: Callable[..., PythonFunctionReturnType] = Field(..., exclude=True)
+    func: FunctionReference
+    """
+    The function to run: either the callable itself (Python workflows) or a
+    ``package.module:function`` string (YAML workflows).
+    """
 
     async def _setup_runtime(
         self, task: "BaseTask"

--- a/src/horus_builtin/task/function.py
+++ b/src/horus_builtin/task/function.py
@@ -30,6 +30,7 @@ from horus_builtin.runtime.python import PythonFunctionRuntime
 from horus_builtin.target.local import LocalTarget
 from horus_builtin.task.horus_task import HorusTask
 from horus_runtime.core.artifact.base import BaseArtifact
+from horus_runtime.core.executor.base import BaseExecutor
 from horus_runtime.core.interaction.transport import BaseInteractionTransport
 from horus_runtime.core.target.base import BaseTarget
 from horus_runtime.core.workflow.base import BaseWorkflow
@@ -50,7 +51,14 @@ class FunctionTask(HorusTask):
     """
 
     runtime: PythonFunctionRuntime
-    executor: PythonFunctionExecutor = PythonFunctionExecutor()
+    executor: BaseExecutor = PythonFunctionExecutor()
+    """
+    In-process by default, unchanged. Typed as ``BaseExecutor`` (rather than
+    the concrete in-process one) so a function task can opt into another
+    executor that accepts this runtime. ``python_function_external`` runs the
+    same function on the target instead. Compatibility is still enforced by
+    ``BaseTask`` against ``executor.runtimes``.
+    """
 
     # Default to CLI transport for interactions in FunctionTasks.
     interaction: BaseInteractionTransport = CLIInteractionTransport()

--- a/tests/unit/executor/test_python_fn_external.py
+++ b/tests/unit/executor/test_python_fn_external.py
@@ -1,0 +1,185 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Tests for ExternalPythonFunctionExecutor.
+
+These run the real thing: a real subprocess, on a real local target, with a
+real cloudpickle payload. Mocking the subprocess away would test the mock,
+and the whole point of this executor is that the work leaves the process.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from horus_builtin.artifact.file import FileArtifact
+from horus_builtin.executor.python_fn_external import (
+    ExternalPythonFunctionExecutor,
+)
+from horus_builtin.runtime.python import PythonFunctionRuntime
+from horus_builtin.target.local import LocalTarget
+from horus_builtin.task.function import FunctionTask
+from horus_runtime.core.executor.base import BaseExecutor
+from horus_runtime.core.resources import ProcessTreeScope
+from horus_runtime.core.task.exceptions import TaskExecutionError
+
+
+def make_task(
+    tmp_path: Path,
+    func: object,
+    *,
+    inputs: list[FileArtifact] | None = None,
+) -> FunctionTask:
+    """Build a FunctionTask wired to the out-of-process executor."""
+    return FunctionTask(
+        id="external_fn",
+        name="external_fn",
+        runtime=PythonFunctionRuntime(func=func),
+        executor=ExternalPythonFunctionExecutor(),
+        target=LocalTarget(working_directory=tmp_path.as_posix()),
+        inputs=inputs or [],
+    )
+
+
+@pytest.mark.unit
+class TestExternalPythonFunctionExecutor:
+    """End-to-end behaviour of the out-of-process function executor."""
+
+    async def test_runs_in_another_process_and_returns_artifacts(
+        self, tmp_path: Path
+    ) -> None:
+        """
+        The function really runs elsewhere, sees its inputs, and its returned
+        side artifacts come back.
+        """
+        source = tmp_path / "input.txt"
+        source.write_text("payload")
+        artifact = FileArtifact(id="data", path=source)
+
+        def work(data: FileArtifact) -> FileArtifact:
+            out = Path("out.txt")
+            out.write_text(f"{os.getpid()}:{Path(data.path).read_text()}")
+            return FileArtifact(id="result", path=out.resolve())
+
+        task = make_task(tmp_path, work, inputs=[artifact])
+        await task.executor.execute(task)
+
+        results = [a for a in task.side_artifacts if a.id == "result"]
+        assert len(results) == 1
+        child_pid, _, content = (
+            Path(results[0].path).read_text().partition(":")
+        )
+        assert content == "payload"
+        assert int(child_pid) != os.getpid()
+
+    async def test_closure_over_local_state(self, tmp_path: Path) -> None:
+        """
+        A closure over local state survives the trip. This is what plain
+        pickle cannot do and why cloudpickle is a dependency.
+        """
+        factor = 21
+        target_file = tmp_path / "closure.txt"
+
+        def work() -> None:
+            target_file.write_text(str(factor * 2))
+
+        task = make_task(tmp_path, work)
+        await task.executor.execute(task)
+
+        assert target_file.read_text() == "42"
+
+    async def test_failure_surfaces_original_exception(
+        self, tmp_path: Path
+    ) -> None:
+        """
+        A raising function fails the task with its own exception type and
+        message, plus the target-side traceback.
+        """
+
+        def work() -> None:
+            raise KeyError("missing-thing")
+
+        task = make_task(tmp_path, work)
+        with pytest.raises(KeyError) as excinfo:
+            await task.executor.execute(task)
+
+        assert "missing-thing" in str(excinfo.value)
+        notes = "".join(getattr(excinfo.value, "__notes__", []))
+        assert "KeyError: 'missing-thing'" in notes
+        assert "in work" in notes
+
+    async def test_rejects_a_function_that_wants_the_live_task(
+        self, tmp_path: Path
+    ) -> None:
+        """
+        The live task cannot cross a process boundary, so asking for it is
+        refused up front rather than handed a useless copy.
+        """
+
+        def work(task: object) -> None:
+            del task
+
+        task = make_task(tmp_path, work)
+        with pytest.raises(TaskExecutionError, match="'task' argument"):
+            await task.executor.execute(task)
+
+    async def test_missing_interpreter_reports_the_task(
+        self, tmp_path: Path
+    ) -> None:
+        """
+        A target with no usable interpreter fails as a task error naming the
+        task, not as an unpickling crash in the orchestrator.
+        """
+
+        def work() -> None:
+            return None
+
+        task = make_task(tmp_path, work)
+        assert isinstance(task.executor, ExternalPythonFunctionExecutor)
+        task.executor.python = "definitely-not-a-python-interpreter"
+        with pytest.raises(TaskExecutionError, match="produced no result"):
+            await task.executor.execute(task)
+
+    async def test_resource_scope_is_the_inherited_process_tree(
+        self, tmp_path: Path
+    ) -> None:
+        """
+        The executor overrides nothing: it gets a real, measurable process
+        tree from BaseExecutor purely by running its work as a command.
+        """
+        assert "resource_scope" not in vars(ExternalPythonFunctionExecutor)
+
+        target = LocalTarget(working_directory=tmp_path.as_posix())
+        proc = await target.run_command("sleep 0.1", cwd=tmp_path.as_posix())
+        try:
+            task = make_task(tmp_path, lambda: None)
+            scope = await task.executor.resource_scope(task, proc)
+        finally:
+            await proc.wait()
+
+        assert isinstance(scope, ProcessTreeScope)
+        assert scope.pid is not None
+        assert scope.pid > 0
+
+    def test_registered_under_its_kind(self) -> None:
+        """The executor is discoverable through the registry."""
+        assert (
+            BaseExecutor.registry["python_function_external"]
+            is ExternalPythonFunctionExecutor
+        )

--- a/tests/unit/runtime/test_python_function_reference.py
+++ b/tests/unit/runtime/test_python_function_reference.py
@@ -1,0 +1,167 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Tests for resolving ``PythonFunctionRuntime.func`` from a dotted path, which
+is what makes a function task expressible in YAML.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from horus_builtin.runtime.python import PythonFunctionRuntime, import_callable
+from horus_builtin.target.local import LocalTarget
+from horus_builtin.task.function import FunctionTask
+from horus_builtin.workflow.horus_workflow import HorusWorkflow
+from horus_runtime.context import HorusContext
+from horus_runtime.core.workflow.base import BaseWorkflow
+
+MODULE_SOURCE = """
+from pathlib import Path
+
+NOT_CALLABLE = 42
+
+
+def work():
+    Path("ran.txt").write_text("ok")
+
+
+class Steps:
+    @staticmethod
+    def nested():
+        return None
+"""
+
+
+@pytest.fixture
+def function_module(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> str:
+    """
+    Write an importable module of task functions and put it on ``sys.path``,
+    the way a user's own workflow package would be.
+    """
+    name = f"horus_test_functions_{abs(hash(tmp_path)) % 10**8}"
+    (tmp_path / f"{name}.py").write_text(MODULE_SOURCE)
+    monkeypatch.syspath_prepend(str(tmp_path))
+    return name
+
+
+@pytest.mark.unit
+class TestImportCallable:
+    """Resolution rules and error messages."""
+
+    def test_colon_form(self, function_module: str) -> None:
+        """``module:function`` resolves."""
+        assert import_callable(f"{function_module}:work").__name__ == "work"
+
+    def test_dotted_form(self, function_module: str) -> None:
+        """``module.function`` resolves too."""
+        assert import_callable(f"{function_module}.work").__name__ == "work"
+
+    def test_attribute_chain(self, function_module: str) -> None:
+        """A reference may walk into a class."""
+        resolved = import_callable(f"{function_module}:Steps.nested")
+        assert resolved() is None
+
+    def test_unknown_module_names_the_module(self) -> None:
+        """A missing module is reported by name, not as a bare ImportError."""
+        with pytest.raises(ValueError, match="no_such_module_here"):
+            import_callable("no_such_module_here:work")
+
+    def test_unknown_attribute_names_the_attribute(
+        self, function_module: str
+    ) -> None:
+        """A typo in the function name says which attribute was missing."""
+        with pytest.raises(ValueError, match="typo"):
+            import_callable(f"{function_module}:typo")
+
+    def test_non_callable_is_rejected(self, function_module: str) -> None:
+        """Pointing at a constant is an error, not a runtime surprise."""
+        with pytest.raises(ValueError, match="non-callable"):
+            import_callable(f"{function_module}:NOT_CALLABLE")
+
+    def test_malformed_reference(self) -> None:
+        """A bare name cannot name both a module and an attribute."""
+        with pytest.raises(ValueError, match="Invalid function reference"):
+            import_callable("work")
+
+
+@pytest.mark.unit
+class TestPythonFunctionRuntimeFunc:
+    """The runtime field itself."""
+
+    def test_accepts_a_real_callable_unchanged(self) -> None:
+        """Passing a function keeps working exactly as before."""
+
+        def work() -> None:
+            return None
+
+        assert PythonFunctionRuntime(func=work).func is work
+
+    def test_accepts_a_reference_string(self, function_module: str) -> None:
+        """A dotted path is resolved at validation time."""
+        runtime = PythonFunctionRuntime(func=f"{function_module}:work")
+        assert callable(runtime.func)
+
+    def test_serializes_back_to_a_reference(
+        self, function_module: str
+    ) -> None:
+        """The dump is the string that imports the function again."""
+        runtime = PythonFunctionRuntime(func=f"{function_module}:work")
+        assert runtime.model_dump(mode="json")["func"] == (
+            f"{function_module}:work"
+        )
+
+
+@pytest.mark.unit
+class TestYamlRoundTrip:
+    """A function task written as YAML loads and runs."""
+
+    async def test_round_trip_and_run(
+        self,
+        tmp_path: Path,
+        function_module: str,
+        horus_context: HorusContext,
+    ) -> None:
+        """``to_yaml`` -> ``from_yaml`` -> ``run`` on a dotted-path task."""
+        del horus_context
+        wf = HorusWorkflow(
+            name="wf",
+            orchestrator_target=LocalTarget(
+                working_directory=tmp_path.as_posix()
+            ),
+        )
+        wf.tasks.append(
+            FunctionTask(
+                id="step",
+                name="step",
+                runtime=PythonFunctionRuntime(func=f"{function_module}:work"),
+            )
+        )
+
+        out_path = tmp_path / "workflow.yaml"
+        wf.to_yaml(out_path)
+        dumped = yaml.safe_load(out_path.read_text())
+        step = next(t for t in dumped["tasks"] if t["id"] == "step")
+        assert step["runtime"]["func"] == f"{function_module}:work"
+
+        loaded = BaseWorkflow.from_yaml(out_path)
+        await loaded.run(trigger_id="step")
+
+        task = next(t for t in loaded.tasks if t.id == "step")
+        assert (Path(task.working_dir) / "ran.txt").read_text() == "ok"

--- a/uv.lock
+++ b/uv.lock
@@ -7,7 +7,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-30T08:07:05.233251Z"
+exclude-newer = "2026-07-30T08:30:15.328059Z"
 exclude-newer-span = "P2D"
 
 [options.exclude-newer-package]
@@ -51,6 +51,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
+]
+
+[[package]]
+name = "cloudpickle"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
 ]
 
 [[package]]
@@ -166,6 +175,7 @@ name = "horus-runtime"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
+    { name = "cloudpickle" },
     { name = "loguru" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -190,6 +200,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = ">=8.3.3" },
+    { name = "cloudpickle", specifier = ">=3.0" },
     { name = "loguru", specifier = "~=0.7" },
     { name = "pydantic", specifier = "~=2.0" },
     { name = "pydantic-settings", specifier = "~=2.0" },


### PR DESCRIPTION
**Stacked on #142** (base is `feat/resource-scope-interface`, so this diff is only the executor work).

## Why

`PythonFunctionExecutor` calls `func(**args)` in the orchestrator process and **ignores `task.target` entirely**. A `FunctionTask` with an `SSHTarget` runs on the orchestrator, not the remote host — a correctness bug, not just a metrics gap.

It is also unmeasurable: no process exists to attribute usage to. A coverage harness (temple-compute/pantheon#13) confirms `python_function` reports **0.0 MB / 0% CPU** while doing 300 MB of real work.

## Part 1: `ExternalPythonFunctionExecutor` (kind `python_function_external`)

cloudpickles `(func, kwargs)`, `put_file`s it plus a launcher into the working dir, and runs it with `target.run_command`. Opt-in — the default for `FunctionTask` is unchanged.

**cloudpickle, not pickle**: closures over local state are a documented, supported pattern for programmatic workflows, and a test proves one survives (`factor = 21` → writes `42`). It is what Dask/Ray/Prefect use for this.

Because the work is now an ordinary spawned process, it inherits #142's default `ProcessTreeScope` and becomes measurable **with no override at all** — a test asserts `"resource_scope" not in vars(...)` precisely to pin that down. That is the abstraction paying for itself.

### The two judgement calls

**Interpreter.** `python: str | None = None`. `None` means the orchestrator's own `sys.executable` when the target is orchestrator-local (that interpreter *provably* has cloudpickle and horus-runtime — it is running this code), else plain `python`, the only defensible assumption for a machine we have never seen. Environment management is not reimplemented: the horus-environments executors already put an interpreter at a known path, so composing is `python: .horus_python_environment/bin/python`.

**`task` passing is refused, loudly.** `PythonFunctionRuntime` injects the live task whenever the signature asks for it. If it does, the executor raises before spawning anything, naming the task and pointing at the in-process executor. A lookalike copy on the far side of a pipe would *look* right and silently do nothing — DAG edits, mutations and interactions would all die with the subprocess. This also enforces the documented `workflow.add_task()`-from-inside-a-task limitation mechanically rather than only in prose.

**Errors keep their identity.** The launcher writes a cloudpickled outcome; on failure the orchestrator re-raises the **original exception object** with the target-side traceback attached via `add_note()`, so `except MyError` still catches what it always caught. Exit code is a fallback only. If the exception will not pickle, the traceback text survives as a `TaskExecutionError`; if no outcome file exists at all (no interpreter, killed job), you get an error naming the task and pointing at the streamed stderr rather than an unpickling crash.

## Part 2: `python_function` is now expressible in YAML

`PythonFunctionRuntime.func` was a pydantic `Callable`, so a dotted path failed validation — meaning function tasks could not be written in YAML, packaged, sanitized, or imported by downstream tools at all. Adds `import_callable()` accepting `pkg.mod:func` and `pkg.mod.func` (including attribute chains like `mod:Class.method`), with real callables passing through untouched. Covered by a full `to_yaml` → `from_yaml` → `run` round-trip that actually executes.

`FunctionTask.executor` widened from `PythonFunctionExecutor` to `BaseExecutor` (default unchanged) — the narrow annotation made the new executor unusable on the very task type it targets. Compatibility is still enforced by `BaseTask._validate_runtime_compatibility`.

## Tests

**687 pass** (669 before, +18); ruff and mypy strict clean. The new tests are real subprocesses against a real target with real cloudpickle payloads, not mocks: child pid differs from `os.getpid()`, artifacts round-trip, a closure works, a raising function surfaces `KeyError: 'missing-thing'` with the remote traceback in the note, a `task`-taking function is refused, a bad interpreter gives a clear error.

## Things to know before merging

- **No remote target was exercised** — only `LocalTarget` exists in this repo. The SSH path is correct by construction (it uses only `mkdir`/`put_file`/`run_command`/`get_file`) but untested. Worth a horus-ssh smoke test before anyone relies on it.
- **`model_dump` for `python_function` now emits `func`** where it was previously excluded. For an importable function that is the fix. For a closure it emits a deterministic dotted path that is not importable, so loading fails loudly instead of the old silent-drop-then-"field required". Visible change for anyone diffing YAML; `test_sanitize` and `test_packaging` are green.
- **No `sys.path` or env propagation to the child** beyond `HORUS_SIDE_ARTIFACTS_DIR`. A function relying on the orchestrator's `sys.path` will `ModuleNotFoundError`. Correct semantics for a remote executor, but a real difference from `python_function` that users will hit locally first.
- **cloudpickle pickles module-level functions by reference**, so tests must define their functions inside the test body or the child cannot import them. Anyone adding tests here will trip on this.

## Docs
- [X] No documentation update required

