### PR TITLE
Create declared output directories on the task's target

### DIFF
--- a/src/horus_runtime/core/executor/base.py
+++ b/src/horus_runtime/core/executor/base.py
@@ -25,7 +25,7 @@ a command or running it inside a SLURM job, either remote or locally.
 
 import tempfile
 from abc import abstractmethod
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, ClassVar, final
 
 from horus_builtin.artifact.file import FileArtifact
@@ -138,8 +138,18 @@ class BaseExecutor(AutoRegistry, entry_point="executor"):
         # their directory must exist beforehand. Only the *parent*: creating a
         # FolderArtifact's own path would make it exist() and the task would
         # skip itself forever.
+        #
+        # The directory is created *on the task's target*, so it has to be the
+        # target-side path. `artifact.path` is anchored to the orchestrator's
+        # run directory, which on a remote target names a directory that does
+        # not exist there (and is not creatable): a task on an SSH host failed
+        # with `mkdir -p '/app/…' failed with exit code 1` before it ever ran.
+        # `path_on_target` is what every other consumer of an output already
+        # uses — `${artifact}` substitution, ArtifactStore, transfer — and it
+        # returns `artifact.path` unchanged for co-located targets.
         for artifact in task.outputs:
-            await task.target.mkdir(str(artifact.path.parent))
+            on_target = PurePosixPath(task.target.path_on_target(artifact))
+            await task.target.mkdir(str(on_target.parent))
 
         try:
             await ExecutorMiddleware.call_with_middleware(

--- a/tests/unit/executor/test_executor_base.py
+++ b/tests/unit/executor/test_executor_base.py
@@ -33,6 +33,7 @@ from horus_builtin.executor.shell import ShellExecutor
 from horus_builtin.runtime.command import CommandRuntime
 from horus_builtin.target.local import LocalTarget
 from horus_builtin.task.horus_task import HorusTask
+from horus_runtime.context import HorusContext
 from horus_runtime.core.artifact.base import BaseArtifact
 from horus_runtime.core.executor.base import BaseExecutor
 from horus_runtime.core.task.exceptions import TaskExecutionError
@@ -285,3 +286,90 @@ class TestOutputDirectoriesAreCreated:
         assert out.parent.is_dir()
         assert not out.exists()
         assert not await task.is_complete()
+
+
+_MKDIRS: list[str] = []
+
+
+class _RelocatingTarget(LocalTarget):
+    """
+    A target that stores artifacts somewhere other than their declared path,
+    the way ``SSHTarget`` puts them under the remote working directory.
+    """
+
+    add_to_registry: ClassVar[bool] = False
+    kind: str = "relocating"
+    relocated_root: str = ""
+
+    def path_on_target(self, artifact: BaseArtifact) -> str:
+        if not self.relocated_root:
+            return super().path_on_target(artifact)
+        return f"{self.relocated_root}/{Path(artifact.path).name}"
+
+    async def mkdir(self, path: str) -> None:
+        _MKDIRS.append(path)
+        await super().mkdir(path)
+
+
+@pytest.mark.unit
+class TestOutputDirectoriesAreCreatedOnTheTarget:
+    """
+    Declared outputs are written by the task itself, so their directory is
+    pre-created — on the *target*, which means it must be the target-side
+    path. ``artifact.path`` is anchored to the orchestrator's run directory
+    and names nothing that exists on a remote host.
+    """
+
+    @staticmethod
+    def _task(tmp_path: Path, out: Path, relocated_root: str) -> HorusTask:
+        return HorusTask(
+            name="t",
+            id="t",
+            outputs=[FileArtifact(id="out", path=out)],
+            runtime=CommandRuntime(command="echo hi"),
+            executor=ShellExecutor(),
+            target=_RelocatingTarget(
+                working_directory=tmp_path.as_posix(),
+                relocated_root=relocated_root,
+            ),
+        )
+
+    async def test_uses_path_on_target_not_the_anchored_path(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """
+        A target that relocates artifacts gets its *relocated* parent created,
+        never the orchestrator-side one. Regression: an SSH task died with
+        ``mkdir -p '/app/...' failed with exit code 1`` before it ever ran.
+        """
+        del horus_context
+        _MKDIRS.clear()
+        relocated = tmp_path / "on_target"
+        task = self._task(
+            tmp_path,
+            out=Path("/app/orch/results/o.tar.gz"),
+            relocated_root=relocated.as_posix(),
+        )
+
+        await task.executor.execute(task)
+
+        assert relocated.as_posix() in _MKDIRS
+        assert "/app/orch/results" not in _MKDIRS
+
+    async def test_colocated_target_still_uses_the_artifact_path(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """
+        The default ``path_on_target`` returns the artifact's own path, so a
+        co-located target keeps creating exactly the directory it always did.
+        """
+        del horus_context
+        _MKDIRS.clear()
+        out_dir = tmp_path / "results"
+        task = self._task(
+            tmp_path, out=out_dir / "o.tar.gz", relocated_root=""
+        )
+
+        await task.executor.execute(task)
+
+        assert out_dir.as_posix() in _MKDIRS


### PR DESCRIPTION
## Problem

`BaseExecutor.execute` pre-creates each declared output's parent directory, because a task writes its own outputs (a shell command redirecting to `${artifact}` never goes through `Artifact.write`):

```python
for artifact in task.outputs:
    await task.target.mkdir(str(artifact.path.parent))
```

The `mkdir` runs **on the task's target**, but `artifact.path` is anchored to the **orchestrator's** run directory. On a co-located target the two coincide, which is why this went unnoticed. On a remote one it names a directory that does not exist there and is not creatable.

Hit in a real run (tc-os, AutoDock Vina docking): a `prep` task on the local target feeds a `dock` task on an SSH host, and `dock` died before it ever ran:

```
TaskExecutionError: mkdir -p '/app/orchestrator/horus_workflow_results/results' failed with exit code 1
```

`/app/orchestrator/...` is a path inside the orchestrator container. `prep` survived only because it runs co-located, where that directory genuinely exists.

Declaring the output relatively does not help. The workflow authored `results/docking_out.tar.gz`; `_anchor_artifact` roots relative *produced* paths under the run directory, resolving it to the same unusable `/app/...` path.

## Change

Use `target.path_on_target(artifact)` — which is what every other consumer of an output already uses:

- `${artifact}` command substitution (`runtime/substitution.py:69`)
- `ArtifactStore.exists` / `digest` / `package` / `unpackage`
- `BaseTransferStrategy.transfer`

That one `mkdir` was the outlier: the task's command was already writing to the correct target-side location, only the pre-created directory was wrong.

`BaseTarget.path_on_target` defaults to `str(artifact.path)` and `LocalTarget` does not override it, so co-located targets are byte-for-byte unaffected.

## Tests

Two cases in `test_executor_base.py` using a target that relocates artifacts the way `SSHTarget` does: the relocated parent is created and the orchestrator-side one is not; and a co-located target still creates exactly the directory it always did. The first fails without the fix.

`tests/unit`: 683 pass. The 12 failures are pre-existing on `main` (identical set with this change stashed) and are local-environment only — CI is green.

## Documentation impact

- [x] No documentation update required

Nothing in the documented contract changes: a task on a remote target was always meant to write its declared outputs there. This only makes it work.