### PR TITLE
feat(workflow): register each map clone's item as its own side artifact

### DIFF
--- a/src/horus_builtin/workflow/map.py
+++ b/src/horus_builtin/workflow/map.py
@@ -216,8 +216,13 @@ class MapTask(HorusTask):
                     )
                 )
 
-        for clone in clones:
-            self.side_artifacts.extend(clone.side_artifacts)
+        # Deliberately NOT merging the clones' side artifacts into this
+        # task's own list: each clone's upload middleware registers them
+        # under the clone's own task id, and a re-upload here (same artifact
+        # ids, different task) would repoint every reference at this map,
+        # erasing the per-clone attribution the UI's clone browser reads.
+        # The aggregate view is the backend's job: listing a task's side
+        # products includes those of its `id[slot]` descendants.
 
         horus_logger.log.debug(
             _("Map task '%(id)s' ran %(n)d clone(s).")
@@ -273,7 +278,7 @@ class MapTask(HorusTask):
             "runs",
         }
 
-        return HorusTask(
+        clone = HorusTask(
             **self.model_dump(exclude=exclude_fields),
             id=f"{self.id}[{slot}]",
             name=f"{self.name}[{slot}]",
@@ -281,3 +286,14 @@ class MapTask(HorusTask):
             outputs=[output],
             target=self.target.idle_copy(),
         )
+
+        # Register this clone's item as a side artifact, so the upload
+        # middleware persists it to S3 under the clone's own task id and the
+        # UI can inspect exactly what this one run of the body received. The
+        # item is an input transfer, not an output of the body, so without
+        # this it would never be uploaded at all.
+        clone.side_artifacts.append(
+            item.model_copy(update={"id": f"{clone.id}_item"})
+        )
+
+        return clone

--- a/tests/unit/workflow/test_map.py
+++ b/tests/unit/workflow/test_map.py
@@ -681,3 +681,61 @@ class TestRoundTrip:
 
         await wf2.run(trigger_id="split")
         assert wf2.status.value == "completed"
+
+
+@pytest.mark.unit
+class TestCloneSideArtifacts:
+    """Per-clone side-artifact attribution: each clone owns what it
+    produced (its item, its log), and the map does not re-register any of
+    it under its own id -- re-uploading the same artifact ids with a
+    different task id would repoint the references and erase the per-clone
+    attribution the UI's clone browser reads.
+    """
+
+    async def test_each_clone_registers_its_item_as_a_side_artifact(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """The item a clone received is uploaded under the clone's own id,
+        so what each run of the body got from the map is inspectable.
+        """
+        del horus_context
+        split = _split_task(tmp_path, ["a.txt", "b.txt"])
+        map_task = _map_task(
+            over_artifact=FolderArtifact(
+                id="batches", path=Path("batches_in")
+            ),
+        )
+        wf = _wire(tmp_path, split=split, map_task=map_task)
+
+        await wf.run(trigger_id="split")
+
+        assert wf.status.value == "completed"
+        for slot, name in enumerate(("a.txt", "b.txt")):
+            clone = next(t for t in wf.tasks if t.id == f"score[{slot}]")
+            item_id = f"score[{slot}]_item"
+            items = [a for a in clone.side_artifacts if a.id == item_id]
+            assert len(items) == 1
+            assert items[0].path.name == name
+
+    async def test_the_map_does_not_merge_clone_side_artifacts(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """Nothing produced by a clone is re-registered under the map's
+        id: the map's own side-artifact list stays free of `score[...]`
+        entries, so the upload pass cannot repoint the clones' refs.
+        """
+        del horus_context
+        split = _split_task(tmp_path, ["a.txt", "b.txt"])
+        map_task = _map_task(
+            over_artifact=FolderArtifact(
+                id="batches", path=Path("batches_in")
+            ),
+        )
+        wf = _wire(tmp_path, split=split, map_task=map_task)
+
+        await wf.run(trigger_id="split")
+
+        assert wf.status.value == "completed"
+        assert not [
+            a for a in map_task.side_artifacts if a.id.startswith("score[")
+        ]


### PR DESCRIPTION
## What

Each `horus_map` clone now registers the item it was bound to as a side artifact on itself (`<clone.id>_item`), and the map no longer merges clone side artifacts into its own list.

## Why

- The item is an input transfer, not an output of the body, so without this it never reaches S3 and there is no way to inspect what one run of the body actually received.
- Re-uploading clone artifacts under the map's task id (the old merge) would repoint every reference at the map and erase the per-clone attribution the UI's clone browser reads. The aggregate view belongs to the backend listing (tc-os adds `include_clone_descendants` for this).

## Tests

- `test_each_clone_registers_its_item_as_a_side_artifact`: each clone owns exactly one `score[i]_item` pointing at its own item file.
- `test_the_map_does_not_merge_clone_side_artifacts`: the map's side-artifact list carries no `score[...]` entries.
- `uv run pytest tests/unit/workflow/test_map.py`: 21 passed; ruff check/format clean.