### PR TITLE
feat(executor): make side-artifact collection re-entrant

### DIFF
--- a/src/horus_runtime/core/executor/base.py
+++ b/src/horus_runtime/core/executor/base.py
@@ -41,6 +41,7 @@ from horus_runtime.middleware.executor import (
 )
 from horus_runtime.registry.auto_registry import AutoRegistry
 from horus_runtime.settings import runtime_settings
+from pydantic import PrivateAttr
 
 if TYPE_CHECKING:
     from horus_runtime.core.task.base import BaseTask
@@ -92,6 +93,16 @@ class BaseExecutor(AutoRegistry, entry_point="executor"):
     """
     Which runtime types this executor can handle. By default, an executor can
     handle any runtime type.
+    """
+
+    _side_landing: dict[str, Path] = PrivateAttr(default_factory=dict)
+    """
+    Local landing directory per task id for collected side artifacts.
+
+    Allocated on first collection and reused afterwards, so collecting again
+    mid-task refreshes the same files instead of scattering copies across
+    fresh temp directories. Keyed by task id because map expansion can run
+    several tasks through one executor instance.
     """
 
     async def resource_scope(
@@ -200,6 +211,11 @@ class BaseExecutor(AutoRegistry, entry_point="executor"):
         ``runtime_settings.MAX_SIDE_ARTIFACT_BYTES`` are skipped with a
         warning; large data should be declared as task inputs/outputs, which
         have their own transfer strategies.
+
+        Safe to call repeatedly while the task is still running, so a long
+        task's log and resource trace can be surfaced before it ends: the
+        landing directory is allocated once per task and each artifact is
+        refreshed in place rather than registered a second time.
         """
         try:
             entries = await task.target.list_dir(task.side_artifacts_dir)
@@ -220,7 +236,15 @@ class BaseExecutor(AutoRegistry, entry_point="executor"):
         safe_id = "".join(
             c if (c.isalnum() or c in "-_.") else "_" for c in task.id
         )
-        landing = Path(tempfile.mkdtemp(prefix=f"horus-side-{safe_id}-"))
+        landing = self._side_landing.get(task.id)
+        if landing is None:
+            landing = Path(tempfile.mkdtemp(prefix=f"horus-side-{safe_id}-"))
+            self._side_landing[task.id] = landing
+
+        # Artifacts already registered for this task, so a repeat collection
+        # refreshes their contents instead of appending a second copy. Ids are
+        # unique per task by construction below.
+        known = {artifact.id for artifact in task.side_artifacts}
 
         for entry in entries:
             try:
@@ -230,15 +254,16 @@ class BaseExecutor(AutoRegistry, entry_point="executor"):
                         % {"name": entry.name}
                     )
                     continue
+                artifact_id = f"{task.id}_{entry.name}"
                 if entry.is_dir:
                     local_path = await self._pull_tree(
                         task, entry.path, landing / entry.name, cap
                     )
-                    task.side_artifacts.append(
-                        FolderArtifact(
-                            id=f"{task.id}_{entry.name}", path=local_path
+                    if artifact_id not in known:
+                        task.side_artifacts.append(
+                            FolderArtifact(id=artifact_id, path=local_path)
                         )
-                    )
+                        known.add(artifact_id)
                 else:
                     if entry.size > cap:
                         horus_logger.log.warning(
@@ -253,11 +278,11 @@ class BaseExecutor(AutoRegistry, entry_point="executor"):
                     local_path.write_bytes(
                         await task.target.get_file(entry.path)
                     )
-                    task.side_artifacts.append(
-                        FileArtifact(
-                            id=f"{task.id}_{entry.name}", path=local_path
+                    if artifact_id not in known:
+                        task.side_artifacts.append(
+                            FileArtifact(id=artifact_id, path=local_path)
                         )
-                    )
+                        known.add(artifact_id)
             except Exception as exc:
                 horus_logger.log.warning(
                     _("Failed to collect side artifact %(name)s: %(err)s")

--- a/tests/unit/executor/test_collect_side_artifacts.py
+++ b/tests/unit/executor/test_collect_side_artifacts.py
@@ -88,6 +88,66 @@ class TestCollectLocalSideArtifacts:
         assert isinstance(empty, FolderArtifact)
         assert empty.path.is_dir()
 
+    async def test_repeat_collection_refreshes_in_place(
+        self, make_shell_task: MakeTaskType
+    ) -> None:
+        """
+        Collecting twice updates the same artifacts instead of duplicating.
+
+        A long task's log is collected while it still runs, so this happens on
+        every publish tick; a fresh landing dir per call would scatter copies
+        and re-register every artifact each time.
+        """
+        task = make_shell_task()
+        sad = Path(task.side_artifacts_dir)
+        sad.mkdir(parents=True)
+        (sad / "log.txt").write_text("first line\n")
+        (sad / "sub").mkdir()
+        (sad / "sub" / "nested.txt").write_text("one")
+
+        await task.executor.collect_side_artifacts(task)
+        first_ids = [a.id for a in task.side_artifacts]
+        log_path = {a.id: a for a in task.side_artifacts}[
+            "test_task_id_log.txt"
+        ].path
+
+        # The task keeps writing, then we collect again mid-run.
+        (sad / "log.txt").write_text("first line\nsecond line\n")
+        (sad / "sub" / "nested.txt").write_text("two")
+        await task.executor.collect_side_artifacts(task)
+
+        assert [a.id for a in task.side_artifacts] == first_ids
+        by_id = {a.id: a for a in task.side_artifacts}
+        # Same path, refreshed contents.
+        assert by_id["test_task_id_log.txt"].path == log_path
+        assert log_path.read_text() == "first line\nsecond line\n"
+        assert (
+            by_id["test_task_id_sub"].path / "nested.txt"
+        ).read_text() == "two"
+
+    async def test_new_artifact_appears_on_a_later_collection(
+        self, make_shell_task: MakeTaskType
+    ) -> None:
+        """A file the task writes later is picked up by the next collection."""
+        task = make_shell_task()
+        sad = Path(task.side_artifacts_dir)
+        sad.mkdir(parents=True)
+        (sad / "log.txt").write_text("hello")
+
+        await task.executor.collect_side_artifacts(task)
+        (sad / "resource-usage.csv").write_text("epoch,rss_kb\n1,2\n")
+        await task.executor.collect_side_artifacts(task)
+
+        by_id = {a.id: a for a in task.side_artifacts}
+        assert set(by_id) == {
+            "test_task_id_log.txt",
+            "test_task_id_resource-usage.csv",
+        }
+        assert (
+            by_id["test_task_id_resource-usage.csv"].path.read_text()
+            == "epoch,rss_kb\n1,2\n"
+        )
+
     async def test_skips_files_over_cap(
         self, make_shell_task: MakeTaskType, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Problem

`collect_side_artifacts` allocated a fresh `mkdtemp` landing directory on every call and blindly appended to `task.side_artifacts`. Calling it twice therefore scattered copies across temp directories and registered every artifact a second time, which confined it to exactly one call — the one in `execute()`'s `finally`.

That is the wrong time for the two artifacts people actually want. A task's `.log` and `resource-usage.csv` are written on the target *while* it runs, and for a task that runs for fifteen minutes they are only useful during it, not after.

## Change

Keep the landing directory per task id (`_side_landing`, a `PrivateAttr` keyed by task id because map expansion can run several tasks through one executor instance) and refresh artifacts in place, registering each id once. Files the task writes later are still picked up by the next collection.

No behavioural change for the existing single call in `execute()`.

## Tests

736 pass (734 before). Two new cases: collecting twice refreshes contents at the same paths without duplicating registrations, and an artifact created between collections appears on the later one.

Verified the first genuinely regresses — stashing the source change fails it on duplicated ids.