### PR TITLE
feat(workflow): scope non-co-located task working dirs by workflow/run

### DIFF
--- a/src/horus_runtime/core/task/base.py
+++ b/src/horus_runtime/core/task/base.py
@@ -183,6 +183,15 @@ class BaseTask(AutoRegistry, entry_point="task"):
     written back into workflow YAML or a hosted workflow snapshot.
     """
 
+    _run_scope: str | None = PrivateAttr(default=None)
+    """
+    Opaque relative path fragment nested under the target's own working
+    directory, set by :meth:`BaseWorkflow._anchor_task` for tasks whose
+    target is not co-located with the orchestrator. Private for the same
+    reason as :attr:`_execution_id`: it must be recomputed fresh from the
+    current run every time, never round-tripped through a stored snapshot.
+    """
+
     @property
     def working_dir(self) -> str:
         """
@@ -190,12 +199,17 @@ class BaseTask(AutoRegistry, entry_point="task"):
         its target's working directory. Inputs are materialized here and
         outputs and side-products are written relative to it.
 
+        A non-co-located target's own directory is further scoped by
+        :attr:`_run_scope` (workflow/run isolation) before the task id.
         Before the task is invoked the legacy ``<target>/<task-id>`` path is
         returned, which keeps setup and inspection code deterministic. Once
         execution begins, the invocation id is appended so re-running a task
         never reuses a previous job's directory.
         """
-        path = Path(self.target.resolved_working_directory) / self.id
+        path = Path(self.target.resolved_working_directory)
+        if self._run_scope:
+            path /= self._run_scope
+        path /= self.id
         if self._execution_id is not None:
             path /= self._execution_id
         return path.as_posix()

--- a/src/horus_runtime/core/workflow/base.py
+++ b/src/horus_runtime/core/workflow/base.py
@@ -147,6 +147,24 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
     free text and may contain path separators.
     """
 
+    workflow_slug: str | None = None
+    """
+    Filesystem-safe, caller-assigned identifier for this workflow, distinct
+    from :attr:`name`. Populated from the stored workflow's slug when a
+    snapshot is validated into a ``BaseWorkflow`` instance; ``None`` when a
+    workflow is built without one (e.g. from a bare YAML document).
+    """
+
+    run_scope: str | None = None
+    """
+    Opaque, caller-set relative path fragment nested under a non-co-located
+    target's own working directory when anchoring tasks (see
+    :meth:`_anchor_task`). This class does not interpret its contents -- a
+    caller such as the orchestrator composes it (e.g. ``f"{workflow_slug}/
+    {run_id}"``) and assigns it before :meth:`run`. Transient: never part of
+    a persisted snapshot's meaning, only ever read fresh at anchor time.
+    """
+
     tasks: list[BaseTask] = Field(
         default_factory=list,
     )
@@ -1262,6 +1280,16 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
           orchestrator target's working directory, mirroring what
           :meth:`_propagate_orchestrator_working_directory` used to do
           inline.
+        - A non-co-located task target (e.g. a remote SSH-style target) keeps
+          its own author-declared ``working_directory`` untouched, but the
+          task records :attr:`run_scope` on itself (``task._run_scope``) so
+          :attr:`BaseTask.working_dir` nests under it. The target's field is
+          deliberately never mutated here: it is part of the persisted
+          snapshot, and a rerun starts from an earlier run's snapshot, so
+          appending onto it in place would compound across reruns. Recording
+          the scope on the task instead means it is always recomputed fresh
+          from this run's :attr:`run_scope`, never from stale serialized
+          state.
 
         Every step here only rewrites still-relative/unset state, so calling
         this more than once for the same task is safe.
@@ -1287,6 +1315,10 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
                     == self.orchestrator_target.location_id
                 ):
                     target.working_directory = orchestrator_wd
+                elif (
+                    target.location_id != self.orchestrator_target.location_id
+                ):
+                    task._run_scope = self.run_scope  # noqa: SLF001
 
     @final
     def _resolve_run_paths(self) -> Path:

--- a/tests/unit/workflow/test_run_layout.py
+++ b/tests/unit/workflow/test_run_layout.py
@@ -277,6 +277,99 @@ class TestRuntimeAnchorLocalPaths:
 
 
 @pytest.mark.unit
