### PR TITLE
Add value-carrying artifacts (number/boolean/string)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,9 @@ file = "horus_builtin.artifact.file"
 folder = "horus_builtin.artifact.folder"
 json = "horus_builtin.artifact.json"
 pickle = "horus_builtin.artifact.pickle"
+number = "horus_builtin.artifact.number"
+boolean = "horus_builtin.artifact.boolean"
+string = "horus_builtin.artifact.string"
 
 [project.entry-points."horus.executor"]
 shell = "horus_builtin.executor.shell"

--- a/src/horus_builtin/artifact/boolean.py
+++ b/src/horus_builtin/artifact/boolean.py
@@ -1,0 +1,61 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Implementation of the BooleanArtifact class, which represents a boolean
+value artifact in the Horus runtime.
+"""
+
+import json
+from pathlib import Path
+from typing import ClassVar, cast
+
+from horus_builtin.artifact.value import ValueArtifact
+from horus_builtin.event.artifact_event import ArtifactEventsEnum
+
+
+class BooleanArtifact(ValueArtifact[bool]):
+    """
+    Represents a boolean (``true``/``false``) value artifact.
+
+    The value is materialized as a JSON boolean on disk, so a task consuming
+    ``$id`` reads a file whose contents are ``true`` or ``false``.
+    """
+
+    kind: str = "boolean"
+    kind_name: ClassVar[str] = "Boolean"
+    kind_description: ClassVar[str] = "A boolean value artifact."
+
+    value: bool = False
+
+    def read(self) -> bool:
+        """
+        Read and deserialize the boolean from the artifact file.
+        """
+        with open(self.path) as f:
+            value = json.load(f)
+        self._emit_event(ArtifactEventsEnum.READ)
+        return cast(bool, value)
+
+    def write(self, value: bool) -> None:
+        """
+        Serialize and write the boolean to the artifact file.
+        """
+        Path(self.path).parent.mkdir(parents=True, exist_ok=True)
+        with open(self.path, "w") as f:
+            json.dump(value, f)
+        self._emit_event(ArtifactEventsEnum.WRITE)

--- a/src/horus_builtin/artifact/number.py
+++ b/src/horus_builtin/artifact/number.py
@@ -1,0 +1,61 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Implementation of the NumberArtifact class, which represents a numeric
+value artifact in the Horus runtime.
+"""
+
+import json
+from pathlib import Path
+from typing import ClassVar, cast
+
+from horus_builtin.artifact.value import ValueArtifact
+from horus_builtin.event.artifact_event import ArtifactEventsEnum
+
+
+class NumberArtifact(ValueArtifact[int | float]):
+    """
+    Represents a numeric value (integer or float) artifact.
+
+    The value is materialized as a JSON number on disk, so a task consuming
+    ``$id`` reads a file whose contents are the bare number.
+    """
+
+    kind: str = "number"
+    kind_name: ClassVar[str] = "Number"
+    kind_description: ClassVar[str] = "A numeric value artifact."
+
+    value: int | float = 0
+
+    def read(self) -> int | float:
+        """
+        Read and deserialize the number from the artifact file.
+        """
+        with open(self.path) as f:
+            value = json.load(f)
+        self._emit_event(ArtifactEventsEnum.READ)
+        return cast(int | float, value)
+
+    def write(self, value: int | float) -> None:
+        """
+        Serialize and write the number to the artifact file.
+        """
+        Path(self.path).parent.mkdir(parents=True, exist_ok=True)
+        with open(self.path, "w") as f:
+            json.dump(value, f)
+        self._emit_event(ArtifactEventsEnum.WRITE)

