### PR TITLE
Fold local file digests into the task fingerprint

### DIFF
--- a/src/horus_builtin/runtime/python_script.py
+++ b/src/horus_builtin/runtime/python_script.py
@@ -83,11 +83,8 @@ class PythonScriptRuntime(CommandRuntime):
 
     def local_files(self) -> list[Path]:
         """
-        The script, unless it is templated.
-
-        A templated script names an input artifact rather than a file on
-        this machine, and that artifact's digest is already in the
-        fingerprint through the task's inputs.
+        The script, unless it is templated: a templated script names an
+        input artifact, already digested through the task's inputs.
         """
         if _is_template(self.script):
             return []

--- a/src/horus_builtin/runtime/python_script.py
+++ b/src/horus_builtin/runtime/python_script.py
@@ -81,6 +81,18 @@ class PythonScriptRuntime(CommandRuntime):
         if not self.script.is_absolute():
             self.script = (base / self.script).resolve()
 
+    def local_files(self) -> list[Path]:
+        """
+        The script, unless it is templated.
+
+        A templated script names an input artifact rather than a file on
+        this machine, and that artifact's digest is already in the
+        fingerprint through the task's inputs.
+        """
+        if _is_template(self.script):
+            return []
+        return [self.script]
+
     async def _setup_runtime(self, task: "BaseTask") -> str:
         if _is_template(self.script):
             # ``script: ${my_script}`` names an input artifact instead of a

--- a/src/horus_builtin/task/horus_task.py
+++ b/src/horus_builtin/task/horus_task.py
@@ -21,8 +21,8 @@ Default Horus task implementation.
 
 import hashlib
 import json
-from pathlib import PurePosixPath
-from typing import ClassVar
+from pathlib import Path, PurePosixPath
+from typing import Any, ClassVar
 
 from pydantic import BaseModel
 
@@ -37,6 +37,20 @@ from horus_runtime.core.task.base import BaseTask
 from horus_runtime.i18n import tr as _
 
 _UNHASHABLE = "unhashable"
+
+
+def _digest_file(path: Path) -> str:
+    """
+    sha256 of a file on the machine running the orchestrator, read in
+    chunks so a large one does not have to fit in memory.
+    """
+    sha = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            sha.update(block)
+    return sha.hexdigest()
+
+
 """Fingerprint value for an input the target cannot digest."""
 
 
@@ -136,15 +150,45 @@ class HorusTask(BaseTask):
             artifact.id: await store.digest(artifact) or _UNHASHABLE
             for artifact in self.inputs
         }
-        config = json.dumps(
-            {
-                "runtime": self.runtime.model_dump(mode="json"),
-                "executor": self.executor.model_dump(mode="json"),
-            },
-            sort_keys=True,
-        )
+        payload: dict[str, Any] = {
+            "runtime": self.runtime.model_dump(mode="json"),
+            "executor": self.executor.model_dump(mode="json"),
+        }
+        # A runtime holds its script as a path, so the dump above changes
+        # when the path changes but not when the file does. Without this a
+        # task keeps skipping after its code was edited.
+        code = self._local_file_digests()
+        if code:
+            payload["code"] = code
+        config = json.dumps(payload, sort_keys=True)
         config_hash = hashlib.sha256(config.encode()).hexdigest()
         return TaskFingerprint(inputs=inputs, config_hash=config_hash)
+
+    def _local_file_digests(self) -> list[list[str]]:
+        """
+        ``[name, sha256]`` for every local file the runtime and executor
+        own, sorted, so the same set hashes the same way twice.
+
+        Keyed by file name rather than full path, so this adds no new
+        path dependence. Note the fingerprint is already path-dependent
+        without it: ``runtime.model_dump()`` carries the script's
+        absolute path, so moving a workflow directory already
+        invalidates every task that runs a script.
+
+        A file that has gone missing is skipped rather than raising. It
+        drops out of the set, which changes the hash, which re-runs the
+        task, which is what a missing script deserves.
+        """
+        digests: list[list[str]] = []
+        for path in [
+            *self.runtime.local_files(),
+            *self.executor.local_files(),
+        ]:
+            try:
+                digests.append([path.name, _digest_file(path)])
+            except OSError:
+                continue
+        return sorted(digests)
 
     async def _write_manifest(self, fingerprint: TaskFingerprint) -> None:
         """

--- a/src/horus_builtin/task/horus_task.py
+++ b/src/horus_builtin/task/horus_task.py
@@ -41,8 +41,7 @@ _UNHASHABLE = "unhashable"
 
 def _digest_file(path: Path) -> str:
     """