+class TestRemoteTargetRunScope:
+    """A non-co-located target's own working_directory is left untouched by
+    anchoring, but the task nests its working_dir under wf.run_scope.
+    """
+
+    def _make_workflow(
+        self, tmp_path: Path, run_scope: str | None
+    ) -> tuple[HorusWorkflow, HorusTask, MagicMock]:
+        ssh_target = MagicMock(spec=BaseTarget)
+        ssh_target.working_directory = "/home/myuser/horus"
+        ssh_target.location_id = "remote-host"
+        ssh_target.resolved_working_directory = "/home/myuser/horus"
+
+        task = HorusTask(
+            id="prep",
+            name="prep",
+            runtime=CommandRuntime(command="echo hi"),
+            executor=ShellExecutor(),
+            target=ssh_target,
+        )
+        wf = HorusWorkflow(
+            name="layout",
+            tasks=[task],
+            orchestrator_target=LocalTarget(working_directory="results"),
+            run_scope=run_scope,
+        )
+        wf._base_directory = tmp_path
+        return wf, task, ssh_target
+
+    def test_task_working_dir_nests_under_run_scope(
+        self, tmp_path: Path
+    ) -> None:
+        """The task's working_dir nests under the workflow's run_scope."""
+        wf, task, ssh_target = self._make_workflow(
+            tmp_path, run_scope="boltz_drugflow/run-123"
+        )
+        wf._resolve_run_paths()
+
+        expected = "/home/myuser/horus/boltz_drugflow/run-123/prep"
+        assert task.working_dir == expected
+        # The author-declared base is never mutated.
+        assert ssh_target.working_directory == "/home/myuser/horus"
+
+    def test_no_run_scope_leaves_working_dir_unchanged(
+        self, tmp_path: Path
+    ) -> None:
+        """Without a run_scope the legacy target/task layout is kept."""
+        wf, task, ssh_target = self._make_workflow(tmp_path, run_scope=None)
+        wf._resolve_run_paths()
+
+        assert task.working_dir == "/home/myuser/horus/prep"
+        assert ssh_target.working_directory == "/home/myuser/horus"
+
+    def test_anchoring_twice_does_not_double_nest(
+        self, tmp_path: Path
+    ) -> None:
+        """Re-anchoring must not nest run_scope more than once."""
+        wf, task, ssh_target = self._make_workflow(
+            tmp_path, run_scope="boltz_drugflow/run-123"
+        )
+        wf._resolve_run_paths()
+        wf._anchor_task(task)
+
+        expected = "/home/myuser/horus/boltz_drugflow/run-123/prep"
+        assert task.working_dir == expected
+        assert ssh_target.working_directory == "/home/myuser/horus"
+
+    def test_colocated_target_unaffected_by_run_scope(
+        self, tmp_path: Path
+    ) -> None:
+        """LocalTarget tasks keep their existing full-overwrite behavior;
+        run_scope is only consulted for non-co-located targets.
+        """
+        task = HorusTask(
+            id="prep",
+            name="prep",
+            runtime=CommandRuntime(command="echo hi"),
+            executor=ShellExecutor(),
+            target=LocalTarget(),
+        )
+        wf = HorusWorkflow(
+            name="layout",
+            tasks=[task],
+            orchestrator_target=LocalTarget(working_directory="results"),
+            run_scope="boltz_drugflow/run-123",
+        )
+        wf._base_directory = tmp_path
+        wf._resolve_run_paths()
+
+        assert task.working_dir == (tmp_path / "results" / "prep").as_posix()
+
+
+@pytest.mark.unit
 class TestFromYamlBaseDirectory:
     """from_yaml anchors the run at the workflow file's own directory."""
 


### PR DESCRIPTION
## What

Adds a caller-set `run_scope` fragment to `BaseWorkflow` and records it on tasks whose target is **not** co-located with the orchestrator (e.g. SSH-style remote targets).

Today a remote target's author-declared `working_directory` (e.g. `/home/myuser/horus`) is left untouched by anchoring, so `BaseTask.working_dir` becomes `<target>/<task_id>/<execution_id>` with no run or workflow isolation. Two runs of the same workflow, or two different workflows sharing a target, can stomp on each other's files.

With this change the orchestrator (or any caller) sets `wf.run_scope` (e.g. `f"{workflow_slug}/{run_id}"`) before `wf.run()`, and non-co-located tasks nest their `working_dir` under `<target>/<run_scope>/<task_id>/<execution_id>`.

## Why this design

- `target.working_directory` is **never mutated**. It is part of the persisted workflow snapshot, and a rerun starts from an earlier run's snapshot, so appending in place would compound across reruns. Recording `run_scope` on the task (`_run_scope`, a `PrivateAttr` like `_execution_id`) means it is always recomputed fresh from the current run.
- Co-located (LocalTarget) tasks are untouched: they already get a full run-scoped overwrite from the orchestrator, which is safe to keep doing wholesale.

## Tests

736 passed; new coverage:
- `test_task_working_dir_nests_under_run_scope`
- `test_no_run_scope_leaves_working_dir_unchanged`
- `test_anchoring_twice_does_not_double_nest`
- `test_colocated_target_unaffected_by_run_scope`

## Companion PR

Consumes this from tc-os: temple-compute/tc-os (orchestrator sets `wf.run_scope` and nests Local work dirs under `workflow_slug/run_id`).