--- a/src/horus_builtin/artifact/string.py
+++ b/src/horus_builtin/artifact/string.py
@@ -1,0 +1,59 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Implementation of the StringArtifact class, which represents a string
+value artifact in the Horus runtime.
+"""
+
+from pathlib import Path
+from typing import ClassVar
+
+from horus_builtin.artifact.value import ValueArtifact
+from horus_builtin.event.artifact_event import ArtifactEventsEnum
+
+
+class StringArtifact(ValueArtifact[str]):
+    """
+    Represents a string value artifact.
+
+    The value is materialized as plain text on disk, so a task consuming
+    ``$id`` reads a file whose contents are the string as authored (no
+    quotes).
+    """
+
+    kind: str = "string"
+    kind_name: ClassVar[str] = "String"
+    kind_description: ClassVar[str] = "A string value artifact."
+
+    value: str = ""
+
+    def read(self) -> str:
+        """
+        Read and deserialize the string from the artifact file.
+        """
+        text = self.path.read_text()
+        self._emit_event(ArtifactEventsEnum.READ)
+        return text
+
+    def write(self, value: str) -> None:
+        """
+        Serialize and write the string to the artifact file.
+        """
+        Path(self.path).parent.mkdir(parents=True, exist_ok=True)
+        self.path.write_text(value)
+        self._emit_event(ArtifactEventsEnum.WRITE)

--- a/src/horus_builtin/artifact/value.py
+++ b/src/horus_builtin/artifact/value.py
@@ -1,0 +1,64 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Shared base for value-carrying artifacts.
+
+A value artifact is file-backed like every other artifact, but also carries
+an inline, typed ``value`` that is the artifact's authored content. The
+workflow graph never distinguishes the two: a ``NumberArtifact`` produced by
+one task is transferred to its consumer exactly like a ``NumberArtifact``
+root whose value was typed by the user. The only runtime difference is that
+a root value artifact materializes itself (``materialize()``) the first time
+a task consumes it, because no producer ever wrote its bytes.
+"""
+
+from typing import ClassVar
+
+from horus_runtime.core.artifact.base import BaseArtifact
+
+
+class ValueArtifact[T: object](BaseArtifact[T]):
+    """
+    A file-backed artifact that carries an inline, typed value.
+
+    Subclasses declare the concrete ``value`` type and the on-disk
+    serialization through ``read``/``write`` (exactly like any other
+    artifact). ``materialize`` writes ``value`` to ``path`` the first time a
+    consumer needs the artifact, so a root value artifact needs no external
+    upload to be runnable.
+    """
+
+    kind_name: ClassVar[str] = "Value"
+    kind_description: ClassVar[str] = "A value-carrying artifact."
+
+    value: T
+    """
+    The artifact's authored value. Round-trips through ``model_dump`` so a
+    workflow document can carry a value that has not been materialized yet.
+    """
+
+    def materialize(self) -> None:
+        """
+        Write ``value`` to ``path`` when no backing file exists yet.
+
+        Idempotent: once the file exists it is left alone, so an uploaded
+        blob (or a value already written by a producer task) is never
+        clobbered by the declared value.
+        """
+        if not self.path.exists():
+            self.write(self.value)

--- a/src/horus_builtin/runtime/substitution.py
+++ b/src/horus_builtin/runtime/substitution.py
@@ -24,11 +24,12 @@ All runtimes that do string substitution (``command``, ``python_script``,
 supported and passes through unchanged.
 
 Supported placeholder forms
-----------------------------
-* ``$id``          — on-target path of the artifact whose id is *id*
+---------------------------
+* ``$id``          — on-target path of the artifact whose id is *id* (or its
+                     authored ``value`` for value-carrying artifacts)
 * ``${id}``        — same, braced form (use when a letter/digit follows)
 * ``${id.attr}``   — attribute of the artifact (e.g. ``${result.path}``,
-                     ``${result.id}``)
+                     ``${result.id}``, ``${result.value}``)
 * ``${task.attr}`` — attribute of the task (e.g. ``${task.name}``)
 
 Unknown ``$name`` references are left as-is (``safe_substitute`` semantics).
@@ -55,6 +56,12 @@ if TYPE_CHECKING:
 # ``${id.id}``, etc. still forward to the artifact.  This is what lets a
 # command or script be written once and run unchanged on a local or remote
 # target.
+#
+# A value-carrying artifact (NumberArtifact/BooleanArtifact/StringArtifact)
+# instead renders its authored ``value``: a task consuming ``$samples`` gets
+# ``10``, not a path to a file whose content happens to be ``10``. The value
+# still materializes to a file for anything that reads it directly; this only
+# changes how the placeholder renders.
 class _ArtifactRef:
     def __init__(self, artifact: "BaseArtifact", target: "BaseTarget") -> None:
         self._a = artifact
@@ -65,11 +72,21 @@ class _ArtifactRef:
             raise AttributeError(name)
         return getattr(self._a, name)
 
+    def _render(self) -> object:
+        value = getattr(self._a, "value", None)
+        if value is not None:
+            # Match the on-disk serialization (json.dump lowercases booleans)
+            # so ``$flag`` and ``cat $flag`` agree.
+            if isinstance(value, bool):
+                return "true" if value else "false"
+            return value
+        return self._t.path_on_target(self._a)
+
     def __str__(self) -> str:
