### PR TITLE
fix(workflow): cap task fan-out concurrency by default instead of unbounded

### DIFF
--- a/src/horus_builtin/workflow/map.py
+++ b/src/horus_builtin/workflow/map.py
@@ -84,7 +84,12 @@ class MapTask(HorusTask):
     """
 
     max_concurrency: int | None = None
-    """Upper bound on clones dispatched at once; ``None`` means unbounded."""
+    """
+    Upper bound on clones dispatched at once. ``None`` (the default) applies
+    a conservative built-in cap (see
+    ``horus_builtin.workflow.scheduler.DEFAULT_MAX_CONCURRENCY``) instead of
+    dispatching every clone at once.
+    """
 
     @property
     def _over_artifact(self) -> IterableArtifact:

--- a/src/horus_builtin/workflow/scheduler.py
+++ b/src/horus_builtin/workflow/scheduler.py
@@ -53,6 +53,16 @@ if TYPE_CHECKING:
     from horus_runtime.core.task.base import BaseTask
 
 
+DEFAULT_MAX_CONCURRENCY = 8
+"""
+Fan-out cap applied when a workflow or ``horus_map`` task leaves
+``max_concurrency`` unset. A DAG (or map input) with no cap of its own
+dispatches every ready task/clone as its own subprocess at once, which can
+over-subscribe a modest host; this keeps that failure mode opt-in-only
+(explicitly pass a larger ``max_concurrency`` to raise it).
+"""
+
+
 class TargetPool:
     """
     Hands out an idle target for each dispatched task, giving otherwise
@@ -79,22 +89,21 @@ class TargetPool:
         # id(declared_target). Lazily seeded with the declared target itself
         # on first acquisition (see `acquire`).
         self._idle: dict[int, list[BaseTarget]] = {}
-        self._semaphore = (
-            asyncio.Semaphore(max_concurrency)
+        self._semaphore = asyncio.Semaphore(
+            max_concurrency
             if max_concurrency is not None
-            else None
+            else DEFAULT_MAX_CONCURRENCY
         )
 
     async def acquire(self, declared_target: BaseTarget) -> BaseTarget:
         """
         Return an idle target equivalent to *declared_target*.
 
-        Blocks on the ``max_concurrency`` semaphore (if set) before handing
-        out a target, so the cap applies to genuinely concurrent dispatches
-        rather than just to distinct target instances.
+        Blocks on the ``max_concurrency`` semaphore before handing out a
+        target, so the cap applies to genuinely concurrent dispatches rather
+        than just to distinct target instances.
         """
-        if self._semaphore is not None:
-            await self._semaphore.acquire()
+        await self._semaphore.acquire()
 
         idle = self._idle.setdefault(id(declared_target), [declared_target])
         if idle:
@@ -110,8 +119,7 @@ class TargetPool:
         *declared_target*) to the idle pool.
         """
         self._idle[id(declared_target)].append(target)
-        if self._semaphore is not None:
-            self._semaphore.release()
+        self._semaphore.release()
 
 
 async def execute_task(
@@ -354,7 +362,8 @@ async def run_schedule(workflow: BaseWorkflow, trigger_id: str) -> None:
     ``BaseTask.is_complete``, applied inside ``BaseTask.run``). Every task
     whose dependencies are already satisfied is dispatched immediately and
     concurrently with any other ready task, bounded by
-    ``workflow.max_concurrency`` when set.
+    ``workflow.max_concurrency`` (or :data:`DEFAULT_MAX_CONCURRENCY` when
+    unset).
 
     ``workflow.failure_policy`` controls what happens once a task fails:
 

--- a/src/horus_runtime/core/workflow/base.py
+++ b/src/horus_runtime/core/workflow/base.py
@@ -206,10 +206,11 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
     max_concurrency: int | None = None
     """
     Upper bound on the number of tasks the scheduler dispatches at once.
