### PR TITLE
docs-check: also accept horus-docs link from PR comments

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -20,6 +20,9 @@ jobs:
 
       - name: Enforce docs reference if required
         if: steps.changes.outputs.runtime == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           BODY=$(cat <<'EOF'
           ${{ github.event.pull_request.body }}
@@ -29,8 +32,12 @@ jobs:
           # If author explicitly says docs are NOT required -> allow
           echo "$BODY" | grep -qi "\[x\] No documentation update required" && exit 0
 
-          # Otherwise, docs ARE required -> enforce horus-docs PR link
-          echo "$BODY" | grep -E "github.com/temple-compute/horus-docs/pull/[0-9]+" \
+          # Docs ARE required -> a horus-docs PR link in the body or in any
+          # PR comment (e.g. a reviewer linking it) satisfies the check.
+          COMMENTS=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" --jq '.[].body')
+
+          printf '%s\n%s\n' "$BODY" "$COMMENTS" \
+            | grep -E "github.com/temple-compute/horus-docs/pull/[0-9]+" \
             && exit 0
 
           echo "❌ Runtime code changed and documentation is required, but no horus-docs PR was linked."


### PR DESCRIPTION
## Summary
- The docs-check workflow only scanned the PR body for a linked `horus-docs` PR, so a link added by a reviewer or other contributor in a comment wasn't recognized.
- Now also fetches PR issue comments via the GitHub API and checks them alongside the body.

## Test plan
- [ ] Open a PR touching `src/**` with no docs link in the body but a `horus-docs` PR link in a comment, confirm the check passes.
- [ ] Confirm the "[x] No documentation update required" opt-out in the body still works.