### PR TITLE
Add labels to BaseArtifact

### DIFF
--- a/src/horus_runtime/core/artifact/base.py
+++ b/src/horus_runtime/core/artifact/base.py
@@ -97,26 +97,10 @@ class BaseArtifact[T: Any = Any](AutoRegistry, entry_point="artifact"):
 
     labels: dict[str, str] = Field(default_factory=dict)
     """
-    Free-form key/value metadata carried with the artifact.
+    Free-form key/value metadata carried with the artifact. Never
+    interpreted by the runtime, and not part of any cache key::
 
-    The runtime never interprets these. They travel with the artifact
-    through serialization and exist for whatever reads a workflow
-    afterwards: a UI grouping nodes, or a lineage reader answering
-    "everything derived from subject X". A domain expresses its own
-    structure through them instead of the runtime growing a field per
-    domain, so one mechanism serves materials science, biology or
-    anything else::
-
-        outputs:
-          - id: scored
-            kind: file
-            path: batch_017.parquet
-            labels: {subject: batch_017, role: measurement}
-
-    Not part of any cache key. Relabelling an artifact describes it
-    differently, it does not make its contents stale, and
-    ``HorusTask._fingerprint`` hashes artifact *content* digests rather
-    than artifact models, so nothing here reaches a cache decision.
+        labels: {subject: batch_017, role: measurement}
     """
 
     path: Annotated[Path, BeforeValidator(validate_path)]

--- a/src/horus_runtime/core/artifact/base.py
+++ b/src/horus_runtime/core/artifact/base.py
@@ -95,6 +95,30 @@ class BaseArtifact[T: Any = Any](AutoRegistry, entry_point="artifact"):
     Optional free-text description of the artifact, shown in the UI.
     """
 
+    labels: dict[str, str] = Field(default_factory=dict)
+    """
+    Free-form key/value metadata carried with the artifact.
+
+    The runtime never interprets these. They travel with the artifact
+    through serialization and exist for whatever reads a workflow
+    afterwards: a UI grouping nodes, or a lineage reader answering
+    "everything derived from subject X". A domain expresses its own
+    structure through them instead of the runtime growing a field per
+    domain, so one mechanism serves materials science, biology or
+    anything else::
+
+        outputs:
+          - id: scored
+            kind: file
+            path: batch_017.parquet
+            labels: {subject: batch_017, role: measurement}
+
+    Not part of any cache key. Relabelling an artifact describes it
+    differently, it does not make its contents stale, and
+    ``HorusTask._fingerprint`` hashes artifact *content* digests rather
+    than artifact models, so nothing here reaches a cache decision.
+    """
+
     path: Annotated[Path, BeforeValidator(validate_path)]
     """
     Absolute local filesystem path where the artifact materializes.

--- a/tests/unit/artifact/test_artifact_base.py
+++ b/tests/unit/artifact/test_artifact_base.py
@@ -235,3 +235,51 @@ class TestBaseArtifactValidation:
         assert artifact.id == "test_artifact"
         assert artifact.path == Path("test").resolve()
         assert artifact.kind == "test"
+
+
+class TestLabels:
+    """
+    Free-form metadata carried with an artifact.
+    """
+
+    def test_labels_default_to_empty(self) -> None:
+        """
+        An artifact that declares none is not different from one that
+        declares an empty mapping.
+        """
+        artifact = ConcreteTestArtifact(id="a", path=Path("a"))
+        assert artifact.labels == {}
+
+    def test_labels_are_not_shared_between_artifacts(self) -> None:
+        """
+        A mutable default shared across instances would let one
+        artifact's labels leak into every other.
+        """
+        first = ConcreteTestArtifact(id="a", path=Path("a"))
+        second = ConcreteTestArtifact(id="b", path=Path("b"))
+        first.labels["subject"] = "batch_017"
+        assert second.labels == {}
+
+    def test_labels_survive_a_round_trip(self) -> None:
+        """
+        They exist to be read after the run, so they have to serialize.
+        """
+        artifact = ConcreteTestArtifact(
+            id="a", path=Path("a"), labels={"subject": "batch_017"}
+        )
+        restored = ConcreteTestArtifact.model_validate(
+            artifact.model_dump(mode="json")
+        )
+        assert restored.labels == {"subject": "batch_017"}
+
+    def test_non_string_values_are_rejected(self) -> None:
+        """
+        String values stay serializable in YAML and JSON without
+        surprises, and can be used directly as index keys.
+        """
+        with pytest.raises(ValidationError):
+            ConcreteTestArtifact(
+                id="a",
+                path=Path("a"),
+                labels={"replicate": object()},  # type: ignore[dict-item]
+            )


### PR DESCRIPTION
## Summary

Closes #181.

```python
labels: dict[str, str] = Field(default_factory=dict)
```

```yaml
outputs:
  - id: scored
    kind: file
    path: batch_017.parquet
    labels: {subject: batch_017, role: measurement}
```

The runtime never interprets them. They travel with the artifact through serialization and exist for whatever reads a workflow afterwards: a UI grouping nodes, or a lineage reader answering "everything derived from subject X". A domain expresses its own structure through labels instead of the runtime growing a field per domain.

Docstring shortened per review.

## Not a cache concern

`HorusTask._fingerprint` hashes artifact **content** digests plus a hash of the runtime and executor models. Artifact models are not in it, so labels cannot reach a cache decision. Relabelling describes an artifact differently, it does not make its contents stale.

## Why `str` values

Strings stay serializable in YAML and JSON without surprises and can be used directly as index keys. Easy to widen to `dict[str, Any]` later, hard to narrow. Happy to change it.

## Tests

Four: defaults to empty, not shared between instances (a mutable default would leak one artifact's labels into every other), survives a `model_dump` / `model_validate` round trip, rejects non-string values.

737 passed, coverage 91.29%, `make lint` clean.

## Documentation impact

If a user, plugin, or GUI can observe the difference, it requires documentation.

- [ ] No documentation update required
- [x] Documentation updated / will be updated

**horus-docs PR:** to follow.

This is a new field workflow authors write in YAML, so it belongs in `sdk/core/artifact.mdx` and `guides/writing-workflows-yaml.mdx`. Happy to write it, or leave it to you.
