### PR TITLE
feat(transfer): skip transfer when the artifact is already on the destination

### DIFF
--- a/src/horus_runtime/core/transfer/strategy.py
+++ b/src/horus_runtime/core/transfer/strategy.py
@@ -31,6 +31,7 @@ from abc import abstractmethod
 from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar, final
 
+from horus_runtime.logging import horus_logger
 from horus_runtime.middleware.transfer import (
     TransferMiddleware,
     TransferMiddlewareContext,
@@ -69,6 +70,8 @@ class BaseTransferStrategy[
         artifact: "BaseArtifact",
         source: S,
         destination: D,
+        *,
+        skip_if_present: bool = False,
     ) -> None:
         """
         Transfer *artifact* from *source* target to *destination* target.
@@ -79,10 +82,35 @@ class BaseTransferStrategy[
         same-filesystem shortcut lives here, at the single entry point every
         transfer goes through, so no individual strategy has to re-implement
         it.
+
+        ``skip_if_present`` asks the strategy to check whether the artifact
+        already exists on the destination and, if so, to skip the transfer
+        entirely (repointing the artifact at the existing on-target path).
+        The check uses the destination target's own primitives
+        (``path_exists`` + ``path_on_target``), so it works uniformly across
+        every target kind.
+
+        ``skip_if_present`` is deliberately *opt-in* and defaults to off: an
+        existence check is only safe when the caller can prove the existing
+        copy is not stale (e.g. a cache restore guarded by an input
+        fingerprint). Skipping a transfer because a *stale* file happens to
+        sit at the destination path would silently hand a consumer outdated
+        bytes, so ordinary input materialization must keep transferring.
         """
         if source.location_id == destination.location_id:
             artifact.path = Path(destination.path_on_target(artifact))
             return
+
+        if skip_if_present:
+            on_target = destination.path_on_target(artifact)
+            if await destination.path_exists(on_target):
+                artifact.path = Path(on_target)
+                horus_logger.log.debug(
+                    f"Artifact '{artifact.id}' already present on "
+                    f"{destination.kind} target '{destination.location_id}' "
+                    f"at {on_target}; skipping transfer"
+                )
+                return
 
         await TransferMiddleware.call_with_middleware(
             TransferMiddlewareContext(

--- a/tests/unit/transfer/test_transfer.py
+++ b/tests/unit/transfer/test_transfer.py
@@ -20,8 +20,10 @@ Unit tests for BaseTransferStrategy abstract base class.
 """
 
 from pathlib import Path
+from typing import ClassVar
 
 import pytest
+from pydantic import Field
 
 from horus_builtin.artifact.file import FileArtifact
 from horus_builtin.target.local import LocalTarget
@@ -277,3 +279,116 @@ class TestSameFilesystemShortCircuit:
 
         with pytest.raises(AssertionError, match="same-filesystem"):
             await _ExplodingTransfer().transfer(artifact, source, destination)
+
+
+class _PresenceProbeTarget(_OtherUnregisteredTarget):
+    """Target whose ``path_exists`` reports a canned answer."""
+
+    present: bool = False
+    probed: list[str] = Field(default_factory=list)
+
+    @property
+    def location_id(self) -> str:
+        return "test://probe"
+
+    async def path_exists(self, path: str) -> bool:
+        self.probed.append(path)
+        return self.present
+
+
+class _RecordingTransfer(BaseTransferStrategy):
+    """A strategy that records the destination it transferred to."""
+
+    add_to_registry = False
+    runs: ClassVar[list[tuple[str, str]]] = []
+
+    async def _transfer(
+        self,
+        artifact: BaseArtifact,
+        source: BaseTarget,
+        destination: BaseTarget,
+    ) -> None:
+        del source
+        _RecordingTransfer.runs.append(
+            (artifact.id, destination.path_on_target(artifact))
+        )
+
+
+@pytest.mark.unit
+class TestSkipIfPresent:
+    """
+    ``skip_if_present`` lets a transfer skip when the artifact already exists
+    on the destination, using only the destination's own ``path_exists`` and
+    ``path_on_target`` primitives.
+    """
+
+    async def test_skip_if_present_skips_transfer_and_repoints(self) -> None:
+        """
+        When the destination already has the artifact, ``_transfer`` is not
+        run and the artifact is repointed at the existing on-target path.
+        """
+        _RecordingTransfer.runs = []
+        source = _UnregisteredTarget()
+        destination = _PresenceProbeTarget(present=True)
+        artifact = FileArtifact(id="a", path=Path("/data/a.txt"))
+
+        await _RecordingTransfer().transfer(
+            artifact, source, destination, skip_if_present=True
+        )
+
+        assert _RecordingTransfer.runs == []
+        assert artifact.path == Path(destination.path_on_target(artifact))
+        assert destination.probed == [destination.path_on_target(artifact)]
+
+    async def test_missing_artifact_still_transfers(self) -> None:
+        """
+        When the destination does not have the artifact, ``skip_if_present``
+        leaves the transfer to run as normal.
+        """
+        _RecordingTransfer.runs = []
+        source = _UnregisteredTarget()
+        destination = _PresenceProbeTarget(present=False)
+        artifact = FileArtifact(id="a", path=Path("/data/a.txt"))
+
+        await _RecordingTransfer().transfer(
+            artifact, source, destination, skip_if_present=True
+        )
+
+        assert _RecordingTransfer.runs == [
+            (artifact.id, destination.path_on_target(artifact))
+        ]
+
+    async def test_default_never_probes_existence(self) -> None:
+        """
+        Without ``skip_if_present`` no existence probe happens and the
+        transfer always runs, even when the file already exists on the
+        destination. Keeping this opt-in is what stops a stale file from
+        silently standing in for fresh input bytes.
+        """
+        _RecordingTransfer.runs = []
+        source = _UnregisteredTarget()
+        destination = _PresenceProbeTarget(present=True)
+        artifact = FileArtifact(id="a", path=Path("/data/a.txt"))
+
+        await _RecordingTransfer().transfer(artifact, source, destination)
+
+        assert _RecordingTransfer.runs == [
+            (artifact.id, destination.path_on_target(artifact))
+        ]
+        assert destination.probed == []
+
+    async def test_same_location_shortcut_wins_over_probe(self) -> None:
+        """
+        Equal ``location_id`` short-circuits before any existence probe, even
+        with ``skip_if_present=True``.
+        """
+        source = _PresenceProbeTarget(present=False)
+        destination = _PresenceProbeTarget(present=False)
+        assert source.location_id == destination.location_id
+        artifact = FileArtifact(id="a", path=Path("/data/a.txt"))
+
+        await _ExplodingTransfer().transfer(
+            artifact, source, destination, skip_if_present=True
+        )
+
+        assert destination.probed == []


### PR DESCRIPTION
## Summary

Add an opt-in `skip_if_present` flag to `BaseTransferStrategy.transfer` so a
transfer can detect that the artifact already exists on the destination target
and skip moving it.

## Motivation

`tc-os` restores a run's cached artifacts from S3 onto the executing target so
unchanged tasks are skipped instead of re-run. For persistent remotes (SSH
hosts) the file is often already there, and re-downloading it from S3 is pure
waste. With this change the restore path can probe the destination's own
primitives (`path_exists` + `path_on_target`) and short-circuit.

## Behavior

- `transfer(artifact, source, destination, *, skip_if_present=False)`.
- When `skip_if_present=True` and `destination.path_exists(destination.path_on_target(artifact))`:
  the artifact is repointed at the existing on-target path and `_transfer`
  never runs.
- The same-location shortcut still wins (probe never fires).
- The flag is **opt-in and defaults off**: a bare existence check is only safe
  when the caller has an independent correctness guard (the cache restore is
  guarded by the task's manifest fingerprint). Normal input materialization
  keeps transferring so a stale file on a persistent remote never silently
  stands in for fresh input bytes.
- Implemented once in the base class, so `GenericTransfer`, `SSHToSSHTransfer`,
  and `s3.local` all inherit it for free. Uses only built-in target methods.

## Tests

`tests/unit/transfer/test_transfer.py`:
- skip when present (repoints, `_transfer` not called)
- transfer runs when missing
- default never probes existence
- same-location shortcut wins over the probe