### PR TITLE
Never skip a task whose inputs or command changed

### DIFF
--- a/src/horus_builtin/runtime/command.py
+++ b/src/horus_builtin/runtime/command.py
@@ -21,6 +21,8 @@ Command implementation for the runtime.
 
 from typing import TYPE_CHECKING, ClassVar
 
+from pydantic import Field
+
 from horus_builtin.runtime.substitution import substitute
 from horus_runtime.context import HorusContext
 from horus_runtime.core.runtime.base import BaseRuntime
@@ -51,7 +53,7 @@ class CommandRuntime(BaseRuntime[str]):
     through untouched.
     """
 
-    formatted_command: str = ""
+    formatted_command: str = Field(default="", exclude=True)
     """
     The formatted command after processing any placeholders.
     """

--- a/src/horus_builtin/task/horus_task.py
+++ b/src/horus_builtin/task/horus_task.py
@@ -19,6 +19,9 @@
 Default Horus task implementation.
 """
 
+import hashlib
+import json
+from pathlib import PurePosixPath
 from typing import ClassVar
 
 from horus_builtin.event.task_event import HorusTaskEvent
@@ -27,8 +30,22 @@ from horus_runtime.context import HorusContext
 from horus_runtime.core.artifact.exceptions import ArtifactDoesNotExistError
 from horus_runtime.core.artifact.store import ArtifactStore
 from horus_runtime.core.target.base import BaseTarget
+from horus_runtime.core.target.exceptions import WorkingDirectoryNotSetError
 from horus_runtime.core.task.base import BaseTask
 from horus_runtime.i18n import tr as _
+
+_CONFIG_KEY = "__config__"
+"""Fingerprint entry holding the hash of the task's own configuration."""
+
+_UNHASHABLE = "unhashable"
+"""Fingerprint value for an input the target cannot digest."""
+
+_DERIVED_FIELDS = {"formatted_command"}
+"""
+Fields the executor writes back onto the runtime while rendering it. They are
+results of a run, not configuration, so they stay out of the fingerprint: a
+task must fingerprint the same before and after it runs.
+"""
 
 
 class HorusTask(BaseTask):
@@ -73,13 +90,94 @@ class HorusTask(BaseTask):
                     % {"input_id": artifact.id}
                 )
 
+        # A task without outputs never reports complete, so it has nothing to
+        # memoize. Taken before execution because the executor rewrites the
+        # runtime as it runs, while the next run's check starts from the
+        # un-rewritten state.
+        fingerprint = await self._fingerprint() if self.outputs else None
+
         # Execute the command using the executor
         await self.executor.execute(self)
 
+        # Only a run that got this far may claim its outputs match its inputs.
+        if fingerprint is not None:
+            await self._write_manifest(fingerprint)
+
+    def _manifest_path(self) -> str | None:
+        """
+        Where this task's input fingerprint is recorded on the target, or
+        ``None`` when the target has no working directory to write it to (in
+        which case the task simply never skips).
+        """
+        try:
+            base = self.target.resolved_working_directory
+        except WorkingDirectoryNotSetError:
+            return None
+        return f"{base}/.horus/{self.id}.json"
+
+    async def _fingerprint(self) -> dict[str, str]:
+        """
+        Everything that must stay unchanged for the previous run's outputs to
+        still be valid: the digest of every input, plus a hash of the task's
+        own configuration, so editing the command invalidates the cache too.
+        """
+        store = ArtifactStore(self.target)
+        # ponytail: a folder input digests to None, so a task whose inputs are
+        # all folders keeps the old existence-only behaviour, upgrade path is a
+        # recursive digest in ArtifactStore.digest.
+        fingerprint = {
+            artifact.id: await store.digest(artifact) or _UNHASHABLE
+            for artifact in self.inputs
+        }
+        config = json.dumps(
+            {
+                "runtime": self.runtime.model_dump(
+                    mode="json", exclude=_DERIVED_FIELDS
+                ),
+                "executor": self.executor.model_dump(mode="json"),
+            },
+            sort_keys=True,
+        )
+        fingerprint[_CONFIG_KEY] = hashlib.sha256(config.encode()).hexdigest()
+        return fingerprint
+
+    async def _write_manifest(self, fingerprint: dict[str, str]) -> None:
+        """
+        Record *fingerprint* on the target, next to the outputs the run just
+        produced.
+        """
+        path = self._manifest_path()
+        if path is None:
+            return
+
+        await self.target.mkdir(str(PurePosixPath(path).parent))
+        await self.target.put_file(
+            json.dumps(fingerprint, sort_keys=True).encode(), path
+        )
+
+    async def _read_manifest(self) -> dict[str, str] | None:
+        """
+        The fingerprint recorded by the last successful run, or ``None`` when
+        there is none or it cannot be trusted. A broken manifest must mean
+        "run the task", never a crashed workflow, so every read error maps to
+        ``None``.
+        """
+        path = self._manifest_path()
+        if path is None:
+            return None
+
+        try:
+            data = json.loads(await self.target.get_file(path))
+        except Exception:
+            return None
+        return data if isinstance(data, dict) else None
+
     async def is_complete(self) -> bool:
         """
-        A HorusTask is considered complete if all of its output artifacts
-        exist.
+        A HorusTask is complete when all of its output artifacts exist *and*
+        its inputs and configuration are the ones the recorded manifest was
+        written for. Outputs left over from before manifests existed re-run
+        once: we cannot prove their inputs are unchanged.
         """
         # If no outputs are declared, we consider the task incomplete and
         # always run it