-    sha256 of a file on the machine running the orchestrator, read in
-    chunks so a large one does not have to fit in memory.
+    sha256 of a local file, read in chunks.
     """
     sha = hashlib.sha256()
     with path.open("rb") as handle:
@@ -166,18 +165,11 @@ class HorusTask(BaseTask):
 
     def _local_file_digests(self) -> list[list[str]]:
         """
-        ``[name, sha256]`` for every local file the runtime and executor
-        own, sorted, so the same set hashes the same way twice.
+        Sorted ``[name, sha256]`` for the runtime's and executor's local
+        files, so the same set hashes the same way twice.
 
-        Keyed by file name rather than full path, so this adds no new
-        path dependence. Note the fingerprint is already path-dependent
-        without it: ``runtime.model_dump()`` carries the script's
-        absolute path, so moving a workflow directory already
-        invalidates every task that runs a script.
-
-        A file that has gone missing is skipped rather than raising. It
-        drops out of the set, which changes the hash, which re-runs the
-        task, which is what a missing script deserves.
+        Keyed by name, not path, to add no new path dependence. A missing
+        file is skipped: it drops out of the set, so the task re-runs.
         """
         digests: list[list[str]] = []
         for path in [

--- a/src/horus_runtime/core/executor/base.py
+++ b/src/horus_runtime/core/executor/base.py
@@ -133,6 +133,18 @@ class BaseExecutor(AutoRegistry, entry_point="executor"):
         working directory instead.
         """
 
+    def local_files(self) -> list[Path]:
+        """
+        Local files this executor reads from the orchestrator, so a change
+        to one invalidates the tasks that use it. Empty by default.
+
+        Mirrors :meth:`BaseRuntime.local_files`, for the same reason as the
+        anchoring above: an executor pointing at a conda
+        ``environment_file`` next to the workflow describes an environment,
+        and editing that file changes the environment.
+        """
+        return []
+
     @final
     async def execute(self, task: "BaseTask") -> None:
         """

--- a/src/horus_runtime/core/executor/base.py
+++ b/src/horus_runtime/core/executor/base.py
@@ -135,13 +135,11 @@ class BaseExecutor(AutoRegistry, entry_point="executor"):
 
     def local_files(self) -> list[Path]:
         """
-        Local files this executor reads from the orchestrator, so a change
-        to one invalidates the tasks that use it. Empty by default.
+        Local files this executor reads from the orchestrator, digested
+        into the task fingerprint. Empty by default.
 
-        Mirrors :meth:`BaseRuntime.local_files`, for the same reason as the
-        anchoring above: an executor pointing at a conda
-        ``environment_file`` next to the workflow describes an environment,
-        and editing that file changes the environment.
+        Mirrors :meth:`BaseRuntime.local_files`; a conda
+        ``environment_file`` is the case this exists for.
         """
         return []
 

--- a/src/horus_runtime/core/runtime/base.py
+++ b/src/horus_runtime/core/runtime/base.py
@@ -65,6 +65,18 @@ class BaseRuntime[T: Any = Any](AutoRegistry, entry_point="runtime"):
         Called by the workflow before execution. No-op by default.
         """
 
+    def local_files(self) -> list[Path]:
+        """
+        Local files this runtime reads from the orchestrator, so a change
+        to one invalidates the task that runs it. Empty by default.
+
+        Mirrors :meth:`anchor_local_paths`: whatever that resolves is what
+        this returns. A runtime that carries its code inline, or that names
+        an artifact rather than a file, owns no local file and returns
+        nothing.
+        """
+        return []
+
     @abstractmethod
     async def _setup_runtime(self, task: "BaseTask") -> T:
         """

--- a/src/horus_runtime/core/runtime/base.py
+++ b/src/horus_runtime/core/runtime/base.py
@@ -67,13 +67,11 @@ class BaseRuntime[T: Any = Any](AutoRegistry, entry_point="runtime"):
 
     def local_files(self) -> list[Path]:
         """
