### PR TITLE
Keep the workflow file path on from_yaml

### DIFF
--- a/src/horus_runtime/core/workflow/base.py
+++ b/src/horus_runtime/core/workflow/base.py
@@ -253,6 +253,14 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
     fall back to the process CWD. Runtime-only state, not serialized.
     """
 
+    _source_path: Path | None = PrivateAttr(default=None)
+    """
+    The workflow file this instance was loaded from, set by
+    :meth:`from_yaml`. ``None`` for a programmatically-built workflow or
+    one validated from a snapshot, neither of which has a file. Runtime-only
+    state, not serialized. Read it through :attr:`source_path`.
+    """
+
     _implicit_task_deps: dict[str, set[str]] = PrivateAttr(
         default_factory=dict
     )
@@ -959,6 +967,7 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
         # own directory, so a run is self-contained regardless of the launch
         # directory.
         workflow._base_directory = Path(path).resolve().parent  # noqa: SLF001
+        workflow._source_path = Path(path).resolve()  # noqa: SLF001
         return workflow
 
     def to_yaml(self, path: str | Path) -> None:
@@ -1156,6 +1165,19 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
     @property
     def _effective_base(self) -> Path:
         return self._base_directory or Path.cwd()
+
+    @property
+    def source_path(self) -> Path | None:
+        """
+        The workflow file this instance was loaded from, or ``None`` when
+        it was not loaded from one.
+
+        Anything wanting to copy, digest or link back to the source needs
+        the path rather than only its folder, and deriving it from
+        :attr:`_base_directory` is only correct when the file happens to
+        be named ``workflow.yaml``.
+        """
+        return self._source_path
 
     @property
     def run_directory(self) -> Path:

--- a/tests/unit/workflow/test_workflow.py
+++ b/tests/unit/workflow/test_workflow.py
@@ -21,6 +21,7 @@ Unit tests for the Workflow class.
 
 import textwrap
 from pathlib import Path
+from typing import ClassVar
 
 import pytest
 import yaml
@@ -140,3 +141,85 @@ class TestWorkflowFromYaml:
 
         with pytest.raises(ValidationError):
             ConcreteWorkflow.from_yaml(wf_file)
+
+
+class SourcePathWorkflow(BaseWorkflow):
+    """
+    A concrete workflow that inherits ``from_yaml`` rather than
+    overriding it, so the loader under test actually runs.
+    """
+
+    add_to_registry: ClassVar[bool] = False
+    kind: str = "source_path_workflow"
+
+    async def _run(self, trigger_id: str) -> None:
+        """
+        No-op body.
+        """
+        del trigger_id
+
+    async def _reset(self) -> None:
+        """
+        No-op reset.
+        """
+        return None
+
+
+class TestSourcePath:
+    """
+    The file a workflow was loaded from.
+    """
+
+    WORKFLOW = textwrap.dedent("""\
+    name: yaml_workflow
+    kind: source_path_workflow
+    tasks:
+        - id: step1_id
+          name: Step 1
+          kind: horus_task
+          runtime:
+              kind: command
+              command: "echo hello"
+          executor:
+              kind: shell
+    """)
+
+    def test_from_yaml_keeps_the_file_path(
+        self, tmp_path: Path, make_workflow_file: MakeWorkflowFileType
+    ) -> None:
+        """
+        Deriving it from the base directory is only correct when the file
+        happens to be named workflow.yaml.
+        """
+        workflow_file = make_workflow_file(tmp_path, self.WORKFLOW)
+        wf = SourcePathWorkflow.from_yaml(workflow_file)
+        assert wf.source_path == workflow_file.resolve()
+
+    def test_the_base_directory_still_points_at_the_folder(
+        self, tmp_path: Path, make_workflow_file: MakeWorkflowFileType
+    ) -> None:
+        """
+        The new field sits beside the existing one, it does not replace
+        it.
+        """
+        workflow_file = make_workflow_file(tmp_path, self.WORKFLOW)
+        wf = SourcePathWorkflow.from_yaml(workflow_file)
+        assert wf.source_path is not None
+        assert wf.source_path.parent == wf._effective_base
+
+    def test_it_is_none_without_a_file(self) -> None:
+        """
+        A workflow built in Python has no source to point at.
+        """
+        assert SourcePathWorkflow(name="built_in_python").source_path is None
+
+    def test_it_is_not_serialized(
+        self, tmp_path: Path, make_workflow_file: MakeWorkflowFileType
+    ) -> None:
+        """
+        Runtime-only state, like the base directory beside it, so a
+        snapshot's meaning does not change.
+        """
+        workflow_file = make_workflow_file(tmp_path, self.WORKFLOW)
+        wf = SourcePathWorkflow.from_yaml(workflow_file)
+        assert "source_path" not in wf.model_dump(mode="json")


### PR DESCRIPTION
## Summary

Closes #182.

`from_yaml` records the workflow file's folder but not the file, so a loaded workflow cannot say where it came from. Anything wanting to copy, digest or link back to the source has to guess a filename, and guessing `workflow.yaml` is wrong whenever the CLI is handed another name.

Adds `source_path` beside `_base_directory`, set in the same place, `None` for a workflow built in Python or validated from a snapshot.

## On your review comment

You are right that the computed property was unnecessary, and it is gone.

One correction though: a `PrivateAttr` cannot be named `source_path`. Pydantic raises `NameError: Private attributes must not use valid field names; use sunder names, e.g. '_source_path'`. That is why the property existed, to give an underscore-free public read.

So I used the same pattern as `BaseArtifact.declared_path` instead:

```python
source_path: Path | None = Field(default=None, init=False, exclude=True)
```

Public name, excluded from `model_dump`, no property. Verified against `FileArtifact` that `declared_path` behaves exactly this way today.

Small thing noticed while checking: `init=False` does not actually stop the value being passed at construction. `FileArtifact(..., declared_path=Path("/y"))` is accepted. That applies to `declared_path` today too, so it is not something this PR introduces.

## Tests

Four, plus a small `SourcePathWorkflow` helper.

The helper is there for a reason worth flagging: the existing `ConcreteTestWorkflow` in that file **overrides `from_yaml`**, so a test using it never runs the loader at all. My first version asserted against the override and passed nothing.

- `from_yaml` keeps the file path
- `_base_directory` still points at the folder, so the new field sits beside the old one rather than replacing it
- `None` without a file
- absent from `model_dump`

737 passed, coverage 91.34%, `make lint` clean.

## Unrelated, but noticed while working

`make test` writes `.horus/` and `n.json` into the repo root, and neither is in `.gitignore`. Anyone running the suite and then `git add -A` sweeps them into a commit. Happy to send a one-line fix.

## Documentation impact

If a user, plugin, or GUI can observe the difference, it requires documentation.

- [ ] No documentation update required
- [x] Documentation updated / will be updated

**horus-docs PR:** to follow.

A plugin can observe this, which is the reason for it, so by the rule above it needs a line in `sdk/core/workflow.mdx`. If you consider an internal attribute out of scope for the docs site, say so and I will tick the other box instead.