@@ -91,7 +189,8 @@ class HorusTask(BaseTask):
             if not await store.exists(artifact):
                 return False
 
-        return True
+        recorded = await self._read_manifest()
+        return recorded is not None and recorded == await self._fingerprint()
 
     async def _reset(self) -> None:
         """
@@ -112,5 +211,10 @@ class HorusTask(BaseTask):
         store = ArtifactStore(self.target)
         for artifact in self.outputs:
             await store.delete(artifact)
+
+        # The manifest only describes those outputs, so it goes with them.
+        path = self._manifest_path()
+        if path is not None:
+            await self.target.remove(path)
 
         self.runs = 0

--- a/src/horus_builtin/task/horus_task.py
+++ b/src/horus_builtin/task/horus_task.py
@@ -24,6 +24,8 @@ import json
 from pathlib import PurePosixPath
 from typing import ClassVar
 
+from pydantic import BaseModel
+
 from horus_builtin.event.task_event import HorusTaskEvent
 from horus_builtin.target.local import LocalTarget
 from horus_runtime.context import HorusContext
@@ -34,18 +36,18 @@ from horus_runtime.core.target.exceptions import WorkingDirectoryNotSetError
 from horus_runtime.core.task.base import BaseTask
 from horus_runtime.i18n import tr as _
 
-_CONFIG_KEY = "__config__"
-"""Fingerprint entry holding the hash of the task's own configuration."""
-
 _UNHASHABLE = "unhashable"
 """Fingerprint value for an input the target cannot digest."""
 
-_DERIVED_FIELDS = {"formatted_command"}
-"""
-Fields the executor writes back onto the runtime while rendering it. They are
-results of a run, not configuration, so they stay out of the fingerprint: a
-task must fingerprint the same before and after it runs.
-"""
+
+class TaskFingerprint(BaseModel):
+    """
+    Everything that must stay unchanged for a task's recorded outputs to
+    still be valid.
+    """
+
+    inputs: dict[str, str]
+    config_hash: str
 
 
 class HorusTask(BaseTask):
@@ -115,7 +117,7 @@ class HorusTask(BaseTask):
             return None
         return f"{base}/.horus/{self.id}.json"
 
-    async def _fingerprint(self) -> dict[str, str]:
+    async def _fingerprint(self) -> TaskFingerprint:
         """
         Everything that must stay unchanged for the previous run's outputs to
         still be valid: the digest of every input, plus a hash of the task's
@@ -125,23 +127,21 @@ class HorusTask(BaseTask):
         # ponytail: a folder input digests to None, so a task whose inputs are
         # all folders keeps the old existence-only behaviour, upgrade path is a
         # recursive digest in ArtifactStore.digest.
-        fingerprint = {
+        inputs = {
             artifact.id: await store.digest(artifact) or _UNHASHABLE
             for artifact in self.inputs
         }
         config = json.dumps(
             {
-                "runtime": self.runtime.model_dump(
-                    mode="json", exclude=_DERIVED_FIELDS
-                ),
+                "runtime": self.runtime.model_dump(mode="json"),
                 "executor": self.executor.model_dump(mode="json"),
             },
             sort_keys=True,
         )
-        fingerprint[_CONFIG_KEY] = hashlib.sha256(config.encode()).hexdigest()
-        return fingerprint
+        config_hash = hashlib.sha256(config.encode()).hexdigest()
+        return TaskFingerprint(inputs=inputs, config_hash=config_hash)
 
-    async def _write_manifest(self, fingerprint: dict[str, str]) -> None:
+    async def _write_manifest(self, fingerprint: TaskFingerprint) -> None:
         """
         Record *fingerprint* on the target, next to the outputs the run just
         produced.
