### PR TITLE
feat(task): add CONFIGURING status for environment setup before execution

### DIFF
--- a/src/horus_builtin/event/tui_subscriber.py
+++ b/src/horus_builtin/event/tui_subscriber.py
@@ -69,6 +69,7 @@ if TYPE_CHECKING:
 _STATUS_STYLE: dict[TaskStatus, str] = {
     TaskStatus.IDLE: "dim",
     TaskStatus.PENDING: "cyan",
+    TaskStatus.CONFIGURING: "cyan",
     TaskStatus.RUNNING: "bold yellow",
     TaskStatus.COMPLETED: "bold green",
     TaskStatus.FAILED: "bold red",
@@ -80,6 +81,7 @@ _STATUS_STYLE: dict[TaskStatus, str] = {
 _STATUS_GLYPH: dict[TaskStatus, str] = {
     TaskStatus.IDLE: "◌",
     TaskStatus.PENDING: "◔",
+    TaskStatus.CONFIGURING: "◑",
     TaskStatus.RUNNING: "●",
     TaskStatus.COMPLETED: "✓",
     TaskStatus.FAILED: "✗",

--- a/src/horus_runtime/core/executor/base.py
+++ b/src/horus_runtime/core/executor/base.py
@@ -35,6 +35,7 @@ from horus_builtin.artifact.folder import FolderArtifact
 from horus_runtime.core.resources import ProcessTreeScope, ResourceScope
 from horus_runtime.core.runtime.base import BaseRuntime
 from horus_runtime.core.target.channel import ChannelProcess
+from horus_runtime.core.task.status import TaskStatus
 from horus_runtime.i18n import tr as _
 from horus_runtime.logging import horus_logger
 from horus_runtime.middleware.executor import (
@@ -162,6 +163,13 @@ class BaseExecutor(AutoRegistry, entry_point="executor"):
         for artifact in task.outputs:
             on_target = PurePosixPath(task.target.path_on_target(artifact))
             await task.target.mkdir(str(on_target.parent))
+
+        # Generic environment setup (above) is done; the executor's own work
+        # starts now. Plugin executors with slower setup of their own (image
+        # build/pull, provisioning, queueing) may set ``task.status`` back to
+        # ``CONFIGURING`` at the start of their ``_execute`` and flip it to
+        # ``RUNNING`` again once real execution starts, the same way this does.
+        task.status = TaskStatus.RUNNING
 
         try:
             await ExecutorMiddleware.call_with_middleware(

--- a/src/horus_runtime/core/task/base.py
+++ b/src/horus_runtime/core/task/base.py
@@ -267,10 +267,12 @@ class BaseTask(AutoRegistry, entry_point="task"):
         Subclasses must implement ``_run()`` instead of overriding this method.
         Status is driven entirely here:
 
-        - ``SKIPPED``   — set when ``skip_if_complete`` is true and outputs
-                          exist (returns early)
-        - ``RUNNING``   — set on entry when not skipped
-        - ``COMPLETED`` — set on clean exit
+        - ``SKIPPED``     — set when ``skip_if_complete`` is true and outputs
+                            exist (returns early)
+        - ``CONFIGURING`` — set on entry when not skipped; the executor flips
+                            this to ``RUNNING`` once its own work starts (see
+                            ``BaseExecutor.execute``)
+        - ``COMPLETED``   — set on clean exit
         - ``CANCELED``  — set when ``CancelledError`` is raised
         - ``FAILED``    — set on any other exception (re-raised after)
         """
@@ -301,9 +303,9 @@ class BaseTask(AutoRegistry, entry_point="task"):
                     % {"task_name": self.name}
                 )
                 return
-            self.status = TaskStatus.RUNNING
+            self.status = TaskStatus.CONFIGURING
             horus_logger.log.debug(
-                _("Task %(task_name)s status → RUNNING")
+                _("Task %(task_name)s status → CONFIGURING")
                 % {"task_name": self.name}
             )
             try:

--- a/src/horus_runtime/core/task/status.py
+++ b/src/horus_runtime/core/task/status.py
@@ -37,6 +37,14 @@ class TaskStatus(Enum):
     The task is dispatched, but has not started executing yet.
     """
 
+    CONFIGURING = "configuring"
+    """
+    The task has started, and the executor is preparing its environment
+    (creating directories, checking/fingerprinting inputs, or -- for plugin
+    executors -- provisioning a machine, building/pulling an image, etc.) but
+    the task's own work has not started yet.
+    """
+
     RUNNING = "running"
     """
     The task is currently executing.

--- a/tests/unit/executor/test_executor_base.py
+++ b/tests/unit/executor/test_executor_base.py
@@ -288,6 +288,35 @@ class TestOutputDirectoriesAreCreated:
         assert not await task.is_complete()
 
 
+@pytest.mark.unit
+class TestExecuteSetsRunning:
+    """
+    ``BaseExecutor.execute`` flips the task to RUNNING itself, once the
+    generic environment setup (directories) is done and right before the
+    executor's own ``_execute`` starts.
+    """
+
+    @pytest.mark.usefixtures("horus_context")
+    async def test_status_is_running_when_execute_starts(
+        self, tmp_path: Path
+    ) -> None:
+        """RUNNING is set before ``_execute``, the executor-specific work."""
+        task = HorusTask(
+            id="writer",
+            name="writer",
+            runtime=CommandRuntime(command="true"),
+            executor=ShellExecutor(),
+            target=LocalTarget(working_directory=tmp_path.as_posix()),
+        )
+        # BaseTask.run() would already have set this; set it directly since
+        # this test drives the executor without going through run().
+        task.status = TaskStatus.CONFIGURING
+
+        await task.executor.execute(task)
+
+        assert task.status is TaskStatus.RUNNING
+
+
 _MKDIRS: list[str] = []
 
 

--- a/tests/unit/task/test_task_base.py
+++ b/tests/unit/task/test_task_base.py
@@ -298,6 +298,37 @@ class TestBaseTaskRun:
 
         assert task.status == TaskStatus.SKIPPED
 
+    async def test_status_is_configuring_during_run_before_execute(
+        self,
+    ) -> None:
+        """
+        Before the executor's own work starts, the task must report
+        CONFIGURING (not RUNNING) -- see ``BaseExecutor.execute``, which is
+        what flips it to RUNNING once environment setup is done.
+        """
+        seen: list[TaskStatus] = []
+
+        class RecordingTask(ConcreteTestTask):
+            kind: str = "recording_status_task"
+            add_to_registry: ClassVar[bool] = False
+
+            async def _run(self) -> None:
+                seen.append(self.status)
+
+        task = RecordingTask(
+            id="test_task_id",
+            name="test_task",
+            skip_if_complete=False,
+            runtime=CommandRuntime(command="echo test"),
+            executor=ShellExecutor(),
+            target=LocalTarget(),
+        )
+
+        await task.run()
+
+        assert seen == [TaskStatus.CONFIGURING]
+        assert task.status == TaskStatus.COMPLETED
+
     async def test_middleware_can_retarget_before_working_dir_is_created(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Summary
- Adds `TaskStatus.CONFIGURING`, between `PENDING` and `RUNNING`.
- `BaseTask.run()` now sets `CONFIGURING` on entry instead of jumping straight to `RUNNING` — previously RUNNING was set the instant the task's coroutine started, before the working directory existed or any environment prep ran.
- `BaseExecutor.execute()` (the one `@final` hook every executor funnels through) flips the status to `RUNNING` once its generic directory setup is done, right before the executor-specific `_execute()` begins.
- Plugin executors (`horus-docker`, `horus-slurm`, `horus-terraform`, etc., not in this repo) can reuse the same status field to report their own slower setup (image build/pull, VM provisioning, queueing) around their own `_execute()` — no new API needed, `status` is already a plain mutable field.
- TUI's exhaustive per-status style/glyph maps updated (the module asserts full coverage, so this was required, not optional).

Ref: temple-compute/tc-os#237

## Test plan
- [x] `uv run pytest -q` — 734 passed
- [x] New test: task status is `CONFIGURING` during `_run`, before the executor's `_execute` runs, then `COMPLETED` on clean exit
- [x] New test: `BaseExecutor.execute` sets `RUNNING` before invoking `_execute`
- [x] `ruff check` clean on all touched files

## Docs
- [x] No documentation update required