### PR TITLE
Shell-quote substituted artifact paths in command/script args

### DIFF
--- a/src/horus_builtin/runtime/command.py
+++ b/src/horus_builtin/runtime/command.py
@@ -63,7 +63,7 @@ class CommandRuntime(BaseRuntime[str]):
         Render ``$``/``${}`` placeholders in the command against *task*'s
         artifacts and task namespace, then emit a ``RuntimeEvent``.
         """
-        fmt = substitute(self.command, task)
+        fmt = substitute(self.command, task, quote=True)
 
         self.formatted_command = fmt
 

--- a/src/horus_builtin/runtime/python_script.py
+++ b/src/horus_builtin/runtime/python_script.py
@@ -97,7 +97,7 @@ class PythonScriptRuntime(CommandRuntime):
             # which the executor uses as cwd and where the outputs land.
             await task.target.put_file(self.script, remote_path)
 
-        args = substitute(self.args, task) if self.args else ""
+        args = substitute(self.args, task, quote=True) if self.args else ""
         cmd = f"{self.python} {shlex.quote(remote_path)} {args}".rstrip()
         self.formatted_command = cmd
 

--- a/src/horus_builtin/runtime/substitution.py
+++ b/src/horus_builtin/runtime/substitution.py
@@ -35,6 +35,7 @@ Unknown ``$name`` references are left as-is (``safe_substitute`` semantics).
 Use ``$$`` to emit a literal ``$``.
 """
 
+import shlex
 from collections.abc import Iterator, Mapping
 from string import Template
 from typing import TYPE_CHECKING
@@ -98,12 +99,13 @@ class _Resolver(Mapping[str, str]):
     :exc:`KeyError` so ``safe_substitute`` leaves the placeholder intact.
     """
 
-    def __init__(self, task: "BaseTask") -> None:
+    def __init__(self, task: "BaseTask", *, quote: bool = False) -> None:
         self._roots: dict[str, object] = {
             a.id: _ArtifactRef(a, task.target)
             for a in (*task.inputs, *task.outputs)
         }
         self._roots["task"] = _TaskNamespace(task)
+        self._quote = quote
 
     def __getitem__(self, key: str) -> str:
         parts = key.split(".")
@@ -115,7 +117,7 @@ class _Resolver(Mapping[str, str]):
                 obj = getattr(obj, part)
             except AttributeError as exc:
                 raise KeyError(key) from exc
-        return str(obj)
+        return shlex.quote(str(obj)) if self._quote else str(obj)
 
     def __iter__(self) -> "Iterator[str]":
         return iter(self._roots)
@@ -139,7 +141,7 @@ def is_template(value: "str | PurePath") -> bool:
     return "$" in str(value).replace("$$", "")
 
 
-def substitute(template: str, task: "BaseTask") -> str:
+def substitute(template: str, task: "BaseTask", *, quote: bool = False) -> str:
     """
     Render *template* against *task* using ``string.Template`` ``$``/``${}``
     syntax.
@@ -149,6 +151,14 @@ def substitute(template: str, task: "BaseTask") -> str:
     * ``${task.attr}``     — attribute of the task
     * Unknown placeholders are left as-is (``safe_substitute`` semantics).
     * ``$$`` emits a literal ``$``.
