### PR TITLE
fix(map): materialize value-artifact items through their own kind (#168)

### DIFF
--- a/src/horus_builtin/artifact/value.py
+++ b/src/horus_builtin/artifact/value.py
@@ -27,7 +27,9 @@ a root value artifact materializes itself (``materialize()``) the first time
 a task consumes it, because no producer ever wrote its bytes.
 """
 
-from typing import ClassVar
+import tempfile
+from pathlib import Path
+from typing import Any, ClassVar
 
 from horus_runtime.core.artifact.base import BaseArtifact
 
@@ -62,3 +64,31 @@ class ValueArtifact[T: object](BaseArtifact[T]):
         """
         if not self.path.exists():
             self.write(self.value)
+
+    def encode_value(self, value: Any) -> bytes | None:
+        """
+        Return the bytes this kind persists for *value*, or ``None`` if
+        *value* does not fit this kind's ``write``.
+
+        The value is round-tripped through this kind's own ``write`` into a
+        throwaway file, so a caller never has to know any per-kind
+        serialization: a ``StringArtifact`` yields plain text, a
+        number/boolean yields a bare JSON scalar, and any future value kind
+        with a bespoke on-disk form is handled for free. This is the
+        counterpart to ``materialize``, which writes this artifact's own
+        ``value`` to ``path``; here an arbitrary candidate value is encoded
+        to that same on-disk form without touching ``path``.
+
+        A type mismatch (e.g. a non-string handed to a ``StringArtifact``,
+        whose ``write`` calls ``write_text`` and raises ``TypeError``)
+        returns ``None`` so the caller can fall back rather than propagate a
+        hard error.
+        """
+        scratch = self.model_copy(deep=True)
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                scratch.path = Path(tmp) / "item"
+                scratch.write(value)
+                return scratch.path.read_bytes()
+        except (TypeError, ValueError):
+            return None

--- a/src/horus_builtin/workflow/map.py
+++ b/src/horus_builtin/workflow/map.py
@@ -67,6 +67,7 @@ import json
 import shlex
 import shutil
 import tarfile
+import tempfile
 import uuid
 from io import BytesIO
 from pathlib import Path
@@ -76,6 +77,7 @@ from pydantic import BaseModel, Field, model_validator
 
 from horus_builtin.artifact.file import FileArtifact
 from horus_builtin.artifact.folder import FolderArtifact
+from horus_builtin.artifact.value import ValueArtifact
 from horus_builtin.executor.shell import ShellExecutor
 from horus_builtin.runtime.command import CommandRuntime
 from horus_builtin.target.local import LocalTarget
@@ -318,6 +320,10 @@ class MapExpander(HorusTask):
             clone = self._build_clone(clone_id)
 
             if self.over.item_input is not None:
+                item_artifact = next(
+                    (a for a in clone.inputs if a.id == self.over.item_input),
+                    None,
+                )
                 item_path = await self._materialize_item(
                     source_task,
                     source_artifact,
@@ -325,6 +331,7 @@ class MapExpander(HorusTask):
                     items_root,
                     i,
                     items,
+                    item_artifact,
                 )
                 self._set_input_path(clone, self.over.item_input, item_path)
 
@@ -475,12 +482,23 @@ class MapExpander(HorusTask):
         items_root: Path,
         i: int,
         items: list[Any] | None,
+        item_artifact: BaseArtifact | None = None,
     ) -> Path:
         """
         Materialize the i-th item on the orchestrator's filesystem and
         return its absolute path: a copy of the i-th child directory for a
-        folder collection, or a small JSON file holding the i-th element
-        for a JSON-list collection.
+        folder collection, or a small file holding the i-th element for a
+        JSON-list collection.
+
+        For a JSON-list collection the bytes depend on the kind the clone
+        declares for its item input (*item_artifact*). A
+        :class:`~horus_builtin.artifact.value.ValueArtifact` element is
+        written through that kind's own on-disk form -- plain text for a
+        :class:`~horus_builtin.artifact.string.StringArtifact`, a bare JSON
+        scalar for a number/boolean -- so the clone reads back the value as
+        authored rather than the JSON-quoted string a blanket ``json.dumps``
+        produced. Everything else (``JSONArtifact``, untyped consumers) keeps
+        the historical ``{i}.json`` + ``json.dumps`` encoding, byte for byte.
         """
         assert source_task is not None
         assert source_artifact is not None