-    ``None`` (the default) means unbounded: every task that becomes ready is
-    dispatched immediately. Set this to cap resource usage (e.g. a shared
-    machine with limited CPUs) when the DAG's natural parallelism would
-    otherwise over-subscribe it.
+    ``None`` (the default) applies a conservative built-in cap (see
+    ``horus_builtin.workflow.scheduler.DEFAULT_MAX_CONCURRENCY``) rather than
+    dispatching every ready task at once. Set this explicitly to raise or
+    lower that cap (e.g. a shared machine with limited CPUs, or a DAG known
+    to be safe running fully in parallel).
     """
 
     capacity: dict[str, ResourceCapacity] | None = None

--- a/tests/unit/workflow/test_scheduler.py
+++ b/tests/unit/workflow/test_scheduler.py
@@ -32,6 +32,7 @@ from horus_builtin.runtime.command import CommandRuntime
 from horus_builtin.target.local import LocalTarget
 from horus_builtin.task.horus_task import HorusTask
 from horus_builtin.workflow.horus_workflow import HorusWorkflow
+from horus_builtin.workflow.scheduler import DEFAULT_MAX_CONCURRENCY
 from horus_runtime.context import HorusContext
 from horus_runtime.core.artifact.base import BaseArtifact
 from horus_runtime.core.placement import (
@@ -279,6 +280,58 @@ class TestConcurrentReadySet:
             await asyncio.wait_for(wf.run(trigger_id="root"), timeout=10)
 
         assert state["max_seen"] == 1
+
+    async def test_unset_max_concurrency_still_caps_a_wide_fanout(
+        self, tmp_path: Path, horus_context: HorusContext
+    ) -> None:
+        """
+        With ``max_concurrency`` left unset, a fan-out wider than
+        ``DEFAULT_MAX_CONCURRENCY`` never has more than that many siblings
+        RUNNING at once (it's not truly unbounded), but more than one still
+        runs at a time (it's not serialized to 1 either).
+        """
+        del horus_context
+        state = {"current": 0, "max_seen": 0}
+
+        class ConcurrencyTask(HorusTask):
+            add_to_registry: ClassVar[bool] = False
+
+            async def _run(self) -> None:
+                state["current"] += 1
+                state["max_seen"] = max(state["max_seen"], state["current"])
+                await asyncio.sleep(0.01)
+                state["current"] -= 1
+
+        root = _task(
+            "root",
+            tmp_path=tmp_path,
+            task_cls=ConcurrencyTask,
+            outputs=[FileArtifact(id="root_out", path=tmp_path / "root.out")],
+        )
+        children = [
+            _task(
+                f"child{i}",
+                tmp_path=tmp_path,
+                task_cls=ConcurrencyTask,
+                inputs=[FileArtifact(id="in", path=tmp_path / "root.out")],
+            )
+            for i in range(DEFAULT_MAX_CONCURRENCY + 4)
+        ]
+
+        wf = HorusWorkflow(
+            name="wide_fanout_unset_concurrency",
+            tasks=[root, *children],
+            edges=[
+                _edge("root", "root_out", child.id, "in") for child in children
+            ],
+        )
+
+        with patch.object(
+            HorusWorkflow, "transfer_artifacts", new=AsyncMock()
+        ):
+            await asyncio.wait_for(wf.run(trigger_id="root"), timeout=10)
+
+        assert 1 < state["max_seen"] <= DEFAULT_MAX_CONCURRENCY
 
     async def test_failure_cancels_concurrent_sibling_and_stops_downstream(
         self, tmp_path: Path, horus_context: HorusContext


### PR DESCRIPTION
## Summary
- Closes temple-compute/tc-os#242
- `TargetPool` (used by both the DAG scheduler's `run_schedule` and `MapTask._execute`'s clone fan-out) now falls back to a new `DEFAULT_MAX_CONCURRENCY = 8` whenever `max_concurrency` is left unset, instead of dispatching every ready task/clone at once.
- Explicit `max_concurrency` values (including `1`, as already covered by existing tests) are unaffected.

## Why
Incident: a workflow with ~60 tasks and little/no edge structure between them ran with no `max_concurrency` set. The scheduler fired all ~60 tasks at once, each spawning its own subprocess/plugin environment, on a host with ~4 cores / 3.8GB RAM. Load average spiked to 122 and memory was exhausted; it only self-recovered as tasks finished and exited. The orchestrator's own `CONCURRENCY` semaphore (in tc-os) only caps concurrent whole workflow *runs*, not task fan-out within a single run, so it did not protect against this.

Kept intentionally simple per the linked issue: a fixed conservative default, not a host-CPU-derived one.

## Test plan
- [x] `uv run pytest tests/unit` — 731 passed
- [x] New test `test_unset_max_concurrency_still_caps_a_wide_fanout` in `tests/unit/workflow/test_scheduler.py`: a fan-out wider than `DEFAULT_MAX_CONCURRENCY` with `max_concurrency` left unset never exceeds the cap, but still runs more than one task at a time.
- [x] `ruff check`, `ruff format`, `mypy` all pass

## Docs
- [x] No documentation update required (default-value change only; docstrings on the affected fields/functions updated in this PR, no user-facing docs site content changes)