+
+    ``quote`` shell-quotes each resolved value individually (via
+    ``shlex.quote``) before it is substituted in, so a path containing spaces
+    or shell metacharacters lands as a single word instead of being split by
+    the shell that later runs the rendered string. Pass it whenever the
+    result is handed to a shell unquoted; leave it off when the result is
+    itself wrapped in ``shlex.quote`` afterwards, or isn't shell text at all
+    (e.g. Python source).
 
     Raises :exc:`ValueError` if any artifact has the reserved id ``"task"``.
     """
@@ -160,4 +170,4 @@ def substitute(template: str, task: "BaseTask") -> str:
                 "Please rename this artifact."
             )
         )
-    return _DotTemplate(template).safe_substitute(_Resolver(task))
+    return _DotTemplate(template).safe_substitute(_Resolver(task, quote=quote))

--- a/tests/unit/runtime/test_python_script.py
+++ b/tests/unit/runtime/test_python_script.py
@@ -106,6 +106,38 @@ async def test_python_script_quotes_remote_path_with_spaces(
 
 
 @pytest.mark.usefixtures("horus_context")
+async def test_python_script_quotes_args_with_spaces(
+    tmp_path: Path,
+) -> None:
+    """
+    An artifact path with a space substituted into ``args`` is shell-quoted
+    as one word, not split into two positional args (regression: this used
+    to reach argparse as separate, "unrecognized" tokens).
+    """
+    work = tmp_path / "my project"
+    work.mkdir()
+    script = tmp_path / "job.py"
+    script.write_text("print('hi')\n")
+
+    result = JSONArtifact(id="result", path=work / "result.json")
+    task = HorusTask(
+        id="run",
+        name="run",
+        runtime=PythonScriptRuntime(script=script, args="$result"),
+        executor=ShellExecutor(),
+        target=LocalTarget(working_directory=work.as_posix()),
+        outputs=[result],
+    )
+
+    cmd = await task.runtime.setup_runtime(task)
+
+    placed = Path(task.working_dir) / "job.py"
+    expected_args = shlex.quote(str(result.path))
+    assert cmd == f"python {shlex.quote(str(placed))} {expected_args}"
+    assert len(shlex.split(cmd)) == 3
+
+
+@pytest.mark.usefixtures("horus_context")
 async def test_python_script_templated_script_uses_input_artifact(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/runtime/test_substitution.py
+++ b/tests/unit/runtime/test_substitution.py
@@ -20,6 +20,7 @@ Unit tests for the shared ``substitute`` helper in
 ``horus_builtin.runtime.substitution``.
 """
 
+import shlex
 from pathlib import Path
 
 import pytest
@@ -130,6 +131,25 @@ async def test_command_runtime_result_path_end_to_end(tmp_path: Path) -> None:
     formatted = await task.runtime.setup_runtime(task)
 
     assert formatted == f"cat {result.path}"
+
+
+@pytest.mark.usefixtures("horus_context")
+async def test_command_runtime_quotes_path_with_spaces(
+    tmp_path: Path,
+) -> None:
+    """
+    A workflow/artifact path with a space is shell-quoted as one word, not
+    split into two positional args by the shell that runs the command.
+    """
+    work = tmp_path / "my project"
+    work.mkdir()
+    result = JSONArtifact(id="result", path=work / "result.json")
+    task = _shell_task(tmp_path, "cat $result", result)
+
+    formatted = await task.runtime.setup_runtime(task)
+
+    assert formatted == f"cat {shlex.quote(str(result.path))}"
+    assert len(shlex.split(formatted)) == 2
 
 
 @pytest.mark.usefixtures("horus_context")


### PR DESCRIPTION
## Summary
- `CommandRuntime.command` and `PythonScriptRuntime.args` render `$id`/`${id.attr}` placeholders as raw text via `substitute()`, then hand the rendered string to `/bin/sh -c` unquoted.
- A path containing a space (e.g. a `Vina Docking` workflow directory) gets split into extra shell words, and the target program (e.g. `argparse`) sees the extra tokens as unrecognized positional arguments — this is the root cause of `prep.py: error: unrecognized arguments: Vina Docking/examples/receptor.pdb ...` reported by a user.
- `substitute()` now accepts a `quote` flag that shell-quotes each resolved placeholder value individually (`shlex.quote`) before it's spliced into the template. The two call sites that hand their result to a shell unquoted (`CommandRuntime._setup_runtime`, `PythonScriptRuntime._setup_runtime`'s `args`) opt into it. Other callers (Python source substitution, and paths that get `shlex.quote`d as a whole afterward) are left unchanged to avoid double-quoting.

## Test plan
- [x] `./.venv/bin/python -m pytest -q --no-cov` — 695 passed
- [x] Added regression tests: `test_command_runtime_quotes_path_with_spaces`, `test_python_script_quotes_args_with_spaces` — both fail on `main` and pass with this change
- [x] `ruff check` / `mypy` clean on touched files

## Docs
- [X] No documentation update required