-        return str(self._t.path_on_target(self._a))
+        return str(self._render())
 
     def __format__(self, spec: str) -> str:
-        return format(self._t.path_on_target(self._a), spec)
+        return format(self._render(), spec)
 
 
 # Create a namespace object to allow for attribute-style access to task
@@ -146,7 +163,8 @@ def substitute(template: str, task: "BaseTask", *, quote: bool = False) -> str:
     Render *template* against *task* using ``string.Template`` ``$``/``${}``
     syntax.
 
-    * ``$id`` / ``${id}`` — on-target path of the artifact whose id is *id*
+    * ``$id`` / ``${id}`` — on-target path of the artifact whose id is *id*,
+      or its authored ``value`` for value-carrying artifacts
     * ``${id.attr}``       — attribute of that artifact
     * ``${task.attr}``     — attribute of the task
     * Unknown placeholders are left as-is (``safe_substitute`` semantics).

--- a/src/horus_runtime/core/artifact/base.py
+++ b/src/horus_runtime/core/artifact/base.py
@@ -152,6 +152,17 @@ class BaseArtifact[T: Any = Any](AutoRegistry, entry_point="artifact"):
         Write the native artifact representation to its canonical path.
         """
 
+    def materialize(self) -> None:
+        """
+        Make the artifact's bytes available at :attr:`path`.
+
+        The default is a no-op: file-backed artifacts assume a producer (or
+        an upload) already wrote them. Value-carrying kinds override this to
+        write their inline ``value`` the first time a consumer needs them, so
+        a workflow-owned root artifact with an authored value is runnable
+        without any external step.
+        """
+
     def pack_command(self, src: str, pkg: str) -> str | None:
         """
         Return a portable shell command that produces the single-file package

--- a/src/horus_runtime/core/workflow/base.py
+++ b/src/horus_runtime/core/workflow/base.py
@@ -1090,7 +1090,29 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
             # The consumer input keeps its own id (the template key); we only
             # point its path at the materialized result.
             src_artifact = source.artifact if source is not None else None
+
+            # A root artifact with an authored value has no producer: write
+            # its bytes the first time a consumer needs them, so the transfer
+            # below has something to move (see BaseArtifact.materialize).
+            if (
+                src_artifact is not None
+                and source is not None
+                and (source.target is None)
+            ):
+                src_artifact.materialize()
+
             transfer_art = (src_artifact or artifact).model_copy()
+
+            # A value root's authored value must reach the consumer's own
+            # input artifact, mirroring the path hand-off above: substitution
+            # renders ``$id`` from the consumer's artifact, so without this it
+            # would see the default value (0/False/"") instead of the root's.
+            if (
+                src_artifact is not None
+                and hasattr(src_artifact, "value")
+                and hasattr(artifact, "value")
+            ):
+                artifact.value = src_artifact.value
 
             # Look up the registered strategy for this (source, dest) pair,
             # falling back to the target-agnostic GenericTransfer when no