-        Local files this runtime reads from the orchestrator, so a change
-        to one invalidates the task that runs it. Empty by default.
+        Local files this runtime reads from the orchestrator, digested
+        into the task fingerprint. Empty by default.
 
-        Mirrors :meth:`anchor_local_paths`: whatever that resolves is what
-        this returns. A runtime that carries its code inline, or that names
-        an artifact rather than a file, owns no local file and returns
-        nothing.
+        Mirrors :meth:`anchor_local_paths`: whatever that resolves is
+        what this returns.
         """
         return []
 

--- a/tests/unit/task/test_builtin_task.py
+++ b/tests/unit/task/test_builtin_task.py
@@ -20,6 +20,8 @@
 Unit tests for HorusTask builtin task.
 """
 
+import hashlib
+import json
 from pathlib import Path
 from unittest.mock import patch
 
@@ -29,6 +31,7 @@ from pydantic import BaseModel, ValidationError
 from horus_builtin.artifact.file import FileArtifact
 from horus_builtin.executor.shell import ShellExecutor
 from horus_builtin.runtime.command import CommandRuntime
+from horus_builtin.runtime.python_script import PythonScriptRuntime
 from horus_builtin.target.local import LocalTarget
 from horus_builtin.task.horus_task import HorusTask
 from horus_runtime.core.artifact.exceptions import ArtifactDoesNotExistError
@@ -457,3 +460,125 @@ class TestHorusTaskInputFingerprint:
 
         assert task.runs == 1
         assert await task.is_complete() is True
+
+
+@pytest.mark.unit
+class TestLocalFilesInFingerprint:
+    """
+    A runtime holds its script as a path, so the config dump changes when
+    the path changes but not when the file does. Without the file's digest
+    a task keeps skipping after its code was edited.
+    """
+
+    @staticmethod
+    def _script_task(tmp_path: Path, body: str) -> HorusTask:
+        """
+        A task whose runtime runs a real script file on disk.
+        """
+        script = tmp_path / "prep.py"
+        script.write_text(body)
+        return HorusTask(
+            id="prep",
+            name="Prepare",
+            runtime=PythonScriptRuntime(script=script),
+            executor=ShellExecutor(),
+            target=LocalTarget(working_directory=str(tmp_path)),
+        )
+
+    async def test_editing_a_script_changes_the_fingerprint(
+        self, tmp_path: Path
+    ) -> None:
+        """
+        The bug this exists to fix: the task used to skip with stale code.
+        """
+        task = self._script_task(tmp_path, "print('one')\n")
+        before = (await task._fingerprint()).config_hash
+
+        (tmp_path / "prep.py").write_text("print('two')\n")
+        after = (await task._fingerprint()).config_hash
+
+        assert before != after
+
+    async def test_an_untouched_script_keeps_its_fingerprint(
+        self, tmp_path: Path
+    ) -> None:
+        """
+        Hashing the file must not make the fingerprint unstable, or every
+        run would re-run everything.
+        """
+        task = self._script_task(tmp_path, "print('one')\n")
+        assert (await task._fingerprint()).config_hash == (
+            await task._fingerprint()
+        ).config_hash
+
+    async def test_a_task_without_local_files_is_unaffected(
+        self, tmp_path: Path, make_shell_task: MakeTaskType
+    ) -> None:
+        """
+        The code entry is only added when a task has local files, so
+        existing caches for command-only tasks stay valid.
+        """
+        del tmp_path
+        task = make_shell_task(cmd="echo hello")
+        fingerprint = await task._fingerprint()
+        payload = json.dumps(
+            {
+                "runtime": task.runtime.model_dump(mode="json"),
+                "executor": task.executor.model_dump(mode="json"),
+            },
+            sort_keys=True,
+        )
+        assert (
+            fingerprint.config_hash
+            == hashlib.sha256(payload.encode()).hexdigest()
+        )
+
+    async def test_a_missing_script_is_skipped_rather_than_raising(
+        self, tmp_path: Path
+    ) -> None:
+        """
+        It drops out of the set, which changes the hash, which re-runs the
+        task. A missing script deserves exactly that.
+        """
+        task = self._script_task(tmp_path, "print('one')\n")
+        with_script = (await task._fingerprint()).config_hash
+
+        (tmp_path / "prep.py").unlink()
+        without = (await task._fingerprint()).config_hash
+
+        assert with_script != without
+
+
+@pytest.mark.unit
+class TestLocalFilesHooks:
+    """
+    What each base class reports as its own local files.
+    """
+
+    def test_a_runtime_owns_nothing_by_default(self) -> None:
+        """
+        A runtime carrying its command inline reads no local file.
+        """
+        assert CommandRuntime(command="echo hi").local_files() == []
+
+    def test_an_executor_owns_nothing_by_default(self) -> None:
+        """
+        The hook exists for executors that point at an environment file.
+        """
+        assert ShellExecutor().local_files() == []
+
+    def test_a_script_runtime_owns_its_script(self, tmp_path: Path) -> None:
+        """
+        The case the fingerprint change depends on.
+        """
+        script = tmp_path / "prep.py"
+        script.write_text("print('one')\n")
+        assert PythonScriptRuntime(script=script).local_files() == [script]
+
+    def test_a_templated_script_owns_nothing(self) -> None:
+        """
+        A templated script names an input artifact, whose digest is
+        already in the fingerprint through the task's inputs.
+        """
+        runtime = PythonScriptRuntime(script=Path("${my_script}"))
+        assert runtime.local_files() == []


