### PR TITLE
docs: rewrite README and add community health files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,95 @@
+name: Bug report
+description: Something in horus-runtime does not work as documented.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. Please upgrade to the latest release first and
+        check whether it still happens there.
+
+        For questions and "how do I ...", use
+        [Discussions](https://github.com/temple-compute/horus-runtime/discussions).
+        For security issues, follow
+        [SECURITY.md](https://github.com/temple-compute/horus-runtime/blob/main/SECURITY.md)
+        instead.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you expect, and what did you get instead?
+      placeholder: |
+        Expected: the consumer task to receive the producer's output.
+        Actual: the run fails with ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: workflow
+    attributes:
+      label: Minimal workflow
+      description: >
+        The smallest workflow YAML (or Python) that reproduces the problem. This is
+        by far the most useful thing you can include.
+      render: yaml
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Save the workflow above as workflow.yaml
+        2. Run `horus run workflow.yaml --no-tui`
+        3. See the error
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: >
+        Output of `horus run workflow.yaml --no-tui --debug`. Please remove anything
+        sensitive such as hostnames, paths, or credentials.
+      render: shell
+    validations:
+      required: false
+
+  - type: input
+    id: version
+    attributes:
+      label: horus-runtime version
+      description: Output of `horus --version`.
+      placeholder: "0.3.2"
+    validations:
+      required: true
+
+  - type: input
+    id: python
+    attributes:
+      label: Python version
+      placeholder: "3.13.5"
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      placeholder: "Ubuntu 24.04 / macOS 15.2"
+    validations:
+      required: true
+
+  - type: input
+    id: plugins
+    attributes:
+      label: Plugins installed
+      description: >
+        Any horus-* plugins in the environment, such as horus-slurm or horus-docker,
+        with versions. Write "none" if there are none.
+      placeholder: "horus-slurm 0.2.0"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,17 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question or idea
+    url: https://github.com/temple-compute/horus-runtime/discussions
+    about: Ask how to do something, or talk through an idea before opening an issue.
+  - name: Documentation
+    url: https://docs.templecompute.com
+    about: CLI reference, SDK guides, and workflow authoring docs.
+  - name: Workflow library (Pantheon)
+    url: https://github.com/temple-compute/pantheon
+    about: Ready-made scientific workflows, and where to report issues with them.
+  - name: Report a security vulnerability
+    url: https://github.com/temple-compute/horus-runtime/security/advisories/new
+    about: Please report vulnerabilities privately, not as a public issue.
+  - name: Commercial licensing and support
+    url: mailto:christian@templecompute.com
+    about: Contact Temple Compute about commercial use, support, or partnerships.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,66 @@
+name: Feature request
+description: Suggest a capability or improvement for horus-runtime.
+labels: ["feature"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion. For open-ended ideas you would like to talk through
+        first, [Discussions](https://github.com/temple-compute/horus-runtime/discussions)
+        is often the better place.
+
+        Note that new targets, runtimes, executors, and artifact kinds can usually be
+        added as a plugin without changing this repo. See the
+        [plugin template](https://github.com/temple-compute/horus-runtime-plugin).
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: >
+        Describe the situation you hit, not just the feature you want. What are you
+        doing today, and where does it break down?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: >
+        What should Horus do? If it changes a workflow file, sketch the YAML you would
+        like to write.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Workarounds you have tried, or other designs you rejected and why.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Which part of the runtime does this touch?
+      options:
+        - Workflow / DAG semantics
+        - Targets (where tasks run)
+        - Runtimes (what runs)
+        - Executors (how it runs)
+        - Artifacts and transfer
+        - CLI or TUI
+        - Plugin API / SDK
+        - Not sure
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: contribute
+    attributes:
+      label: Would you be willing to contribute this?
+      options:
+        - label: I would be interested in opening a PR for this.
+          required: false

--- a/.github/workflows/python-ci.yaml
+++ b/.github/workflows/python-ci.yaml
@@ -1,6 +1,8 @@
 name: Python CI
 
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,89 @@
+# Contributor Covenant 3.0 Code of Conduct
+
+## Our Pledge
+
+We pledge to make our community welcoming, safe, and equitable for all.
+
+We are committed to fostering an environment that respects and promotes the dignity, rights, and contributions of all individuals, regardless of characteristics including race, ethnicity, caste, color, age, physical characteristics, neurodiversity, disability, sex or gender, gender identity or expression, sexual orientation, language, philosophy or religion, national or social origin, socio-economic position, level of education, or other status. The same privileges of participation are extended to everyone who participates in good faith and in accordance with this Covenant.
+
+
+## Encouraged Behaviors
+
+While acknowledging differences in social norms, we all strive to meet our community's expectations for positive behavior. We also understand that our words and actions may be interpreted differently than we intend based on culture, background, or native language.
+
+With these considerations in mind, we agree to behave mindfully toward each other and act in ways that center our shared values, including:
+
+1. Respecting the **purpose of our community**, our activities, and our ways of gathering.
+2. Engaging **kindly and honestly** with others.
+3. Respecting **different viewpoints** and experiences.
+4. **Taking responsibility** for our actions and contributions.
+5. Gracefully giving and accepting **constructive feedback**.
+6. Committing to **repairing harm** when it occurs.
+7. Behaving in other ways that promote and sustain the **well-being of our community**.
+
+
+## Restricted Behaviors
+
+We agree to restrict the following behaviors in our community. Instances, threats, and promotion of these behaviors are violations of this Code of Conduct.
+
+1. **Harassment.** Violating explicitly expressed boundaries or engaging in unnecessary personal attention after any clear request to stop.
+2. **Character attacks.** Making insulting, demeaning, or pejorative comments directed at a community member or group of people.
+3. **Stereotyping or discrimination.** Characterizing anyone’s personality or behavior on the basis of immutable identities or traits.
+4. **Sexualization.** Behaving in a way that would generally be considered inappropriately intimate in the context or purpose of the community.
+5. **Violating confidentiality**. Sharing or acting on someone's personal or private information without their permission.
+6. **Endangerment.** Causing, encouraging, or threatening violence or other harm toward any person or group.
+7. Behaving in other ways that **threaten the well-being** of our community.
+
+### Other Restrictions
+
+1. **Misleading identity.** Impersonating someone else for any reason, or pretending to be someone else to evade enforcement actions.
+2. **Failing to credit sources.** Not properly crediting the sources of content you contribute.
+3. **Promotional materials**. Sharing marketing or other commercial content in a way that is outside the norms of the community.
+4. **Irresponsible communication.** Failing to responsibly present content which includes, links or describes any other restricted behaviors.
+
+
+## Reporting an Issue
+
+Tensions can occur between community members even when they are trying their best to collaborate. Not every conflict represents a code of conduct violation, and this Code of Conduct reinforces encouraged behaviors and norms that can help avoid conflicts and minimize harm.
+
+When an incident does occur, it is important to report it promptly. To report a possible violation, email the maintainers at [christian@templecompute.com](mailto:christian@templecompute.com). Reports are handled confidentially. If your report concerns a maintainer, say so and it will be handled by someone not involved.
+
+The maintainers take reports of violations seriously and will make every effort to respond in a timely manner. They will investigate all reports of code of conduct violations, reviewing messages, logs, and recordings, or interviewing witnesses and other participants. They will keep investigation and enforcement actions as transparent as possible while prioritizing safety and confidentiality. In order to honor these values, enforcement actions are carried out in private with the involved parties, but communicating to the whole community may be part of a mutually agreed upon resolution.
+
+
+## Addressing and Repairing Harm
+
+If an investigation by the maintainers finds that this Code of Conduct has been violated, the following enforcement ladder may be used to determine how best to repair harm, based on the incident's impact on the individuals involved and the community as a whole. Depending on the severity of a violation, lower rungs on the ladder may be skipped.
+
+1) Warning
+   1) Event: A violation involving a single incident or series of incidents.
+   2) Consequence: A private, written warning from the maintainers.
+   3) Repair: Examples of repair include a private written apology, acknowledgement of responsibility, and seeking clarification on expectations.
+2) Temporarily Limited Activities
+   1) Event: A repeated incidence of a violation that previously resulted in a warning, or the first incidence of a more serious violation.
+   2) Consequence: A private, written warning with a time-limited cooldown period designed to underscore the seriousness of the situation and give the community members involved time to process the incident. The cooldown period may be limited to particular communication channels or interactions with particular community members.
+   3) Repair: Examples of repair may include making an apology, using the cooldown period to reflect on actions and impact, and being thoughtful about re-entering community spaces after the period is over.
+3) Temporary Suspension
+   1) Event: A pattern of repeated violation which the maintainers have tried to address with warnings, or a single serious violation.
+   2) Consequence: A private written warning with conditions for return from suspension. In general, temporary suspensions give the person being suspended time to reflect upon their behavior and possible corrective actions.
+   3) Repair: Examples of repair include respecting the spirit of the suspension, meeting the specified conditions for return, and being thoughtful about how to reintegrate with the community when the suspension is lifted.
+4) Permanent Ban
+   1) Event: A pattern of repeated code of conduct violations that other steps on the ladder have failed to resolve, or a violation so serious that the maintainers determine there is no way to keep the community safe with this person as a member.
+   2) Consequence: Access to all community spaces, tools, and communication channels is removed. In general, permanent bans should be rarely used, should have strong reasoning behind them, and should only be resorted to if working through other remedies has failed to change the behavior.
+   3) Repair: There is no possible repair in cases of this severity.
+
+This enforcement ladder is intended as a guideline. It does not limit the ability of maintainers to use their discretion and judgment, in keeping with the best interests of our community.
+
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public or other spaces. Examples of representing our community include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 3.0, permanently available at [https://www.contributor-covenant.org/version/3/0/](https://www.contributor-covenant.org/version/3/0/).
+
+Contributor Covenant is stewarded by the Organization for Ethical Source and licensed under CC BY-SA 4.0. To view a copy of this license, visit [https://creativecommons.org/licenses/by-sa/4.0/](https://creativecommons.org/licenses/by-sa/4.0/)
+
+For answers to common questions about Contributor Covenant, see the FAQ at [https://www.contributor-covenant.org/faq](https://www.contributor-covenant.org/faq). Translations are provided at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations). Additional enforcement and community guideline resources can be found at [https://www.contributor-covenant.org/resources](https://www.contributor-covenant.org/resources). The enforcement ladder was inspired by the work of [Mozilla’s code of conduct team](https://github.com/mozilla/inclusion).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,102 @@
+# Contributing to Horus Runtime
+
+Thanks for taking the time to contribute. Bug reports, docs fixes, plugins, and features
+are all welcome.
+
+## Ways to help
+
+- **Report a bug**: [open an issue](https://github.com/temple-compute/horus-runtime/issues/new/choose)
+  with a minimal `workflow.yaml` that reproduces it.
+- **Pick up an issue**: start with
+  [good first issues](https://github.com/temple-compute/horus-runtime/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
+- **Ask or propose something**: use
+  [Discussions](https://github.com/temple-compute/horus-runtime/discussions) before large
+  changes, so we can agree on the approach first.
+- **Write a plugin**: you usually do not need to change this repo at all. See
+  [the plugin template](https://github.com/temple-compute/horus-runtime-plugin).
+
+## Development setup
+
+Requirements: Python 3.13 or 3.14.
+
+With `uv` (what CI uses):
+
+```bash
+git clone https://github.com/temple-compute/horus-runtime.git
+cd horus-runtime
+uv sync --group dev
+```
+
+With micromamba and pip:
+
+```bash
+micromamba create -y -n horus_runtime python=3.14
+micromamba activate horus_runtime
+pip install -e ".[dev]"
+```
+
+Install the git hooks, which run lint, types, translations, and license headers on commit:
+
+```bash
+pre-commit install
+```
+
+## Everyday commands
+
+| Command | Purpose |
+| --- | --- |
+| `make test` | Run the full test suite with coverage (same invocation as CI). |
+| `make lint` | Ruff lint, Ruff format check, and mypy (same as CI). |
+| `make format` | Auto-fix and format with Ruff. |
+| `make type-check` | mypy only. |
+| `make add-license-headers` | Apply AGPL headers to `src` and `tests`. |
+| `make babel-check` | Verify no missing or fuzzy translations. |
+| `make help` | Everything else. |
+
+## What CI enforces
+
+Your PR must pass all of these, so run them locally first:
+
+- **Ruff** lint and format, at a 79 character line length.
+- **mypy in strict mode** over `src` and `tests`. New code needs type annotations.
+- **Tests** on Python 3.13 and 3.14, with a **90% coverage floor**.
+- **License headers**: CI runs `make add-license-headers` and fails if it changes any
+  file, so run it before pushing.
+- **Translations**: `make babel-check` must report every string translated.
+
+## Internationalization
+
+User-facing strings go through gettext. Import the translation helper and wrap them:
+
+```python
+from horus_runtime.i18n import tr as _
+
+message = _("Hello, world!")
+
+# Plurals and substitution
+message = _("{n} notification", "{n} notifications", n=2)
+```
+
+After adding or changing strings, refresh the catalogs and translate the new entries
+(currently `es`), then verify:
+
+```bash
+make babel-refresh
+make babel-check
+```
+
+Details in the [SDK i18n guide](https://docs.templecompute.com/sdk/i18n).
+
+## Pull requests
+
+- Branch off `main` and keep the change focused on one thing.
+- Add tests for behaviour changes.
+- Fill in the PR template. **If a user, plugin, or GUI can observe your change, it needs
+  documentation**, and the template asks you to link the corresponding
+  [horus-docs](https://github.com/temple-compute/horus-docs) PR.
+- Green CI is required before review.
+
+## License
+
+By contributing you agree that your contributions are licensed under the
+[AGPL-3.0](LICENSE), the same license as the project.

--- a/README.md
+++ b/README.md
@@ -1,126 +1,192 @@
-# horus-runtime
+# Horus Runtime
 
+**Reproducible scientific workflows, from your laptop to the HPC cluster.**
+
+[![PyPI](https://img.shields.io/pypi/v/horus-runtime?color=blue)](https://pypi.org/project/horus-runtime/)
+[![Python](https://img.shields.io/pypi/pyversions/horus-runtime)](https://pypi.org/project/horus-runtime/)
+[![CI](https://img.shields.io/github/actions/workflow/status/temple-compute/horus-runtime/python-ci.yaml?branch=main&label=CI)](https://github.com/temple-compute/horus-runtime/actions/workflows/python-ci.yaml)
+[![Downloads](https://img.shields.io/pypi/dm/horus-runtime?color=blue)](https://pypi.org/project/horus-runtime/)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
-[![Python 3.13+](https://img.shields.io/badge/python-3.13%20%E2%80%94%203.14-blue.svg)](https://www.python.org/downloads/)
+[![Docs](https://img.shields.io/badge/docs-templecompute.com-blue)](https://docs.templecompute.com)
+[![Discussions](https://img.shields.io/github/discussions/temple-compute/horus-runtime)](https://github.com/temple-compute/horus-runtime/discussions)
 
-horus-runtime is the command-line engine for the Temple Compute platform, a workflow manager designed for High Performance Computing. It enables the creation, management, and execution of complex workflows, especially scientific computing.
-
-- **Modular & Extensible:** Designed for integration, automation, and extension via Python.
-
-## Features
-
-- **Workflow Execution:** Run and manage scientific workflows from the terminal.
-- **Modular Blocks:** Compose workflows from reusable, autonomous blocks.
-- **Remote Execution:** Configure targets to offload calculations.
-- **Extensible:** Build and share your own blocks and extensions using the horus-runtime library.
-- **Reproducibility:** Share and version your workflows, including all state and configuration.
+Horus Runtime is the open-source engine behind the [Temple Compute](https://www.templecompute.com)
+platform: you describe a pipeline once, in YAML or Python, and run it wherever the compute
+lives. It tracks every artifact a task produces, moves those artifacts between machines
+for you, and skips work that is already done when you run it again.
 
 <img width="1600" height="1202" alt="Horus Runtime TUI" src="https://github.com/user-attachments/assets/8f6a5f77-c0fa-48bf-b82b-5683af1caec4" />
 
-## Workflows Library
+## Quickstart
 
-Check out the [Pantheon](https://github.com/temple-compute/pantheon/) repository for a curated library of production-ready workflows, from drug discovery (Boltz-2 virtual screening, AutoDock Vina docking) to molecular dynamics setup with BioExcel Building Blocks (GROMACS, AMBER). Contributions are welcomed.
-
-## How to Run horus-runtime
-
-You can find full documentation on the SDK and the command line interface at: [docs.templecompute.com](https://docs.templecompute.com)
-
-### Installation
-
-Using `uv` (recommended):
+Install it:
 
 ```bash
-uv add horus-runtime
+uv add horus-runtime     # or: pip install horus-runtime
 ```
 
-Or with plain `pip`:
+Save this as `workflow.yaml`:
 
-```bash
-pip install horus-runtime
+```yaml
+name: example_pipeline
+kind: horus_workflow
+
+tasks:
+  - id: producer
+    name: Produce data
+    kind: horus_task
+    runtime:
+      kind: command
+      # $data renders to the on-target path of the "data" output artifact.
+      command: "mkdir -p /tmp/horus_example && echo 42 > $data"
+    executor:
+      kind: shell
+    target:
+      kind: local
+    outputs:
+      - id: data
+        kind: file
+        path: /tmp/horus_example/data.txt
+
+  - id: consumer
+    name: Summarize data
+    kind: horus_task
+    runtime:
+      kind: command
+      command: "wc -l ${data_in} > $summary"
+    executor:
+      kind: shell
+    target:
+      kind: local
+    inputs:
+      - id: data_in
+        kind: file
+        path: /tmp/horus_example/data.txt
+    outputs:
+      - id: summary
+        kind: file
+        path: /tmp/horus_example/summary.txt
+
+# Edges are the DAG: producer.data feeds consumer.data_in, so producer runs
+# first and its output is transferred before the consumer starts.
+edges:
+  - source: producer
+    source_output: data
+    target: consumer
+    target_input: data_in
 ```
 
-Some workflows (e.g. BioExcel-based ones) also require a conda-family tool (`micromamba`, `mamba`, or `conda`) on your `PATH` to build simulation environments.
-
-### Quick Start
+Run it:
 
 ```bash
 horus run workflow.yaml
 ```
 
-This executes the pipeline defined in `workflow.yaml`, routing each stage to the configured compute target (local, SSH remote, or HPC cluster).
-
-## Development
-
-### Requirements
-
-- Python 3.13–3.14
-- [micromamba](https://mamba.readthedocs.io/en/latest/user_guide/micromamba.html) (for environment management, optional but recommended)
-
-### Environment
-
-```bash
-# Create and activate environment (recommended)
-micromamba create -y -n horus_runtime python=3.14
-micromamba activate horus_runtime
+```
+[HorusTask._run] Task Produce data started.
+[TaskTimeMiddleware.after] Task Produce data completed in 0.01 seconds.
+[HorusTask._run] Task Summarize data started.
+[TaskTimeMiddleware.after] Task Summarize data completed in 0.03 seconds.
+[WorkflowTimeMiddleware.after] Workflow example_pipeline completed in 0.05 seconds.
 ```
 
-Install the package in editable (development) mode to enable local development alongside dependencies:
+Run it a second time and nothing re-executes, because both tasks' output artifacts already
+exist:
 
-```bash
-pip install -e .[dev]
+```
+[BaseTask.run] Skipping task Produce data. Already complete.
+[BaseTask.run] Skipping task Summarize data. Already complete.
 ```
 
-To commit to the repo, you'll need the pre-commit package:
+Delete the outputs, or pass `--no-skip-all`, to force a fresh run.
 
-```bash
-pip install pre-commit
+## Why Horus
+
+- **Write once, run anywhere.** A task declares *what* to run (`runtime`), *how* to run it
+  (`executor`), and *where* (`target`). Moving a stage from your laptop to a SLURM cluster
+  is a change to the `target` block, not a rewrite.
+- **Artifacts, not filenames.** Inputs and outputs are typed, addressable objects. Horus
+  resolves them into your commands, transfers them between targets when an edge crosses
+  machines, and knows when they already exist.
+- **Restartable by default.** Completed tasks are skipped on re-run, so a pipeline that
+  failed at hour nine picks up at hour nine.
+- **Everything is a plugin.** Targets, runtimes, executors, artifacts, tasks, transfer
+  strategies, and middleware are all registered `kind`s. Adding one is a package with an
+  entry point, never a fork.
+- **Built for real science.** Resource requests, subworkflows, mapped fan-out, run
+  packaging, and a live TUI, driven from a file you can commit and diff.
+
+## CLI
+
+| Command | What it does |
+| --- | --- |
+| `horus run WORKFLOW_YAML` | Execute the workflow. `--trigger` picks the starting task, `--no-tui` streams plain logs, `--no-skip TASK_ID` / `--no-skip-all` force re-runs, `--debug` turns on debug logging. |
+| `horus package WORKFLOW_YAML` | Bundle the workflow and every file it references into a zip, so it runs on a machine that never had your directory. |
+| `horus sanitize WORKFLOW_YAML` | Promote implicit root inputs into declared top-level artifacts, which is what lets a UI offer them as workflow inputs. |
+
+Full CLI and SDK reference: [docs.templecompute.com](https://docs.templecompute.com).
+
+## Built-in kinds
+
+Everything below ships with the runtime and is usable straight after install.
+
+| Category | Kinds |
+| --- | --- |
+| Targets | `local` |
+| Runtimes | `command`, `python`, `python_string`, `python_script` |
+| Executors | `shell`, `python_exec`, `python_fn`, `python_fn_external` |
+| Artifacts | `file`, `folder`, `json`, `pickle`, `number`, `boolean`, `string` |
+| Tasks | `horus_task`, `subworkflow` |
+| Workflows | `horus_workflow` |
+
+## Ecosystem
+
+Official plugins, installable alongside the runtime:
+
+| Plugin | Adds |
+| --- | --- |
+| [horus-slurm](https://github.com/temple-compute/horus-slurm) | Run tasks as SLURM jobs on an HPC cluster. |
+| [horus-docker](https://github.com/temple-compute/horus-docker) | Execute tasks inside Docker containers. |
+| [horus-singularity](https://github.com/temple-compute/horus-singularity) | Execute tasks inside Singularity/Apptainer containers. |
+| [horus-environments](https://github.com/temple-compute/horus-environments) | Auto-provision per-task Python environments with `uv` or conda. |
+
+And for ready-made science: [**Pantheon**](https://github.com/temple-compute/pantheon) is a
+curated library of production workflows, from drug discovery (Boltz-2 virtual screening,
+AutoDock Vina docking) to molecular dynamics setup with BioExcel Building Blocks (GROMACS,
+AMBER). Contributions welcome there too.
+
+## Writing your own plugin
+
+A plugin is an ordinary Python package that declares a `horus.*` entry point:
+
+```toml
+[project.entry-points."horus.target"]
+my_cluster = "my_package.target"
 ```
 
-### Command Shortcuts
+Once installed, `kind: my_cluster` works in any workflow. Start from the
+[plugin template](https://github.com/temple-compute/horus-runtime-plugin) and see the
+[SDK docs](https://docs.templecompute.com) for the base classes.
 
-- **Run all tests:**
-  ```bash
-  make test
-  ```
-- **Lint and type-check:**
-  ```bash
-  make lint
-  make type-check
-  ```
-- **Format code:**
-  ```bash
-  make format
-  ```
+## Contributing
 
-See `make help` for all available commands.
+Contributions are very welcome, from bug reports to new plugins.
 
-## Internationalization (i18n)
+- Read [CONTRIBUTING.md](CONTRIBUTING.md) for dev setup and the PR checklist.
+- Browse [good first issues](https://github.com/temple-compute/horus-runtime/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
+- Ask questions in [Discussions](https://github.com/temple-compute/horus-runtime/discussions).
+- Be excellent to each other: [Code of Conduct](CODE_OF_CONDUCT.md).
 
-Horus Runtime supports multiple languages through a comprehensive i18n system. Translations are managed using Babel and GNU gettext.
-
-### Using Translations in Your Code
-
-Import the translation function in your plugins:
-
-```python
-from horus_runtime.i18n import tr as _
-
-# Use it in your code
-message = _("Hello, world!")
-
-# Supports plurals and text substitution
-message = _("{n} notification", "{n} notifications", n=2)
-```
-
-For detailed documentation on internationalization and SDK usage, see the [horus-runtime SDK i18n guide](https://docs.templecompute.com/sdk/i18n).
+Found a security issue? Please follow [SECURITY.md](SECURITY.md) instead of opening an issue.
 
 ## Funding & Credits
 
-- Developed by [Temple Compute](www.templecompute.com)
+Developed by [Temple Compute](https://www.templecompute.com).
 
 ## License
 
 `horus-runtime` is licensed under the GNU Affero General Public License v3.0 (AGPL-3.0).
 See the [LICENSE](LICENSE) file for details.
 
-For commercial licensing and support, please contact Temple Compute at [christian@templecompute.com](mailto:christian@templecompute.com)
+For commercial licensing and support, contact Temple Compute at
+[christian@templecompute.com](mailto:christian@templecompute.com).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,44 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes land on the latest released version of `horus-runtime`. Please upgrade to
+the newest release before reporting an issue.
+
+| Version | Supported |
+| --- | --- |
+| Latest release | Yes |
+| Anything older | No |
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for a security problem.**
+
+Report it privately in either of these ways:
+
+- [Open a private security advisory](https://github.com/temple-compute/horus-runtime/security/advisories/new)
+  on this repository (preferred).
+- Email [christian@templecompute.com](mailto:christian@templecompute.com).
+
+Please include:
+
+- What the issue is and the impact you believe it has.
+- Affected version (`horus --version`) and platform.
+- Steps to reproduce, ideally a minimal workflow file.
+
+## What to expect
+
+- We aim to acknowledge a report within **3 working days**.
+- We will confirm the issue, agree a fix and a disclosure timeline with you, and keep you
+  updated while we work on it.
+- With your permission we will credit you in the advisory when the fix is released.
+
+Please give us a reasonable window to ship a fix before disclosing publicly.
+
+## Scope note
+
+Horus Runtime executes the commands and code that a workflow file tells it to execute.
+Treat a workflow file as you would a shell script: **only run workflows you trust**. A
+workflow doing something harmful because its author wrote it that way is not a
+vulnerability in the runtime. Sandbox escapes, privilege escalation beyond what the
+workflow declares, and unintended remote code execution are.


### PR DESCRIPTION
## Summary

Makes the repo readable and contributable for a first-time visitor. The old README led with the package name, had two static badges, and spent half its length on maintainer-only content before showing a runnable workflow. There were no community health files at all.

**README**
- Tagline, badge row (PyPI, Python, CI, downloads, license, docs, discussions), and the TUI screenshot before any prose.
- A copy-pasteable quickstart with a real `workflow.yaml` and its actual output. I ran it end to end: both tasks execute, artifacts land in `/tmp/horus_example/`, and a second run skips both.
- "Why Horus", a CLI table (`run` / `package` / `sanitize`, flags checked against `src/horus_runtime/cli.py`), a built-in kinds table generated from the `horus.*` entry points, and an **Ecosystem** section linking the public plugins (horus-slurm, horus-docker, horus-singularity, horus-environments) plus Pantheon.
- Development setup and the i18n section move to `CONTRIBUTING.md`.

**New files**
- `CONTRIBUTING.md`: dev setup with both uv and micromamba, make targets, and exactly what CI enforces (ruff, mypy strict, 90% coverage, license headers, babel).
- `CODE_OF_CONDUCT.md`: Contributor Covenant 3.0, verbatim upstream text with the reporting placeholder filled in.
- `SECURITY.md`: private reporting via GitHub advisories, plus a scope note that a workflow doing something harmful because its author wrote it that way is not a runtime vulnerability.
- `.github/ISSUE_TEMPLATE/`: bug and feature forms, with `config.yml` routing questions to Discussions and vulnerabilities to advisories.

**CI**
- `python-ci` now also runs on pushes to `main`. Without this the branch-scoped CI badge renders "no status" forever.

## Repo settings (already applied, outside this diff)

- 16 topics added (was zero): `workflow-engine`, `hpc`, `scientific-computing`, `slurm`, `bioinformatics`, `drug-discovery`, `molecular-dynamics`, `dag`, and others.
- Description sharpened; homepage set to `https://docs.templecompute.com`.
- `good first issue` label created.

## Verification

- Quickstart workflow run twice locally: executes, then skips. Output in the README is real, trimmed of timestamps.
- All 27 URLs return 200. The one exception is the `blob/main/SECURITY.md` link, which resolves once this merges.
- All new YAML parses; every pre-commit hook passes.

## Follow-ups (not in this PR)

- `Makefile:43` creates the env with `python=3.11`, but `requires-python = ">=3.13"`, so `make install` produces an env that cannot install the package.
- The two `astral-sh/setup-uv` pins differ between the `lint` and `test` jobs.
- Worth labelling a few of the open issues `good first issue` now that the label exists.

## Documentation impact

- [x] No documentation update required

Docs-only change to repo-level files; the docs site is unaffected.