--- a/tests/unit/artifact/test_value_artifact.py
+++ b/tests/unit/artifact/test_value_artifact.py
@@ -1,0 +1,192 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Unit tests for the value-carrying artifact kinds (number, boolean, string).
+"""
+
+import tempfile
+from pathlib import Path
+from typing import cast
+
+import pytest
+from pydantic import BaseModel
+
+from horus_builtin.artifact.boolean import BooleanArtifact
+from horus_builtin.artifact.number import NumberArtifact
+from horus_builtin.artifact.string import StringArtifact
+from horus_runtime.context import HorusContext
+from horus_runtime.core.artifact.base import BaseArtifact
+
+
+@pytest.mark.unit
+class TestValueArtifactRegistry:
+    """
+    The value kinds register under the artifact registry like any other kind.
+    """
+
+    def test_new_kinds_are_registered(self) -> None:
+        """All three value kinds resolve through the AutoRegistry."""
+        assert "number" in BaseArtifact.registry
+        assert "boolean" in BaseArtifact.registry
+        assert "string" in BaseArtifact.registry
+        assert BaseArtifact.registry["number"] is NumberArtifact
+        assert BaseArtifact.registry["boolean"] is BooleanArtifact
+        assert BaseArtifact.registry["string"] is StringArtifact
+
+    def test_discriminated_union_round_trips_values(self) -> None:
+        """Values survive model_dump/model_validate round trips by kind."""
+
+        class TestModel(BaseModel):
+            artifact: list[BaseArtifact]
+
+        result = TestModel.model_validate(
+            {
+                "artifact": [
+                    {"id": "n", "kind": "number", "value": 10, "path": "/a"},
+                    {
+                        "id": "b",
+                        "kind": "boolean",
+                        "value": True,
+                        "path": "/b",
+                    },
+                    {"id": "s", "kind": "string", "value": "hi", "path": "/c"},
+                ]
+            }
+        )
+        values = [
+            cast(NumberArtifact, result.artifact[0]).value,
+            cast(BooleanArtifact, result.artifact[1]).value,
+            cast(StringArtifact, result.artifact[2]).value,
+        ]
+        assert values == [10, True, "hi"]
+
+
+@pytest.mark.unit
+class TestNumberArtifact:
+    """NumberArtifact serializes an int/float value as a JSON number."""
+
+    def test_defaults(self) -> None:
+        """A bare number artifact defaults to 0 with kind ``number``."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            artifact = NumberArtifact(id="n", path=Path(temp_dir) / "n.json")
+            assert artifact.kind == "number"
+            assert artifact.value == 0
+
+    def test_write_then_read_round_trips(
+        self, horus_context: HorusContext
+    ) -> None:
+        """write() persists an int and read() returns it."""
+        del horus_context
+        with tempfile.TemporaryDirectory() as temp_dir:
+            target = Path(temp_dir) / "n.json"
+            artifact = NumberArtifact(id="n", path=target)
+            artifact.write(10)
+            assert target.read_text() == "10"
+            assert artifact.read() == 10
+
+    def test_float_is_preserved(self, horus_context: HorusContext) -> None:
+        """A float value survives the write/read round trip."""
+        del horus_context
+        with tempfile.TemporaryDirectory() as temp_dir:
+            artifact = NumberArtifact(id="n", path=Path(temp_dir) / "n.json")
+            artifact.write(3.5)
+            assert artifact.read() == 3.5
+
+
+@pytest.mark.unit
+class TestBooleanArtifact:
+    """BooleanArtifact serializes a bool as lowercase JSON true/false."""
+
+    def test_defaults(self) -> None:
+        """A bare boolean artifact defaults to False."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            artifact = BooleanArtifact(id="b", path=Path(temp_dir) / "b.json")
+            assert artifact.kind == "boolean"
+            assert artifact.value is False
+
+    def test_write_then_read_round_trips(
+        self, horus_context: HorusContext
+    ) -> None:
+        """write(True) persists ``true`` and read() returns True."""
+        del horus_context
+        with tempfile.TemporaryDirectory() as temp_dir:
+            target = Path(temp_dir) / "b.json"
+            artifact = BooleanArtifact(id="b", path=target)
+            artifact.write(True)
+            assert target.read_text() == "true"
+            assert artifact.read() is True
+
+
+@pytest.mark.unit
+class TestStringArtifact:
+    """StringArtifact serializes text as a plain UTF-8 file."""
+
+    def test_defaults(self) -> None:
+        """A bare string artifact defaults to an empty string."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            artifact = StringArtifact(id="s", path=Path(temp_dir) / "s.txt")
+            assert artifact.kind == "string"
+            assert artifact.value == ""
+
+    def test_write_then_read_round_trips(
+        self, horus_context: HorusContext
+    ) -> None:
+        """write() persists text and read() returns it."""
+        del horus_context
+        with tempfile.TemporaryDirectory() as temp_dir:
+            target = Path(temp_dir) / "s.txt"
+            artifact = StringArtifact(id="s", path=target)
+            artifact.write("hello")
+            assert target.read_text() == "hello"
+            assert artifact.read() == "hello"
+
+
+@pytest.mark.unit
+class TestValueArtifactMaterialize:
+    """Value artifacts materialize their authored value to a backing file."""
+
+    def test_materialize_writes_value_when_file_missing(
+        self, horus_context: HorusContext
+    ) -> None:
+        """A missing backing file is written from the authored value."""
+        del horus_context
+        with tempfile.TemporaryDirectory() as temp_dir:
+            target = Path(temp_dir) / "n.json"
+            artifact = NumberArtifact(id="n", path=target, value=42)
+            assert not target.exists()
+            artifact.materialize()
+            assert target.read_text() == "42"
+
+    def test_materialize_is_idempotent_and_does_not_clobber(self) -> None:
+        """An existing backing file always wins over the authored value."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            target = Path(temp_dir) / "s.txt"
+            target.write_text("uploaded bytes")
+            artifact = StringArtifact(id="s", path=target, value="edited")
+            artifact.materialize()
+            assert target.read_text() == "uploaded bytes"
+
+    def test_base_artifact_materialize_is_noop(self) -> None:
+        """BaseArtifact.materialize() is a no-op for non-value artifacts."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            target = Path(temp_dir) / "f.txt"
+            artifact = BaseArtifact.model_validate(
+                {"id": "f", "kind": "file", "path": str(target)}
+            )
+            artifact.materialize()
+            assert not target.exists()

