### PR TITLE
🐛 Create the task working directory inside the task middleware chain

### DIFF
--- a/src/horus_runtime/core/task/base.py
+++ b/src/horus_runtime/core/task/base.py
@@ -293,14 +293,24 @@ class BaseTask(AutoRegistry, entry_point="task"):
                 % {"task_name": self.name}
             )
             try:
-                # Every executor receives a real, empty directory for this
-                # invocation. This is intentionally here rather than in a
-                # specific executor so shell, Python, remote, and plugin
-                # executors all share the same isolation guarantee.
-                await self.target.mkdir(self.working_dir)
+
+                async def mkdir_and_run() -> None:
+                    # Every executor receives a real, empty directory for this
+                    # invocation. This is intentionally here rather than in a
+                    # specific executor so shell, Python, remote, and plugin
+                    # executors all share the same isolation guarantee.
+                    #
+                    # It runs *inside* the middleware chain so middleware that
+                    # retargets the task (e.g. an orchestrator re-anchoring a
+                    # runtime-added task's working directory) has already run:
+                    # creating the directory first would create it at the old
+                    # path and leave the new one missing.
+                    await self.target.mkdir(self.working_dir)
+                    await self._run()
+
                 await TaskMiddleware.call_with_middleware(
                     TaskMiddlewareContext(task=self),
-                    self._run,
+                    mkdir_and_run,
                 )
             except CancelledError:
                 self.status = TaskStatus.CANCELED

--- a/tests/unit/task/test_task_base.py
+++ b/tests/unit/task/test_task_base.py
@@ -33,6 +33,7 @@ from horus_builtin.target.local import LocalTarget
 from horus_runtime.core.target.base import BaseTarget
 from horus_runtime.core.task.base import BaseTask
 from horus_runtime.core.task.status import TaskStatus
+from horus_runtime.middleware.task import TaskMiddleware, TaskMiddlewareContext
 from horus_runtime.registry.auto_registry import (
     AutoRegistry,
 )
@@ -296,6 +297,64 @@ class TestBaseTaskRun:
         await task.run()
 
         assert task.status == TaskStatus.SKIPPED
+
+    async def test_middleware_can_retarget_before_working_dir_is_created(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        The per-invocation working directory is created inside the middleware
+        chain, so middleware that repoints the task's target (the orchestrator
+        re-anchors runtime-added tasks that way) sees the directory created at
+        the new path -- not left behind at the old one.
+        """
+        anchored = tmp_path / "run-dir"
+        anchored.mkdir()
+        elsewhere = tmp_path / "cwd"
+        elsewhere.mkdir()
+        monkeypatch.chdir(elsewhere)
+
+        seen: list[bool] = []
+        # Snapshot before the middleware class below exists: defining it
+        # registers it, and restoring a snapshot taken afterwards would leave
+        # it anchoring every later test's tasks at this tmp_path.
+        original_registry = list(TaskMiddleware.registry)
+
+        class RecordingTask(ConcreteTestTask):
+            """Records whether its working directory existed when it ran."""
+
+            kind: str = "recording_task"
+            add_to_registry: ClassVar[bool] = False
+
+            async def _run(self) -> None:
+                seen.append(Path(self.working_dir).is_dir())
+
+        class AnchoringMiddleware(TaskMiddleware):
+            """Repoints the task at *anchored* just before it runs."""
+
+            add_to_registry: ClassVar[bool] = False
+
+            async def before(self, context: TaskMiddlewareContext) -> None:
+                context.task.target.working_directory = anchored.as_posix()
+
+        TaskMiddleware.registry = [*original_registry, AnchoringMiddleware]
+        try:
+            task = RecordingTask(
+                id="test_task_id",
+                name="test_task",
+                skip_if_complete=False,
+                runtime=CommandRuntime(command="echo test"),
+                executor=ShellExecutor(),
+                target=LocalTarget(),
+            )
+            await task.run()
+        finally:
+            TaskMiddleware.registry = original_registry
+
+        assert seen == [True]
+        assert Path(task.working_dir).is_dir()
+        assert anchored in Path(task.working_dir).parents
+        # No stray task directory left under the process CWD on the way there.
+        assert not (elsewhere / task.id).exists()
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Problem

`BaseTask.run` created the per-invocation working directory *before* entering the task middleware chain:

```python
await self.target.mkdir(self.working_dir)
await TaskMiddleware.call_with_middleware(TaskMiddlewareContext(task=self), self._run)
```

Middleware that repoints a task's target therefore ran too late: the directory was created at the old path, and the executor then launched with `cwd=task.working_dir` pointing at a directory that was never created.

This is how tc-os's `LocalWorkingDirMiddleware` re-anchors tasks the engine adds *during* a run (map-expander clones, inlined subworkflow bodies). Those clones get a `LocalTarget` with no `working_directory`, which falls back to the process CWD, so the run also littered task directories next to the orchestrator process.

## Fix

Move the `mkdir` into the innermost call of the chain, so every middleware `before` hook has run by the time the directory is created. No middleware in this repo depends on the directory existing before `call_next`.

## Test

`tests/unit/task/test_task_base.py::TestBaseTaskRun::test_middleware_can_retarget_before_working_dir_is_created` — a middleware retargets the task in `before`; the test asserts the working dir exists when `_run` executes, sits under the new target, and that no stray task directory is left under the process CWD.

Full `tests/unit` run shows no new failures (the 13 that fail locally fail identically on the base branch; they are coupled to ambient plugin installs).

---

**horus-docs PR:** https://github.com/temple-compute/horus-docs/pull/51
