### PR TITLE
feat(task): track started_at/finished_at on BaseTask

### DIFF
--- a/src/horus_runtime/core/task/base.py
+++ b/src/horus_runtime/core/task/base.py
@@ -23,6 +23,7 @@ executing tasks, and should be ingested by the executor.
 
 from abc import abstractmethod
 from asyncio import CancelledError
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar, Self, final
 from uuid import uuid4
@@ -155,6 +156,18 @@ class BaseTask(AutoRegistry, entry_point="task"):
     Why the task was skipped, set only alongside ``TaskStatus.SKIPPED``. Lets a
     consumer tell a memoized cache hit apart from a branch that was not taken,
     which are the same status but mean opposite things to a reader.
+    """
+
+    started_at: datetime | None = None
+    """
+    When this task's status last moved to ``RUNNING`` (UTC). ``None`` before
+    the task has ever run.
+    """
+
+    finished_at: datetime | None = None
+    """
+    When this task's status last reached a terminal state (UTC). ``None``
+    while idle, pending, or running.
     """
 
     runs: int = 0
@@ -302,6 +315,8 @@ class BaseTask(AutoRegistry, entry_point="task"):
                 )
                 return
             self.status = TaskStatus.RUNNING
+            self.started_at = datetime.now(UTC)
+            self.finished_at = None
             horus_logger.log.debug(
                 _("Task %(task_name)s status → RUNNING")
                 % {"task_name": self.name}
@@ -328,6 +343,7 @@ class BaseTask(AutoRegistry, entry_point="task"):
                 )
             except CancelledError:
                 self.status = TaskStatus.CANCELED
+                self.finished_at = datetime.now(UTC)
                 horus_logger.log.debug(
                     _("Task %(task_name)s status → CANCELED")
                     % {"task_name": self.name}
@@ -335,6 +351,7 @@ class BaseTask(AutoRegistry, entry_point="task"):
                 raise
             except Exception:
                 self.status = TaskStatus.FAILED
+                self.finished_at = datetime.now(UTC)
                 horus_logger.log.debug(
                     _("Task %(task_name)s status → FAILED")
                     % {"task_name": self.name}
@@ -342,6 +359,7 @@ class BaseTask(AutoRegistry, entry_point="task"):
                 raise
             else:
                 self.status = TaskStatus.COMPLETED
+                self.finished_at = datetime.now(UTC)
                 horus_logger.log.debug(
                     _("Task %(task_name)s status → COMPLETED")
                     % {"task_name": self.name}
@@ -385,6 +403,8 @@ class BaseTask(AutoRegistry, entry_point="task"):
         """
         self.status = TaskStatus.IDLE
         self.skip_reason = None
+        self.started_at = None
+        self.finished_at = None
         horus_logger.log.debug(
             _("Task %(task_name)s reset → IDLE") % {"task_name": self.name}
         )

--- a/tests/unit/task/test_task_base.py
+++ b/tests/unit/task/test_task_base.py
@@ -20,6 +20,7 @@ Unit tests for BaseTask abstract base class.
 """
 
 from abc import ABC
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import ClassVar
 
@@ -297,6 +298,26 @@ class TestBaseTaskRun:
         await task.run()
 
         assert task.status == TaskStatus.SKIPPED
+        assert task.started_at is None
+        assert task.finished_at is None
+
+    async def test_run_sets_started_and_finished_at_on_completion(
+        self, horus_context: object
+    ) -> None:
+        """
+        A task that actually runs (not skipped) must record when it started
+        and when it reached a terminal state.
+        """
+        del horus_context
+        task = _make_concrete_task()
+        task.skip_if_complete = False
+
+        await task.run()
+
+        assert task.status == TaskStatus.COMPLETED
+        assert task.started_at is not None
+        assert task.finished_at is not None
+        assert task.finished_at >= task.started_at
 
     async def test_middleware_can_retarget_before_working_dir_is_created(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -375,6 +396,22 @@ class TestBaseTaskReset:
         await task.reset()
 
         assert task.status == TaskStatus.IDLE
+
+    async def test_reset_clears_timestamps(
+        self,
+    ) -> None:
+        """
+        reset() must clear started_at/finished_at so a re-run doesn't show a
+        leftover duration before it starts.
+        """
+        task = _make_concrete_task()
+        task.started_at = datetime.now(UTC)
+        task.finished_at = datetime.now(UTC)
+
+        await task.reset()
+
+        assert task.started_at is None
+        assert task.finished_at is None
 
     async def test_default_reset_is_noop(
         self,


### PR DESCRIPTION
## Summary
- Adds `started_at`/`finished_at` datetime fields to `BaseTask`, set at the existing `RUNNING`/terminal status transitions in `run()`, cleared on `reset()`.
- Lets consumers of the workflow snapshot (tc-os's canvas) show how long a task actually took to run — see temple-compute/tc-os#248.

## Test plan
- [x] `uv run pytest tests/unit/task/test_task_base.py -q` — new tests: skip leaves timestamps unset, a real run sets both, reset clears both
- [x] `uv run pytest tests/unit -q` — full unit suite passes (732 passed)

## Docs
- [x] No documentation update required