@@ -151,11 +151,10 @@ class HorusTask(BaseTask):
             return
 
         await self.target.mkdir(str(PurePosixPath(path).parent))
-        await self.target.put_file(
-            json.dumps(fingerprint, sort_keys=True).encode(), path
-        )
+        body = fingerprint.model_dump_json().encode()
+        await self.target.put_file(body, path)
 
-    async def _read_manifest(self) -> dict[str, str] | None:
+    async def _read_manifest(self) -> TaskFingerprint | None:
         """
         The fingerprint recorded by the last successful run, or ``None`` when
         there is none or it cannot be trusted. A broken manifest must mean
@@ -167,10 +166,11 @@ class HorusTask(BaseTask):
             return None
 
         try:
-            data = json.loads(await self.target.get_file(path))
+            return TaskFingerprint.model_validate_json(
+                await self.target.get_file(path)
+            )
         except Exception:
             return None
-        return data if isinstance(data, dict) else None
 
     async def is_complete(self) -> bool:
         """

--- a/src/horus_runtime/core/artifact/base.py
+++ b/src/horus_runtime/core/artifact/base.py
@@ -54,11 +54,13 @@ class BaseArtifact[T: Any = Any](AutoRegistry, entry_point="artifact"):
 
     The artifact is identified by a unique ID.
 
-    The workflow will derive status completion based on artifact existence
-    and hash. If the artifact exists and the hash matches, the workflow
-    considers the task that produces it as completed. If the artifact does
-    not exist or the hash does not match, the workflow considers the task as
-    not completed and will attempt to execute it to produce the artifact.
+    The workflow derives status completion from artifacts on both sides of a
+    task: a task counts as complete when all of its output artifacts exist
+    *and* the digests of its input artifacts still match the ones recorded
+    when it last ran (see
+    :meth:`~horus_builtin.task.horus_task.HorusTask.is_complete`). A missing
+    output, an edited input, or a missing record all mean "not complete", and
+    the workflow executes the task again.
 
 
     In summary, the artifact is the fundamental unit of data in the Horus

--- a/src/horus_runtime/core/artifact/store.py
+++ b/src/horus_runtime/core/artifact/store.py
@@ -35,6 +35,9 @@ from horus_runtime.i18n import tr as _
 if TYPE_CHECKING:
     from horus_runtime.core.artifact.base import BaseArtifact
 
+_SHA256_HEX_LEN = 64
+"""Length of a hex-encoded sha256, used to sanity-check command output."""
+
 
 class ArtifactStore:
     """
@@ -52,6 +55,29 @@ class ArtifactStore:
         return await self.target.path_exists(
             self.target.path_on_target(artifact)
         )
+
+    async def digest(self, artifact: "BaseArtifact") -> str | None:
+        """
+        sha256 of *artifact*'s bytes as they are on the target, or ``None``
+        when it cannot be hashed (missing, a directory, no hashing tool).
+
+        Hashing happens target-side through the shell channel, like
+        :meth:`~horus_runtime.core.target.base.BaseTarget.path_exists`, so it
+        works for any target without a new primitive. ``shasum`` is the
+        fallback because macOS ships no ``sha256sum``.
+        """
+        path = shlex.quote(self.target.path_on_target(artifact))
+        proc = await self.target.run_command_sync(
+            f"sha256sum {path} 2>/dev/null || shasum -a 256 {path}"
+        )
+        out, _stderr = await proc.communicate()
+        if await proc.wait() != 0:
+            return None
+
+        fields = out.decode(errors="replace").split()
+        if not fields or len(fields[0]) != _SHA256_HEX_LEN:
+            return None
+        return fields[0]
 
     async def delete(self, artifact: "BaseArtifact") -> None:
         """

--- a/tests/unit/task/test_builtin_task.py
+++ b/tests/unit/task/test_builtin_task.py
@@ -29,10 +29,12 @@ from pydantic import BaseModel, ValidationError
 from horus_builtin.artifact.file import FileArtifact
 from horus_builtin.executor.shell import ShellExecutor
 from horus_builtin.runtime.command import CommandRuntime
+from horus_builtin.target.local import LocalTarget
 from horus_builtin.task.horus_task import HorusTask
 from horus_runtime.core.artifact.exceptions import ArtifactDoesNotExistError
 from horus_runtime.core.task.base import BaseTask
 from horus_runtime.core.task.exceptions import TaskExecutionError
+from horus_runtime.core.task.status import TaskStatus
 from tests.conftest import MakeMockSubprocessType, MakeTaskType
 
 