### PR DESCRIPTION
## Summary

Closes #180. A runtime holds its script as a path, so `runtime.model_dump()` changes when the path changes but not when the file does. The script is not a declared input either, so its digest is nowhere in the fingerprint. Editing a script leaves `config_hash` identical, the task skips, and it keeps output from the previous version of the code.

Adds `local_files()` to `BaseRuntime` and `BaseExecutor`, returning `[]` by default, mirroring the existing `anchor_local_paths` pair. `PythonScriptRuntime` returns its script unless it is templated. `HorusTask._fingerprint` folds those files' digests into the config payload.

**The `code` entry is only added when a task actually has local files**, so a command-only task hashes byte-identically to before and its cache stays valid. There is a test asserting exactly that against a hand-built payload. Tasks that run scripts will re-run once.

Verified on a real workflow: editing a script now takes effect on the next run instead of surfacing two runs later when something unrelated invalidates. An unchanged re-run still skips every task.

## Two things for you to rule on

**The `BaseExecutor` hook has no override yet.** I added it because your own `anchor_local_paths` docstring names a conda `environment_file`, and that file has the same bug: editing it changes the environment but not the fingerprint. `horus-environments` would supply the override. Say the word and I will drop it from this PR.

**The fingerprint is already path-dependent, separately from this.** `runtime.model_dump()` carries the script's absolute path, so moving a workflow directory already invalidates every script task today. I wrote a test asserting a move should be neutral, watched it fail, and deleted it. Mentioning it because it works against the machine-independence you said you wanted next, and this PR neither helps nor hurts it.

## Tests

Nine. Five on the fingerprint: an edit changes the hash, an untouched script does not, a task with no local files matches the old scheme exactly, a missing script is skipped rather than raising. Four on the hooks.

741 passed, coverage 91.38%, `make lint` clean.

## Documentation impact

If a user, plugin, or GUI can observe the difference, it requires documentation.

- [ ] No documentation update required
- [x] Documentation updated / will be updated

**horus-docs PR:** to follow.

This changes when a cached task re-runs, which `sdk/core/task.mdx` and `guides/concepts.mdx` describe. Happy to write it, tell me if you would rather. I have not ticked "no documentation required" because a caching behaviour change is exactly the kind of thing people rely on.