@@ -495,11 +513,54 @@ class MapExpander(HorusTask):
             )
             return dest
 
+        if isinstance(item_artifact, ValueArtifact):
+            encoded = self._encode_value_item(item_artifact, items[i])
+            if encoded is not None:
+                # No ``.json`` suffix: the bytes are the value kind's own
+                # on-disk form, which is not necessarily a JSON document.
+                dest = items_root / str(i)
+                await orchestrator.put_file(encoded, str(dest))
+                return dest
+            # The element does not fit the declared value kind (e.g. a
+            # number fanned into a StringArtifact, whose write() needs a
+            # str). Fall through to the historical JSON encoding so such a
+            # mismatch behaves exactly as it did before this fix -- it never
+            # raised -- rather than turning into a hard error.
+
         dest = items_root / f"{i}.json"
         await orchestrator.put_file(
             json.dumps(items[i]).encode("utf-8"), str(dest)
         )
         return dest
+
+    @staticmethod
+    def _encode_value_item(
+        item_artifact: ValueArtifact[Any], element: Any
+    ) -> bytes | None:
+        """
+        Return the bytes *item_artifact*'s own kind persists for *element*,
+        or ``None`` if the element does not fit that kind.
+
+        The element is round-tripped through that kind's real ``write`` into
+        a throwaway file, so this module never hardcodes any per-kind
+        serialization: a ``StringArtifact`` item stays plain text, a
+        number/boolean item stays a bare JSON scalar, and any future value
+        kind with a bespoke on-disk form becomes a valid map item for free.
+
+        A type mismatch (e.g. a non-string element handed to a
+        ``StringArtifact``, whose ``write`` calls ``write_text`` and would
+        raise ``TypeError``) returns ``None`` so the caller can fall back to
+        the legacy JSON encoding, preserving the pre-fix behaviour where any
+        JSON element could be materialized without error.
+        """
+        scratch = item_artifact.model_copy(deep=True)
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                scratch.path = Path(tmp) / "item"
+                scratch.write(element)
+                return scratch.path.read_bytes()
+        except (TypeError, ValueError):
+            return None
 
     @staticmethod
     async def _materialize_index(

--- a/src/horus_builtin/workflow/map.py
+++ b/src/horus_builtin/workflow/map.py
@@ -67,7 +67,6 @@ import json
 import shlex
 import shutil
 import tarfile
-import tempfile
 import uuid
 from io import BytesIO
 from pathlib import Path
@@ -320,6 +319,13 @@ class MapExpander(HorusTask):
             clone = self._build_clone(clone_id)
 
             if self.over.item_input is not None:
+                # Resolve the artifact the clone declares for its item input
+                # so _materialize_item can serialize the element through that
+                # kind's own on-disk form -- plain text for a StringArtifact,
+                # a bare JSON scalar for a number/boolean -- instead of a
+                # blanket json.dumps that reaches a StringArtifact quoted
+                # (#168). None means the item input is untyped; the JSON
+                # fallback then applies.
                 item_artifact = next(
                     (a for a in clone.inputs if a.id == self.over.item_input),
                     None,
@@ -514,7 +520,7 @@ class MapExpander(HorusTask):
             return dest
 
         if isinstance(item_artifact, ValueArtifact):
-            encoded = self._encode_value_item(item_artifact, items[i])
+            encoded = item_artifact.encode_value(items[i])
             if encoded is not None:
                 # No ``.json`` suffix: the bytes are the value kind's own
                 # on-disk form, which is not necessarily a JSON document.
@@ -532,35 +538,6 @@ class MapExpander(HorusTask):
             json.dumps(items[i]).encode("utf-8"), str(dest)
         )
         return dest
-
-    @staticmethod
-    def _encode_value_item(
-        item_artifact: ValueArtifact[Any], element: Any
-    ) -> bytes | None:
-        """
-        Return the bytes *item_artifact*'s own kind persists for *element*,
-        or ``None`` if the element does not fit that kind.
-
-        The element is round-tripped through that kind's real ``write`` into
-        a throwaway file, so this module never hardcodes any per-kind
-        serialization: a ``StringArtifact`` item stays plain text, a
-        number/boolean item stays a bare JSON scalar, and any future value
-        kind with a bespoke on-disk form becomes a valid map item for free.
-
-        A type mismatch (e.g. a non-string element handed to a
-        ``StringArtifact``, whose ``write`` calls ``write_text`` and would
-        raise ``TypeError``) returns ``None`` so the caller can fall back to
-        the legacy JSON encoding, preserving the pre-fix behaviour where any
-        JSON element could be materialized without error.
-        """
-        scratch = item_artifact.model_copy(deep=True)
-        try:
-            with tempfile.TemporaryDirectory() as tmp:
-                scratch.path = Path(tmp) / "item"
-                scratch.write(element)
-                return scratch.path.read_bytes()
-        except (TypeError, ValueError):
-            return None
 
     @staticmethod
     async def _materialize_index(

--- a/tests/unit/artifact/test_value_artifact.py
+++ b/tests/unit/artifact/test_value_artifact.py
@@ -190,3 +190,50 @@ class TestValueArtifactMaterialize:
             )
             artifact.materialize()
             assert not target.exists()
+
+
+@pytest.mark.unit
+class TestValueArtifactEncodeValue:
+    """
+    encode_value() returns a candidate value's on-disk bytes for this kind,
+    or None when the value does not fit -- the serialization map fan-out
+    uses to materialize a JSON-list item through the clone's declared kind.
+    """
+
+    def test_string_item_is_encoded_unquoted(
+        self, horus_context: HorusContext
+    ) -> None:
+        """A StringArtifact encodes text as plain, unquoted UTF-8 bytes."""
+        del horus_context
+        with tempfile.TemporaryDirectory() as temp_dir:
+            artifact = StringArtifact(id="s", path=Path(temp_dir) / "s.txt")
+            assert artifact.encode_value("benzene") == b"benzene"
+
+    def test_number_item_is_byte_identical_to_json(
+        self, horus_context: HorusContext
+    ) -> None:
+        """A NumberArtifact encodes a number as its bare JSON scalar."""
+        del horus_context
+        with tempfile.TemporaryDirectory() as temp_dir:
+            artifact = NumberArtifact(id="n", path=Path(temp_dir) / "n.json")
+            assert artifact.encode_value(10) == b"10"
+
+    def test_does_not_touch_backing_path(
+        self, horus_context: HorusContext
+    ) -> None:
+        """Encoding a candidate value leaves the artifact's path untouched."""
+        del horus_context
+        with tempfile.TemporaryDirectory() as temp_dir:
+            target = Path(temp_dir) / "s.txt"
+            artifact = StringArtifact(id="s", path=target, value="authored")
+            artifact.encode_value("candidate")
+            assert not target.exists()
+
+    def test_type_mismatch_returns_none(
+        self, horus_context: HorusContext
+    ) -> None:
+        """A value the kind's write() rejects yields None, not an error."""
+        del horus_context
+        with tempfile.TemporaryDirectory() as temp_dir:
+            artifact = StringArtifact(id="s", path=Path(temp_dir) / "s.txt")
+            assert artifact.encode_value(10) is None

--- a/tests/unit/workflow/test_map.py
+++ b/tests/unit/workflow/test_map.py
@@ -32,6 +32,8 @@ from pydantic import ValidationError
 from horus_builtin.artifact.file import FileArtifact
 from horus_builtin.artifact.folder import FolderArtifact
 from horus_builtin.artifact.json import JSONArtifact
+from horus_builtin.artifact.number import NumberArtifact
+from horus_builtin.artifact.string import StringArtifact
 from horus_builtin.executor.shell import ShellExecutor
 from horus_builtin.runtime.command import CommandRuntime
 from horus_builtin.target.local import LocalTarget
@@ -252,6 +254,144 @@ class TestCollectionMapEndToEnd:
         assert wf.status.value == "completed"
         gathered = tmp_path / "score.gathered"
         assert sorted(p.name for p in gathered.iterdir()) == ["0", "1"]
+
+    async def test_json_list_string_item_materializes_unquoted(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """A JSON string element fanned into a ``StringArtifact`` item is
+        materialized through the string kind's own plain-text on-disk form,
+        so the clone reads back ``benzene`` (``StringArtifact.read()`` is a
+        plain ``read_text()``) -- not the JSON-quoted ``"benzene"`` the map's
+        hardcoded ``json.dumps`` used to write. The pinned item file also
+        drops the ``.json`` suffix, since it is no longer a JSON document.
+        """
+        del horus_context
+        split = _json_split_task(tmp_path, ["benzene", "toluene"])
+        gather = _gather_task(tmp_path)
+
+        wf = HorusWorkflow(
+            name="wf",
+            tasks=[split, gather],
+            orchestrator_target=LocalTarget(
+                working_directory=tmp_path.as_posix()
+            ),
+        )
+        template = HorusTask(
+            id="template",
+            name="template",
+            runtime=CommandRuntime(command="mkdir -p $scored"),
+            executor=ShellExecutor(),
+            target=LocalTarget(),
+            inputs=[StringArtifact(id="item", path=Path("item_in"))],
+            outputs=[FolderArtifact(id="scored", path=Path("scored_out"))],
+        )
+        wf.map(
+            id="score",
+            template=template,
+            over=("split", "batches", "item"),
+            gather=("gather", "results"),
+        )
+
+        await wf.run(trigger_id="split")
+
+        assert wf.status.value == "completed"
+        items_root = tmp_path / "score.items"
+        # The clone that consumes item i reads exactly these bytes back via
+        # StringArtifact.read(); no surrounding JSON quotes, no .json suffix.
+        assert (items_root / "0").read_text() == "benzene"
+        assert (items_root / "1").read_text() == "toluene"
+        assert not (items_root / "0.json").exists()
+        assert not (items_root / "1.json").exists()
+        probe = StringArtifact(id="i", path=items_root / "0")
+        assert probe.read() == "benzene"
+
+    async def test_json_list_number_item_stays_byte_identical(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """A JSON number element fanned into a ``NumberArtifact`` item keeps
+        its bare-JSON-scalar on-disk form, so kinds whose serialization
+        already matches ``json.dumps`` are unchanged by the string fix -- only
+        the ``.json`` suffix is dropped, consistently with every value kind.
+        """
+        del horus_context
+        split = _json_split_task(tmp_path, [10, 20])
+        gather = _gather_task(tmp_path)
+
+        wf = HorusWorkflow(
+            name="wf",
+            tasks=[split, gather],
+            orchestrator_target=LocalTarget(
+                working_directory=tmp_path.as_posix()
+            ),
+        )
+        template = HorusTask(
+            id="template",
+            name="template",
+            runtime=CommandRuntime(command="mkdir -p $scored"),
+            executor=ShellExecutor(),
+            target=LocalTarget(),
+            inputs=[NumberArtifact(id="item", path=Path("item_in"))],
+            outputs=[FolderArtifact(id="scored", path=Path("scored_out"))],
+        )
+        wf.map(
+            id="score",
+            template=template,
+            over=("split", "batches", "item"),
+            gather=("gather", "results"),
+        )
+
+        await wf.run(trigger_id="split")
+
+        assert wf.status.value == "completed"
+        items_root = tmp_path / "score.items"
+        assert (items_root / "0").read_text() == "10"
+        assert (items_root / "1").read_text() == "20"
+        assert NumberArtifact(id="i", path=items_root / "0").read() == 10
+
+    async def test_json_number_into_string_item_falls_back_not_raises(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """A type mismatch -- a JSON *number* fanned into a ``StringArtifact``
+        item, whose ``write`` needs a ``str`` -- must not become a hard error.
+        It falls back to the historical ``{i}.json`` + ``json.dumps``
+        encoding, exactly as it materialized before value kinds were taught
+        to the map, so the run still completes.
+        """
+        del horus_context
+        split = _json_split_task(tmp_path, [1, 2])
+        gather = _gather_task(tmp_path)
+
+        wf = HorusWorkflow(
+            name="wf",
+            tasks=[split, gather],
+            orchestrator_target=LocalTarget(
+                working_directory=tmp_path.as_posix()
+            ),
+        )
+        template = HorusTask(
+            id="template",
+            name="template",
+            runtime=CommandRuntime(command="mkdir -p $scored"),
+            executor=ShellExecutor(),
+            target=LocalTarget(),
+            inputs=[StringArtifact(id="item", path=Path("item_in"))],
+            outputs=[FolderArtifact(id="scored", path=Path("scored_out"))],
+        )
+        wf.map(
+            id="score",
+            template=template,
+            over=("split", "batches", "item"),
+            gather=("gather", "results"),
+        )
+
+        await wf.run(trigger_id="split")
+
+        assert wf.status.value == "completed"
+        items_root = tmp_path / "score.items"
+        # Legacy JSON fallback: the number is materialized as a bare JSON
+        # scalar at the historical .json path, unchanged from pre-fix.
+        assert (items_root / "0.json").read_text() == "1"
+        assert (items_root / "1.json").read_text() == "2"
 
     async def test_gather_wired_to_trigger_still_waits_for_expander(
         self, tmp_path: Path, horus_context: HorusContext


### PR DESCRIPTION
## What

`map` fans a JSON list into N clones, but `MapExpander._materialize_item` wrote `json.dumps(element)` into `{i}.json` for **every** element, regardless of the artifact kind the clone declares for its item input.

`StringArtifact.read()` is a plain `read_text()`, so a list entry `benzene` reached the clone as `"benzene"` (JSON-quoted). `NumberArtifact`/`BooleanArtifact` only survived because their on-disk form already *is* JSON. (Issue #168 — thanks @chdominguez for the precise repro and analysis.)

## Fix

When the clone's declared item input is a `ValueArtifact`, serialize the element through that kind's own `write()` and pin a path **without** the `.json` suffix (the bytes are no longer necessarily a JSON document). This is kind-agnostic — a future value kind with a bespoke on-disk form becomes a valid map item for free — so `map.py` never hardcodes per-kind serialization.

- String item → plain text (`benzene`), fixing the quoting bug.
- Number / boolean item → bare JSON scalar, **byte-identical** to before.
- `JSONArtifact` / untyped consumers → unchanged `{i}.json` + `json.dumps`.
- Type mismatch (e.g. a number fanned into a `StringArtifact`, whose `write()` needs a `str`) → falls back to the legacy `{i}.json` + `json.dumps` path, so anything that materialized before still materializes now — it never raised, and it still doesn't.

## Tests

Three new end-to-end map tests: string item arrives unquoted (and pinned without `.json`), number item stays byte-identical, and the number-into-`StringArtifact` mismatch falls back instead of raising. Full unit suite green (739 passed); `ruff check`, `ruff format --check`, and `mypy` all clean.

Fixes #168.