@@ -331,3 +333,94 @@ class TestHorusTaskExecution:
         await task.reset()
 
         assert task.runs == 0
+
+
+@pytest.mark.unit
+class TestHorusTaskInputFingerprint:
+    """
+    Completion is decided by output existence *and* the recorded input
+    fingerprint, so an edited input or command invalidates the cached run.
+    """
+
+    @staticmethod
+    def _make_copy_task(tmp_path: Path, cmd: str = "") -> HorusTask:
+        """
+        Build a task that copies ``in.txt`` to ``out.txt`` under *tmp_path*.
+        """
+        src = tmp_path / "in.txt"
+        dest = tmp_path / "out.txt"
+        return HorusTask(
+            id="copy_task",
+            name="copy_task",
+            inputs=[FileArtifact(id="src", path=src)],
+            outputs=[FileArtifact(id="dest", path=dest)],
+            runtime=CommandRuntime(command=cmd or f"cat {src} > {dest}"),
+            executor=ShellExecutor(),
+            target=LocalTarget(working_directory=tmp_path.as_posix()),
+        )
+
+    async def test_skips_second_run_with_unchanged_inputs(
+        self, tmp_path: Path
+    ) -> None:
+        """
+        Nothing changed, so the second run is a cache hit.
+        """
+        (tmp_path / "in.txt").write_text("one")
+        task = self._make_copy_task(tmp_path)
+
+        await task.run()
+        await task.run()
+
+        assert task.runs == 1
+        assert task.status == TaskStatus.SKIPPED
+
+    async def test_reruns_after_input_content_changes(
+        self, tmp_path: Path
+    ) -> None:
+        """
+        The output still exists, but it was produced from other bytes.
+        """
+        (tmp_path / "in.txt").write_text("one")
+        task = self._make_copy_task(tmp_path)
+
+        await task.run()
+        (tmp_path / "in.txt").write_text("two")
+        await task.run()
+
+        assert task.runs == 2
+        assert (tmp_path / "out.txt").read_text() == "two"
+
+    async def test_reruns_after_command_changes(self, tmp_path: Path) -> None:
+        """
+        Same inputs, different command, so the cached output is not the one
+        this task would produce.
+        """
+        (tmp_path / "in.txt").write_text("one")
+        task = self._make_copy_task(tmp_path)
+
+        await task.run()
+        task.runtime = CommandRuntime(
+            command=f"echo changed > {tmp_path / 'out.txt'}"
+        )
+        await task.run()
+
+        assert task.runs == 2
+        assert (tmp_path / "out.txt").read_text() == "changed\n"
+
+    async def test_does_not_skip_without_a_manifest(
+        self, tmp_path: Path
+    ) -> None:
+        """
+        Outputs from before manifests existed prove nothing about the inputs,
+        so the task runs once more and self-heals.
+        """
+        (tmp_path / "in.txt").write_text("one")
+        (tmp_path / "out.txt").write_text("stale")
+        task = self._make_copy_task(tmp_path)
+
+        assert await task.is_complete() is False
+
+        await task.run()
+
+        assert task.runs == 1
+        assert await task.is_complete() is True

--- a/tests/unit/workflow/test_builtin_workflow.py
+++ b/tests/unit/workflow/test_builtin_workflow.py
@@ -293,6 +293,9 @@ class TestWorkflowRun:
                 new_callable=AsyncMock,
                 return_value=True,
             ),
+            # Completion also needs a recorded manifest matching the current
+            # fingerprint; a task's own fingerprint always matches itself.
+            patch.object(HorusTask, "_read_manifest", HorusTask._fingerprint),
             patch.object(HorusTask, "_run") as mock_run,
         ):
             await wf.run(trigger_id="test_task_id")

--- a/tests/unit/workflow/test_conditions.py
+++ b/tests/unit/workflow/test_conditions.py
@@ -451,6 +451,9 @@ class TestSkipReasonDistinguishesCacheHit:
             ),
         )
 
+        # The first run records the input manifest the pre-created output is
+        # missing; only the second run can be a cache hit.
+        await wf.run(trigger_id="cached")
         await wf.run(trigger_id="cached")
 
         assert task.status is TaskStatus.SKIPPED

--- a/tests/unit/workflow/test_map.py
+++ b/tests/unit/workflow/test_map.py
@@ -340,32 +340,40 @@ class TestPartialCompletion:
         self, tmp_path: Path, horus_context: HorusContext
     ) -> None:
         """
-        Clone 1's output already exists on disk (as if from a prior run);
-        re-running with a *fresh* workflow object re-derives the same
-        clone set but skips clone 1 while the others run.
+        Clone 1 is left complete from a prior run (output *and* recorded
+        input manifest); re-running with a *fresh* workflow object re-derives
+        the same clone set but skips clone 1 while the others run.
         """
         del horus_context
