### PR TITLE
Add explicit website URL to .wci.yml

### DIFF
--- a/.wci.yml
+++ b/.wci.yml
@@ -34,6 +34,8 @@ description: >
 
 language: Python
 
+website: https://templecompute.com
+
 documentation:
   general: https://docs.templecompute.com
   installation: https://docs.templecompute.com/guides/installation


### PR DESCRIPTION
## Summary
- The workflows.community system page (https://workflows.community/systems/horus-runtime/) links to a broken URL because it falls back to this repo's GitHub homepage field (`templecompute.com`, no scheme), which renders as a relative link
- Sets `website: https://templecompute.com` explicitly in `.wci.yml`, which the site's build script prefers over the GitHub homepage field

## Test plan
- [ ] Confirm workflows.community rebuilds and the "Visit website" / "Website" links on the horus-runtime system page point to `https://templecompute.com`