--- a/tests/unit/runtime/test_substitution.py
+++ b/tests/unit/runtime/test_substitution.py
@@ -25,7 +25,10 @@ from pathlib import Path
 
 import pytest
 
+from horus_builtin.artifact.boolean import BooleanArtifact
 from horus_builtin.artifact.json import JSONArtifact
+from horus_builtin.artifact.number import NumberArtifact
+from horus_builtin.artifact.string import StringArtifact
 from horus_builtin.executor.python_exec import PythonExecExecutor
 from horus_builtin.executor.shell import ShellExecutor
 from horus_builtin.runtime.command import CommandRuntime
@@ -163,3 +166,63 @@ async def test_python_code_string_result_path_end_to_end(
     code = await task.runtime.setup_runtime(task)
 
     assert code == f"open('{result.path}')"
+
+
+def _value_task(
+    tmp_path: Path, inputs: list[object], command: str
+) -> HorusTask:
+    """A task whose command consumes only the given value artifacts."""
+    result = JSONArtifact(id="result", path=tmp_path / "result.json")
+    return HorusTask(
+        id="run",
+        name="my_task",
+        runtime=CommandRuntime(command=command),
+        executor=ShellExecutor(),
+        target=LocalTarget(working_directory=tmp_path.as_posix()),
+        inputs=inputs,  # type: ignore[arg-type]
+        outputs=[result],
+    )
+
+
+def test_value_artifact_renders_its_value(tmp_path: Path) -> None:
+    """$id for a value artifact renders the authored value, not a path."""
+    n = NumberArtifact(id="n", path=tmp_path / "n.json", value=42)
+    task = _value_task(tmp_path, [n], "--samples $n")
+
+    assert substitute("--samples $n", task) == "--samples 42"
+
+
+def test_boolean_renders_lowercase(tmp_path: Path) -> None:
+    """A boolean value renders true/false, matching its on-disk form."""
+    b = BooleanArtifact(id="flag", path=tmp_path / "flag.json", value=True)
+    task = _value_task(tmp_path, [b], "--use-msa $flag")
+
+    assert substitute("--use-msa $flag", task) == "--use-msa true"
+
+
+def test_string_value_is_quoted_with_spaces(tmp_path: Path) -> None:
+    """A string value is shell-quoted as one word when quote=True."""
+    s = StringArtifact(id="s", path=tmp_path / "s.txt", value="hello world")
+    task = _value_task(tmp_path, [s], "echo $s")
+
+    assert substitute("echo $s", task, quote=True) == (
+        f"echo {shlex.quote('hello world')}"
+    )
+
+
+def test_value_is_accessible_as_attribute(tmp_path: Path) -> None:
+    """${id.value} and ${id.path} still forward to the artifact itself."""
+    n = NumberArtifact(id="n", path=tmp_path / "n.json", value=42)
+    task = _value_task(tmp_path, [n], "echo ${n.value} ${n.path}")
+
+    rendered = substitute("echo ${n.value} ${n.path}", task)
+
+    assert rendered == f"echo 42 {n.path}"
+
+
+def test_file_artifact_still_renders_path(tmp_path: Path) -> None:
+    """Non-value artifacts keep rendering their on-target path."""
+    f = JSONArtifact(id="result", path=tmp_path / "result.json")
+    task = _shell_task(tmp_path, "cat $result", f)
+
+    assert substitute("cat $result", task) == f"cat {f.path}"

--- a/tests/unit/workflow/test_subworkflow.py
+++ b/tests/unit/workflow/test_subworkflow.py
@@ -30,6 +30,7 @@ from pydantic import ValidationError
 
 from horus_builtin.artifact.file import FileArtifact
 from horus_builtin.artifact.folder import FolderArtifact
+from horus_builtin.artifact.number import NumberArtifact
 from horus_builtin.executor.shell import ShellExecutor
 from horus_builtin.runtime.command import CommandRuntime
 from horus_builtin.target.local import LocalTarget
@@ -442,6 +443,78 @@ class TestBoundaryWiring:
         wf.edges.append(edge)
         wf.subworkflow(id="sub", body=child)
         assert edge.transfer is False
+
+
+@pytest.mark.unit
+class TestValueRootsAcrossBoundary:
+    """Value roots travel through a subworkflow into the inner command."""
+
+    def _child_with_number_root(self) -> HorusWorkflow:
+        """A child whose in-port is a NumberArtifact, not a file."""
+        report = _shell_task(
+            "report",
+            "printf '%s' $n > $report_out",
+            inputs=[NumberArtifact(id="n", path=Path("n.json"))],
+            outputs=[FileArtifact(id="report_out", path=Path("report.txt"))],
+        )
+        return HorusWorkflow(
+            name="child",
+            tasks=[report],
+            artifacts=[NumberArtifact(id="n", path=Path("n.json"), value=42)],
+            edges=[
+                WorkflowEdge(
+                    source="artifact-n",
+                    source_output="n",
+                    target="report",
+                    target_input="n",
+                ),
+            ],
+        )
+
+    async def test_unfed_value_root_survives_and_renders(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """An unfed number root keeps its authored value in the child."""
+        del horus_context
+        child = self._child_with_number_root()
+        wf = _parent(tmp_path)
+        wf.subworkflow(id="sub", body=child)
+
+        await wf.run(trigger_id="sub")
+
+        assert wf.status.value == "completed"
+        assert any(a.id == "sub/n" for a in wf.artifacts)
+        report = _inner(wf, "sub/report")
+        assert report.outputs[0].path.read_text().strip() == "42"
+
+    async def test_value_root_can_be_fed_by_parent_value(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """A parent root artifact feeds the child's number in-port."""
+        del horus_context
+        child = self._child_with_number_root()
+        wf = _parent(tmp_path)
+        wf.subworkflow(id="sub", body=child)
+        wf.artifacts.append(
+            NumberArtifact(id="n", path=Path("n.json"), value=7)
+        )
+        wf.edges.append(
+            WorkflowEdge(
+                source="artifact-n",
+                source_output="n",
+                target="sub",
+                target_input="n",
+                transfer=False,
+            )
+        )
+
+        await wf.run(trigger_id="sub")
+
+        assert wf.status.value == "completed"
+        report = _inner(wf, "sub/report")
+        assert report.outputs[0].path.read_text().strip() == "7"
+        # The child's own root is dropped: the parent supplies the value.
+        assert not any(a.id == "sub/n" for a in wf.artifacts)
 
 
 @pytest.mark.unit

--- a/tests/unit/workflow/test_value_roots.py
+++ b/tests/unit/workflow/test_value_roots.py
@@ -1,0 +1,152 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+End-to-end tests for workflow-owned value artifacts.
+
+A root artifact that carries an authored ``value`` (NumberArtifact,
+BooleanArtifact, StringArtifact) is indistinguishable at runtime from a file
+artifact: it is materialized the first time a task consumes it, transferred
+through the ordinary path, and substituted into task commands like any other
+input. These tests pin that behaviour down.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from horus_builtin.artifact.boolean import BooleanArtifact
+from horus_builtin.artifact.file import FileArtifact
+from horus_builtin.artifact.number import NumberArtifact
+from horus_builtin.artifact.string import StringArtifact
+from horus_builtin.executor.shell import ShellExecutor
+from horus_builtin.runtime.command import CommandRuntime
+from horus_builtin.target.local import LocalTarget
+from horus_builtin.task.horus_task import HorusTask
+from horus_builtin.workflow.horus_workflow import HorusWorkflow
+from horus_runtime.context import HorusContext
+from horus_runtime.core.workflow.edge import WorkflowEdge
+
+
+def _value_root(
+    artifact_id: str,
+    *,
+    kind: str,
+    value: object,
+) -> object:
+    """One value artifact usable both as a root and as a task input."""
+    return {
+        "number": NumberArtifact,
+        "boolean": BooleanArtifact,
+        "string": StringArtifact,
+    }[kind](id=artifact_id, path=Path(f"roots/{artifact_id}"), value=value)
+
+
+def _consume_workflow(tmp_path: Path) -> HorusWorkflow:
+    """
+    A single task that cats every value root into one report, so a run
+    proves each value was materialized and substituted.
+    """
+    roots = [
+        _value_root("n", kind="number", value=42),
+        _value_root("b", kind="boolean", value=True),
+        _value_root("s", kind="string", value="hello"),
+    ]
+    task = HorusTask(
+        id="consume",
+        name="consume",
+        runtime=CommandRuntime(command="printf '%s|%s|%s' $n $b $s > $report"),
+        executor=ShellExecutor(),
+        target=LocalTarget(),
+        inputs=[r.model_copy(deep=True) for r in roots],  # type: ignore[attr-defined]
+        outputs=[FileArtifact(id="report", path=Path("report.txt"))],
+    )
+    wf = HorusWorkflow(
+        name="value-roots",
+        tasks=[task],
+        artifacts=roots,  # type: ignore[arg-type]
+        edges=[
+            WorkflowEdge(
+                source="artifact-n",
+                source_output="n",
+                target="consume",
+                target_input="n",
+            ),
+            WorkflowEdge(
+                source="artifact-b",
+                source_output="b",
+                target="consume",
+                target_input="b",
+            ),
+            WorkflowEdge(
+                source="artifact-s",
+                source_output="s",
+                target="consume",
+                target_input="s",
+            ),
+        ],
+    )
+    wf._base_directory = tmp_path
+    return wf
+
+
+@pytest.mark.unit
+class TestValueRootsMaterializeAndTransfer:
+    """Value roots are materialized, substituted, and survive reloads."""
+
+    async def test_values_reach_the_task_command(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """Each value root is materialized and substituted into the shell."""
+        del horus_context
+        wf = _consume_workflow(tmp_path)
+
+        await wf.run(trigger_id="consume")
+
+        assert wf.status.value == "completed"
+        report = next(t for t in wf.tasks if t.id == "consume").outputs[0]
+        assert report.path.read_text().strip() == "42|true|hello"
+
+    async def test_root_files_exist_after_run(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """The materialized bytes land on disk under the run's base dir."""
+        del horus_context
+        wf = _consume_workflow(tmp_path)
+
+        await wf.run(trigger_id="consume")
+
+        assert (tmp_path / "roots/n").read_text() == "42"
+        assert (tmp_path / "roots/b").read_text() == "true"
+        assert (tmp_path / "roots/s").read_text() == "hello"
+
+    async def test_values_survive_dump_reload(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """
+        A workflow document that carries authored values round-trips through
+        model_validate without losing them, so the orchestrator sees the same
+        values the editor saved.
+        """
+        del horus_context
+        wf = _consume_workflow(tmp_path)
+
+        reloaded = HorusWorkflow.model_validate(wf.model_dump(mode="json"))
+        root_ids = {a.id for a in reloaded.artifacts}
+        assert root_ids == {"n", "b", "s"}
+        values = {a.id: getattr(a, "value", None) for a in reloaded.artifacts}
+        assert values == {"n": 42, "b": True, "s": "hello"}


### PR DESCRIPTION
Introduces value-carrying artifacts for the reusable-workflows work.

## What
- New `ValueArtifact` base (`src/horus_builtin/artifact/value.py`): a file-backed artifact that also carries an inline, typed `value`.
- Concrete kinds registered in pyproject entry points: `number`, `boolean`, `string`.
- `BaseArtifact.materialize()` (default no-op): value kinds override to write their authored `value` the first time a consumer needs them, so a workflow-owned root value artifact is runnable without an external producer.
- `workflow/base.py` `_transfer`: materializes value roots and copies the root's authored value onto the consumer's input artifact so substitution sees the real value.
- `substitution.py`: `$id` renders the authored `value` for value-carrying artifacts (booleans lowercased to match on-disk JSON), else the on-target path as before.

## Tests
`uv run pytest` → 721 passed, 91.78% coverage (all new tests in `tests/unit/artifact/test_value_artifact.py` and `tests/unit/workflow/test_value_roots.py`).

---

**horus-docs PR:** https://github.com/temple-compute/horus-docs/pull/50