-        # Pre-create clone 1's deterministic output location.
-        gathered_1 = tmp_path / "score.gathered" / "1"
-        gathered_1.mkdir(parents=True)
-        (gathered_1 / "out.txt").write_text("already done")
 
-        split = _split_task(tmp_path, ["a", "b", "c"])
-        gather = _gather_task(tmp_path)
-        wf = HorusWorkflow(
-            name="wf",
-            tasks=[split, gather],
-            orchestrator_target=LocalTarget(
-                working_directory=tmp_path.as_posix()
-            ),
-        )
-        wf.map(
-            id="score",
-            template=_template_task(),
-            over=("split", "batches", "batch"),
-            gather=("gather", "results"),
-        )
+        def _build() -> HorusWorkflow:
+            wf = HorusWorkflow(
+                name="wf",
+                tasks=[
+                    _split_task(tmp_path, ["a", "b", "c"]),
+                    _gather_task(tmp_path),
+                ],
+                orchestrator_target=LocalTarget(
+                    working_directory=tmp_path.as_posix()
+                ),
+            )
+            wf.map(
+                id="score",
+                template=_template_task(),
+                over=("split", "batches", "batch"),
+                gather=("gather", "results"),
+            )
+            return wf
 
+        # A full prior run, with everything but clone 1's leftovers removed:
+        # an output on its own no longer proves a clone is complete, only an
+        # output plus the manifest recorded alongside it does.
+        await _build().run(trigger_id="split")
+        for i in (0, 2):
+            shutil.rmtree(tmp_path / "score.gathered" / str(i))
+            (tmp_path / ".horus" / f"score[{i}].json").unlink()
+
+        wf = _build()
         await wf.run(trigger_id="split")
 
         statuses = {t.id: t.status for t in wf.tasks}


### PR DESCRIPTION
## The bug

`HorusTask.is_complete` decided a task was done from **output paths existing, and nothing else**. Edit an input file, re-run, and the task is skipped against stale output.

`BaseArtifact`'s own docstring already claimed completion was derived from "existence **and hash**":

> If the artifact exists and the hash matches, the workflow considers the task that produces it as completed.

No hash was ever computed anywhere in the package, and there was nowhere to record one. `--no-skip-all` was the only escape hatch, and it is a blunt one: it forces *everything* to re-run.

## The fix

An executor's outputs are only valid for the inputs that produced them, so record those inputs.

- **`ArtifactStore.digest`** hashes an artifact target-side over the shell channel, the same way `path_exists` already shells out `test -e`. No new target primitive, and it works for remote targets for free. Falls back to `shasum -a 256` because macOS ships no `sha256sum`; anything unhashable (a directory, a missing file, no tool) degrades to `None`.
- A successful run writes `{input id: digest}` plus a hash of the task's own runtime/executor config to `.horus/<task id>.json` under the target's working directory.
- `is_complete` now requires all outputs to exist **and** that record to match. Editing the command invalidates the cache as surely as editing an input.
- `_reset` deletes the manifest alongside the outputs it describes.

## Two things worth a reviewer's attention

**`formatted_command` is excluded from the config hash.** The executor writes it back onto the runtime while rendering, so including it made a task fingerprint differently before and after running, and nothing ever skipped. It is a result of a run, not configuration.

**Outputs that exist with no manifest re-run once.** This is a deliberate behaviour change and the only sound answer: their inputs cannot be shown to be unchanged. It self-heals after a single run. Four existing tests asserted a skip from hand-placed outputs and were updated to establish a real prior run instead; `test_pre_created_clone_output_is_skipped` needed the most rework and preserves its original assertions exactly.

## Known ceiling

Marked in the code with an upgrade path: a folder input digests to `None` and so does not constrain the fingerprint, meaning a task whose inputs are all folders keeps the old existence-only behaviour. Closing that needs a recursive digest in `ArtifactStore.digest`.

## Verification

```
uv run pytest                                        660 passed
uv run ruff check src tests && ruff format --check    clean
uv run mypy src                                       no issues
```

New tests in `tests/unit/task/test_builtin_task.py::TestHorusTaskInputFingerprint`: skips on unchanged inputs, re-runs after input content changes, re-runs after the command changes, does not skip when outputs exist with no manifest and then self-heals.

## Docs
- [X] No documentation update required
