### PR TITLE
feat(secrets): mark and redact credential fields on plugin models

### DIFF
--- a/src/horus_runtime/core/workflow/base.py
+++ b/src/horus_runtime/core/workflow/base.py
@@ -87,6 +87,7 @@ from horus_runtime.middleware.workflow import (
     WorkflowMiddlewareContext,
 )
 from horus_runtime.registry.auto_registry import AutoRegistry
+from horus_runtime.secrets import iter_secret_fields, redact
 
 if TYPE_CHECKING:
     from horus_builtin.workflow.subworkflow.expander import SubworkflowExpander
@@ -980,14 +981,24 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
         similar become plain strings) exactly as ``from_yaml`` expects them
         back on load.
 
+        Every ``Secret``-marked field (see :mod:`horus_runtime.secrets`) is
+        replaced with a ``${secret:<ref>}`` reference before writing.
+        ``model_dump``'s own default -- masking with ``**********`` -- is
+        the wrong answer for a file meant to be re-imported: a masked value
+        round-trips back in as that literal string.
+
         Args:
             path: Path to the YAML file.
 
         Returns:
             None
         """
+        dumped = self.model_dump(mode="json")
+        secret_fields = list(iter_secret_fields(self))
+        if secret_fields:
+            dumped = redact(dumped, secret_fields)
         with Path(path).open("w", encoding="utf-8") as fh:
-            yaml.safe_dump(self.model_dump(mode="json"), fh)
+            yaml.safe_dump(dumped, fh)
 
     def _build_source_map(self) -> dict[tuple[str, str], EdgeSource]:
         """

--- a/src/horus_runtime/core/workflow/base.py
+++ b/src/horus_runtime/core/workflow/base.py
@@ -981,11 +981,8 @@ class BaseWorkflow(AutoRegistry, entry_point="workflow"):
         similar become plain strings) exactly as ``from_yaml`` expects them
         back on load.
 
-        Every ``Secret``-marked field (see :mod:`horus_runtime.secrets`) is
-        replaced with a ``${secret:<ref>}`` reference before writing.
-        ``model_dump``'s own default -- masking with ``**********`` -- is
-        the wrong answer for a file meant to be re-imported: a masked value
-        round-trips back in as that literal string.
+        ``Secret``-marked fields (see :mod:`horus_runtime.secrets`) are
+        redacted to ``${secret:<ref>}`` before writing.
 
         Args:
             path: Path to the YAML file.

--- a/src/horus_runtime/packaging.py
+++ b/src/horus_runtime/packaging.py
@@ -54,20 +54,13 @@ def _redact_source(text: str, workflow: BaseWorkflow) -> str:
     """
     Replace each literal secret value's occurrence in *text* with its
     ``${secret:<ref>}`` reference.
-
-    Substring replacement on the source text, not a re-dump through the
-    model: re-dumping resolves every relative path to absolute (see
-    :meth:`BaseWorkflow.to_yaml`), which would make the packaged
-    ``workflow.yaml`` unportable -- the same reason :mod:`horus_runtime.
-    sanitize` rewrites text rather than re-dumping. A value already holding
-    a ``${secret:<ref>}`` reference is left alone; there is nothing literal
-    left to redact.
-
-    ponytail: a literal secret value that happens to also appear verbatim
-    elsewhere in the file (e.g. reused as another field's value) gets
-    replaced there too. Narrow this to the exact YAML node with a real
-    parser (ruamel) if that ever produces a wrong substitution.
     """
+    # Substring replacement on the source text, not a re-dump through the
+    # model: re-dumping absolutizes relative paths (see BaseWorkflow.to_yaml),
+    # same reason horus_runtime.sanitize rewrites text instead.
+    # ponytail: a literal value reused verbatim elsewhere in the file gets
+    # replaced there too. Narrow to the exact YAML node with ruamel if that
+    # ever produces a wrong substitution.
     for path, secret in iter_secret_fields(workflow):
         if secret.ref is not None:
             continue

--- a/src/horus_runtime/packaging.py
+++ b/src/horus_runtime/packaging.py
@@ -38,6 +38,7 @@ from pathlib import Path
 from horus_builtin.runtime.substitution import is_template
 from horus_runtime.core.workflow.base import BaseWorkflow
 from horus_runtime.i18n import tr as _
+from horus_runtime.secrets import iter_secret_fields, ref_for_path
 
 # Junk that can sit inside a referenced folder artifact but is never input.
 _EXCLUDED_DIRS = frozenset(
@@ -47,6 +48,34 @@ _EXCLUDED_DIRS = frozenset(
 
 class BundleError(Exception):
     """A workflow could not be packaged."""
+
+
+def _redact_source(text: str, workflow: BaseWorkflow) -> str:
+    """
+    Replace each literal secret value's occurrence in *text* with its
+    ``${secret:<ref>}`` reference.
+
+    Substring replacement on the source text, not a re-dump through the
+    model: re-dumping resolves every relative path to absolute (see
+    :meth:`BaseWorkflow.to_yaml`), which would make the packaged
+    ``workflow.yaml`` unportable -- the same reason :mod:`horus_runtime.
+    sanitize` rewrites text rather than re-dumping. A value already holding
+    a ``${secret:<ref>}`` reference is left alone; there is nothing literal
+    left to redact.
+
+    ponytail: a literal secret value that happens to also appear verbatim
+    elsewhere in the file (e.g. reused as another field's value) gets
+    replaced there too. Narrow this to the exact YAML node with a real
+    parser (ruamel) if that ever produces a wrong substitution.
+    """
+    for path, secret in iter_secret_fields(workflow):
+        if secret.ref is not None:
+            continue
+        value = secret.resolve()
+        if not value:
+            continue
+        text = text.replace(value, f"${{secret:{ref_for_path(path)}}}")
+    return text
 
 
 def collect_bundle_paths(
@@ -152,12 +181,16 @@ def package_workflow(
     output = output or base / f"{base.name}.zip"
     output = output.resolve()
 
+    workflow_text = _redact_source(
+        workflow_yaml.read_text(encoding="utf-8"), workflow
+    )
+
     with zipfile.ZipFile(
         output, "w", compression=zipfile.ZIP_DEFLATED
     ) as bundle:
         # Always at the archive root under a fixed name, so an importer can
         # find the definition without guessing the original filename.
-        bundle.write(workflow_yaml, "workflow.yaml")
+        bundle.writestr("workflow.yaml", workflow_text)
         for rel in members:
             bundle.write(base / rel, rel.as_posix())
 

--- a/src/horus_runtime/secrets.py
+++ b/src/horus_runtime/secrets.py
@@ -19,22 +19,11 @@
 """
 Mark, find, and redact credential fields on plugin models.
 
-A plugin model has no way to say "this field is a secret" today -- a
-password is just a ``str``, indistinguishable from a hostname, so nothing
-that serializes a workflow (``to_yaml``, ``package_workflow``, tc-os's export
-routes) can single it out. :class:`Secret` is that declaration: a plugin
-opts a field in with a one-word change, ``password: Secret | None = None``.
-
-:class:`Secret` already inherits ``pydantic.SecretStr``'s safe defaults --
-``repr``/``str``/``model_dump(mode="json")`` show ``**********``, never the
-value. That default is *masking*, which is fine for logs but the wrong
-answer for an export a colleague might re-import: a masked value round-trips
-back in as the literal string ``"**********"``. :func:`iter_secret_fields`
-and :func:`redact` are the extra step ``to_yaml`` and ``package_workflow``
-take before writing: replace the field with a ``${secret:<ref>}`` reference
-instead, which is portable and inert. :meth:`Secret.resolve` resolves such a
-reference lazily, from the run-time environment or a local secrets file,
-never from the workflow document itself.
+``Secret`` opts a field into export redaction (``password: Secret | None``).
+Export replaces the value with ``${secret:<ref>}`` instead of pydantic's own
+``**********`` mask, since a mask re-imports as a literal password.
+``Secret.resolve()`` reads the real value back from the environment or a
+local secrets file at run time.
 """
 
 import copy
@@ -46,6 +35,17 @@ from typing import Any
 
 import yaml
 from pydantic import BaseModel, SecretStr
+
+__all__ = [
+    "Secret",
+    "SecretResolutionError",
+    "env_key_for_ref",
+    "iter_secret_fields",
+    "iter_secret_refs",
+    "redact",
+    "ref_for_path",
+    "secret_ref",
+]
 
 #: Matches a secret reference literal, e.g. ``${secret:ssh-password}``.
 _REF_RE = re.compile(r"^\$\{secret:([A-Za-z0-9_.:-]+)\}$")
@@ -62,32 +62,17 @@ def secret_ref(raw: str) -> str | None:
 
 
 def ref_for_path(path: str) -> str:
-    """
-    Derive a stable, template-safe reference id from a dotted field path.
-
-    Used for a literal value with no reference of its own yet (see
-    :func:`redact`), so redacting the same document twice yields the same
-    ref rather than a fresh one each time.
-    """
+    """Derive a stable ref id from a dotted path (same path -> same ref)."""
     return re.sub(r"[^a-z0-9]+", "_", path.lower()).strip("_")
 
 
 def env_key_for_ref(ref: str) -> str:
-    """
-    The environment variable name :func:`Secret.resolve` (and a dispatcher
-    provisioning one for it) checks first for *ref* -- the one place this
-    mapping is defined, so a dispatcher and the runtime it hands values to
-    can never derive it differently.
-    """
+    """Env var name :meth:`Secret.resolve` checks first for *ref*."""
     return "HORUS_SECRET_" + re.sub(r"[^A-Za-z0-9]+", "_", ref).upper()
 
 
 def _resolve(ref: str) -> str:
-    """
-    Resolve *ref* to a value: the environment first, then a local secrets
-    file, matching the export side's own precedence (an operator can always
-    override a file-provisioned secret with an env var).
-    """
+    """Resolve *ref*: env var first, then ``$HORUS_SECRETS_FILE``."""
     env_key = env_key_for_ref(ref)
     if env_key in os.environ:
         return os.environ[env_key]
@@ -106,31 +91,17 @@ class Secret(SecretStr):
     """
     A model field marker for a credential.
 
-    Declare it in place of ``str`` to opt a plugin field into export
-    redaction: ``password: Secret | None = None``. Everything else follows
-    from ``SecretStr``: ``repr``/``str`` show ``**********``, and the JSON
-    schema pydantic generates carries ``format: "password"`` (already what
-    tc-os's frontend keys its password-input heuristic on) and
-    ``writeOnly: True``.
-
-    A value validated from a ``${secret:<ref>}`` literal is a *reference*:
-    :attr:`ref` reports it, and :meth:`resolve` resolves it lazily from the
-    environment or a local secrets file rather than returning the literal
-    string. Any other value is a literal secret, ``ref is None``, and
-    :meth:`resolve` returns it as-is -- the plugin using it (e.g.
-    ``asyncssh.connect``) is none the wiser.
-
-    ``get_secret_value()``, inherited unchanged from ``SecretStr``, is
-    deliberately *not* overridden to resolve: pydantic's own default JSON
-    serialization (the masking every other caller of ``model_dump`` relies
-    on) calls it internally to build ``**********``, and that must keep
-    working even when nothing has resolved the reference yet -- an
-    unredacted ``model_dump(mode="json")`` of an already-exported workflow
-    must not raise just because this process has no value for a secret it
-    is about to overwrite with a reference anyway. Only :meth:`resolve` --
-    called by a plugin at the point it actually needs the credential --
-    performs the lookup, and only there can it fail.
+    Inherits ``SecretStr``'s masked ``repr``/``str``/JSON dump, and pydantic's
+    ``format: "password"`` / ``writeOnly`` in the generated JSON schema. A
+    value validated from ``${secret:<ref>}`` is a *reference* (``.ref`` set,
+    ``.resolve()`` looks it up); any other value is a literal (``.ref is
+    None``, ``.resolve()`` returns it as-is).
     """
+
+    # get_secret_value() is left unoverridden: pydantic's own JSON masking
+    # calls it internally to build "**********", and that must not raise
+    # just because this process can't resolve a reference yet. Only
+    # resolve() -- called when a plugin actually needs the value -- can fail.
 
     def __init__(self, secret_value: str) -> None:
         super().__init__(secret_value)
@@ -152,20 +123,11 @@ def iter_secret_fields(
     obj: Any, _prefix: str = ""
 ) -> Iterator[tuple[str, Secret]]:
     """
-    Walk *obj* and yield ``(dotted_path, secret)`` for every :class:`Secret`
-    field reachable from it.
+    Walk a model (or the lists/dicts it's built from) and yield
+    ``(dotted_path, secret)`` for every ``Secret`` field reachable from it.
 
-    *obj* is normally a :class:`~horus_runtime.core.workflow.base.BaseWorkflow`
-    instance, but the walk is generic over any pydantic model plus the
-    lists and dicts a workflow is built from (``tasks``, nested
-    ``target``/``runtime``/``executor``, artifact lists), so it finds a
-    secret at any depth without a plugin registering anything.
-
-    Paths use ``.`` throughout, including for list indices
-    (``tasks.1.target.password``) rather than ``tasks[1]...``, so a caller
-    holding the *dumped* dict (tc-os, which never imports horus-runtime's
-    plugin models) can apply the same path to it with nothing more than
-    ``str.split(".")``.
+    Dotted paths use ``.`` even for list indices (``tasks.1.target.password``)
+    so ``iter_secret_refs`` can match the same path on the dumped dict.
     """
     if isinstance(obj, Secret):
         if _prefix:
@@ -187,6 +149,31 @@ def iter_secret_fields(
         return
 
 
+def iter_secret_refs(
+    data: Any, _prefix: str = ""
+) -> Iterator[tuple[str, str]]:
+    """
+    Walk a *dumped* workflow dict (no model classes, e.g. tc-os's opaque
+    ``workflow_data``) and yield ``(dotted_path, ref)`` for every
+    ``${secret:<ref>}`` string found. The dict-side twin of
+    :func:`iter_secret_fields`, for a caller with no plugin models to walk.
+    """
+    if isinstance(data, str):
+        ref = secret_ref(data)
+        if ref is not None and _prefix:
+            yield _prefix, ref
+        return
+    if isinstance(data, list):
+        for i, item in enumerate(data):
+            yield from iter_secret_refs(item, f"{_prefix}.{i}")
+        return
+    if isinstance(data, dict):
+        for key, value in data.items():
+            path = f"{_prefix}.{key}" if _prefix else key
+            yield from iter_secret_refs(value, path)
+        return
+
+
 def _set_path(data: Any, parts: list[str], value: str) -> None:
     node = data
     for part in parts[:-1]:
@@ -202,16 +189,10 @@ def redact(
     data: dict[str, Any], secret_fields: Iterable[tuple[str, Secret]]
 ) -> dict[str, Any]:
     """
-    Return a deep copy of *data* with each secret-marked field replaced by a
-    ``${secret:<ref>}`` reference -- never the value, not even masked.
-
-    *data* is normally ``workflow.model_dump(mode="json")`` and
-    *secret_fields* ``iter_secret_fields(workflow)`` on the same instance --
-    kept separate rather than combined into one call so a caller that only
-    has the dumped dict (tc-os) can pass paths it derived itself instead. A
-    value that already came from a ``${secret:<ref>}`` literal keeps its own
-    ref, so redacting an already-redacted document is a no-op; a literal
-    value is assigned a ref derived from its path (see :func:`ref_for_path`).
+    Return a deep copy of *data* with each secret field replaced by its
+    ``${secret:<ref>}`` reference -- never the value, not even masked. A
+    literal gets a ref derived from its path; an existing reference keeps its
+    own ref, so redacting an already-redacted document is a no-op.
     """
     out = copy.deepcopy(data)
     for path, secret in secret_fields:

--- a/src/horus_runtime/secrets.py
+++ b/src/horus_runtime/secrets.py
@@ -72,7 +72,13 @@ def ref_for_path(path: str) -> str:
     return re.sub(r"[^a-z0-9]+", "_", path.lower()).strip("_")
 
 
-def _env_key(ref: str) -> str:
+def env_key_for_ref(ref: str) -> str:
+    """
+    The environment variable name :func:`Secret.resolve` (and a dispatcher
+    provisioning one for it) checks first for *ref* -- the one place this
+    mapping is defined, so a dispatcher and the runtime it hands values to
+    can never derive it differently.
+    """
     return "HORUS_SECRET_" + re.sub(r"[^A-Za-z0-9]+", "_", ref).upper()
 
 
@@ -82,7 +88,7 @@ def _resolve(ref: str) -> str:
     file, matching the export side's own precedence (an operator can always
     override a file-provisioned secret with an env var).
     """
-    env_key = _env_key(ref)
+    env_key = env_key_for_ref(ref)
     if env_key in os.environ:
         return os.environ[env_key]
     secrets_file = os.environ.get("HORUS_SECRETS_FILE")
@@ -91,8 +97,8 @@ def _resolve(ref: str) -> str:
         if isinstance(data, dict) and ref in data:
             return str(data[ref])
     raise SecretResolutionError(
-        f"No value for secret reference {ref!r}: set {_env_key(ref)} or add "
-        f"it to the file named by $HORUS_SECRETS_FILE."
+        f"No value for secret reference {ref!r}: set {env_key} or add it "
+        f"to the file named by $HORUS_SECRETS_FILE."
     )
 
 

--- a/src/horus_runtime/secrets.py
+++ b/src/horus_runtime/secrets.py
@@ -1,0 +1,214 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+"""
+Mark, find, and redact credential fields on plugin models.
+
+A plugin model has no way to say "this field is a secret" today -- a
+password is just a ``str``, indistinguishable from a hostname, so nothing
+that serializes a workflow (``to_yaml``, ``package_workflow``, tc-os's export
+routes) can single it out. :class:`Secret` is that declaration: a plugin
+opts a field in with a one-word change, ``password: Secret | None = None``.
+
+:class:`Secret` already inherits ``pydantic.SecretStr``'s safe defaults --
+``repr``/``str``/``model_dump(mode="json")`` show ``**********``, never the
+value. That default is *masking*, which is fine for logs but the wrong
+answer for an export a colleague might re-import: a masked value round-trips
+back in as the literal string ``"**********"``. :func:`iter_secret_fields`
+and :func:`redact` are the extra step ``to_yaml`` and ``package_workflow``
+take before writing: replace the field with a ``${secret:<ref>}`` reference
+instead, which is portable and inert. :meth:`Secret.resolve` resolves such a
+reference lazily, from the run-time environment or a local secrets file,
+never from the workflow document itself.
+"""
+
+import copy
+import os
+import re
+from collections.abc import Iterable, Iterator
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import BaseModel, SecretStr
+
+#: Matches a secret reference literal, e.g. ``${secret:ssh-password}``.
+_REF_RE = re.compile(r"^\$\{secret:([A-Za-z0-9_.:-]+)\}$")
+
+
+class SecretResolutionError(RuntimeError):
+    """No value is available for a secret reference at run time."""
+
+
+def secret_ref(raw: str) -> str | None:
+    """Return the reference id in *raw* (``${secret:<ref>}``), or ``None``."""
+    match = _REF_RE.match(raw)
+    return match.group(1) if match else None
+
+
+def ref_for_path(path: str) -> str:
+    """
+    Derive a stable, template-safe reference id from a dotted field path.
+
+    Used for a literal value with no reference of its own yet (see
+    :func:`redact`), so redacting the same document twice yields the same
+    ref rather than a fresh one each time.
+    """
+    return re.sub(r"[^a-z0-9]+", "_", path.lower()).strip("_")
+
+
+def _env_key(ref: str) -> str:
+    return "HORUS_SECRET_" + re.sub(r"[^A-Za-z0-9]+", "_", ref).upper()
+
+
+def _resolve(ref: str) -> str:
+    """
+    Resolve *ref* to a value: the environment first, then a local secrets
+    file, matching the export side's own precedence (an operator can always
+    override a file-provisioned secret with an env var).
+    """
+    env_key = _env_key(ref)
+    if env_key in os.environ:
+        return os.environ[env_key]
+    secrets_file = os.environ.get("HORUS_SECRETS_FILE")
+    if secrets_file:
+        data = yaml.safe_load(Path(secrets_file).read_text(encoding="utf-8"))
+        if isinstance(data, dict) and ref in data:
+            return str(data[ref])
+    raise SecretResolutionError(
+        f"No value for secret reference {ref!r}: set {_env_key(ref)} or add "
+        f"it to the file named by $HORUS_SECRETS_FILE."
+    )
+
+
+class Secret(SecretStr):
+    """
+    A model field marker for a credential.
+
+    Declare it in place of ``str`` to opt a plugin field into export
+    redaction: ``password: Secret | None = None``. Everything else follows
+    from ``SecretStr``: ``repr``/``str`` show ``**********``, and the JSON
+    schema pydantic generates carries ``format: "password"`` (already what
+    tc-os's frontend keys its password-input heuristic on) and
+    ``writeOnly: True``.
+
+    A value validated from a ``${secret:<ref>}`` literal is a *reference*:
+    :attr:`ref` reports it, and :meth:`resolve` resolves it lazily from the
+    environment or a local secrets file rather than returning the literal
+    string. Any other value is a literal secret, ``ref is None``, and
+    :meth:`resolve` returns it as-is -- the plugin using it (e.g.
+    ``asyncssh.connect``) is none the wiser.
+
+    ``get_secret_value()``, inherited unchanged from ``SecretStr``, is
+    deliberately *not* overridden to resolve: pydantic's own default JSON
+    serialization (the masking every other caller of ``model_dump`` relies
+    on) calls it internally to build ``**********``, and that must keep
+    working even when nothing has resolved the reference yet -- an
+    unredacted ``model_dump(mode="json")`` of an already-exported workflow
+    must not raise just because this process has no value for a secret it
+    is about to overwrite with a reference anyway. Only :meth:`resolve` --
+    called by a plugin at the point it actually needs the credential --
+    performs the lookup, and only there can it fail.
+    """
+
+    def __init__(self, secret_value: str) -> None:
+        super().__init__(secret_value)
+        self._ref = secret_ref(secret_value)
+
+    @property
+    def ref(self) -> str | None:
+        """The reference id, if this value is a ``${secret:<ref>}`` literal."""
+        return self._ref
+
+    def resolve(self) -> str:
+        """The real value: as-is for a literal, looked up for a reference."""
+        if self._ref is None:
+            return self.get_secret_value()
+        return _resolve(self._ref)
+
+
+def iter_secret_fields(
+    obj: Any, _prefix: str = ""
+) -> Iterator[tuple[str, Secret]]:
+    """
+    Walk *obj* and yield ``(dotted_path, secret)`` for every :class:`Secret`
+    field reachable from it.
+
+    *obj* is normally a :class:`~horus_runtime.core.workflow.base.BaseWorkflow`
+    instance, but the walk is generic over any pydantic model plus the
+    lists and dicts a workflow is built from (``tasks``, nested
+    ``target``/``runtime``/``executor``, artifact lists), so it finds a
+    secret at any depth without a plugin registering anything.
+
+    Paths use ``.`` throughout, including for list indices
+    (``tasks.1.target.password``) rather than ``tasks[1]...``, so a caller
+    holding the *dumped* dict (tc-os, which never imports horus-runtime's
+    plugin models) can apply the same path to it with nothing more than
+    ``str.split(".")``.
+    """
+    if isinstance(obj, Secret):
+        if _prefix:
+            yield _prefix, obj
+        return
+    if isinstance(obj, BaseModel):
+        for name in type(obj).model_fields:
+            value = getattr(obj, name, None)
+            path = f"{_prefix}.{name}" if _prefix else name
+            yield from iter_secret_fields(value, path)
+        return
+    if isinstance(obj, list):
+        for i, item in enumerate(obj):
+            yield from iter_secret_fields(item, f"{_prefix}.{i}")
+        return
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            yield from iter_secret_fields(value, f"{_prefix}.{key}")
+        return
+
+
+def _set_path(data: Any, parts: list[str], value: str) -> None:
+    node = data
+    for part in parts[:-1]:
+        node = node[int(part)] if isinstance(node, list) else node[part]
+    last = parts[-1]
+    if isinstance(node, list):
+        node[int(last)] = value
+    else:
+        node[last] = value
+
+
+def redact(
+    data: dict[str, Any], secret_fields: Iterable[tuple[str, Secret]]
+) -> dict[str, Any]:
+    """
+    Return a deep copy of *data* with each secret-marked field replaced by a
+    ``${secret:<ref>}`` reference -- never the value, not even masked.
+
+    *data* is normally ``workflow.model_dump(mode="json")`` and
+    *secret_fields* ``iter_secret_fields(workflow)`` on the same instance --
+    kept separate rather than combined into one call so a caller that only
+    has the dumped dict (tc-os) can pass paths it derived itself instead. A
+    value that already came from a ``${secret:<ref>}`` literal keeps its own
+    ref, so redacting an already-redacted document is a no-op; a literal
+    value is assigned a ref derived from its path (see :func:`ref_for_path`).
+    """
+    out = copy.deepcopy(data)
+    for path, secret in secret_fields:
+        ref = secret.ref or ref_for_path(path)
+        _set_path(out, path.split("."), f"${{secret:{ref}}}")
+    return out

--- a/tests/unit/test_secrets.py
+++ b/tests/unit/test_secrets.py
@@ -1,0 +1,235 @@
+#
+# horus-runtime
+# Copyright (C) 2026 Temple Compute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Tests for the ``Secret`` field marker, its enumeration, and redaction.
+"""
+
+import zipfile
+from pathlib import Path
+
+import pytest
+from pydantic import BaseModel
+
+from horus_builtin.target.local import LocalTarget
+from horus_runtime.core.workflow.base import BaseWorkflow
+from horus_runtime.packaging import package_workflow
+from horus_runtime.secrets import (
+    Secret,
+    SecretResolutionError,
+    iter_secret_fields,
+    redact,
+)
+
+HUNTER2 = "hunter2"  # test fixture value, not a real secret
+
+
+class SecretTarget(LocalTarget):
+    """A LocalTarget with one secret-marked field, for testing the walk."""
+
+    kind: str = "secret_target"
+    password: Secret | None = None
+
+
+class Nested(BaseModel):
+    """A plain nested model with its own secret field."""
+
+    inner: Secret | None = None
+
+
+class Holder(BaseModel):
+    """Exercises every shape :func:`iter_secret_fields` walks."""
+
+    name: str
+    secret: Secret | None = None
+    nested: Nested | None = None
+    many: list[Nested] = []
+
+
+WORKFLOW_YAML = f"""
+kind: horus_workflow
+name: Has A Secret
+tasks:
+  - kind: horus_task
+    id: run
+    name: Run
+    executor:
+      kind: shell
+    runtime:
+      kind: command
+      command: echo hi
+    target:
+      kind: secret_target
+      password: {HUNTER2}
+"""
+
+
+@pytest.fixture
+def workflow_dir(tmp_path: Path) -> Path:
+    """A workflow directory holding one workflow with a literal password."""
+    (tmp_path / "workflow.yaml").write_text(WORKFLOW_YAML)
+    return tmp_path
+
+
+@pytest.mark.unit
+class TestSecret:
+    """Tests for the ``Secret`` type itself."""
+
+    def test_literal_value_has_no_ref(self) -> None:
+        """A plain string is a literal secret: no reference to resolve."""
+        secret = Secret(HUNTER2)
+        assert secret.ref is None
+        assert secret.get_secret_value() == HUNTER2
+
+    def test_masks_repr_like_secretstr(self) -> None:
+        """repr/str never leak the value, inherited from SecretStr."""
+        assert HUNTER2 not in repr(Secret(HUNTER2))
+        assert str(Secret(HUNTER2)) == "**********"
+
+    def test_reference_resolves_from_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A ``${secret:<ref>}`` resolves from ``HORUS_SECRET_<ref>``."""
+        monkeypatch.setenv("HORUS_SECRET_MY_REF", "resolved-value")
+        secret = Secret("${secret:my-ref}")
+        assert secret.ref == "my-ref"
+        assert secret.resolve() == "resolved-value"
+
+    def test_reference_resolves_from_secrets_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Falls back to ``$HORUS_SECRETS_FILE`` when no env var is set."""
+        secrets_file = tmp_path / "secrets.yaml"
+        secrets_file.write_text("my-ref: from-file\n")
+        monkeypatch.delenv("HORUS_SECRET_MY_REF", raising=False)
+        monkeypatch.setenv("HORUS_SECRETS_FILE", str(secrets_file))
+        assert Secret("${secret:my-ref}").resolve() == "from-file"
+
+    def test_unresolved_reference_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Neither source having the ref is a hard failure, not a blank."""
+        monkeypatch.delenv("HORUS_SECRET_MISSING", raising=False)
+        monkeypatch.delenv("HORUS_SECRETS_FILE", raising=False)
+        with pytest.raises(SecretResolutionError, match="missing"):
+            Secret("${secret:missing}").resolve()
+
+    def test_default_json_dump_masks_a_reference_without_resolving(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        Pydantic's default JSON masking must not require resolution: a
+        plain ``model_dump(mode="json")`` of a workflow already carrying a
+        reference must not raise just because this process has no value
+        for it yet.
+        """
+        monkeypatch.delenv("HORUS_SECRET_MY_REF", raising=False)
+        monkeypatch.delenv("HORUS_SECRETS_FILE", raising=False)
+        holder = Holder(name="x", secret=Secret("${secret:my-ref}"))
+        assert holder.model_dump(mode="json")["secret"] == "**********"
+
+
+@pytest.mark.unit
+class TestIterSecretFields:
+    """Tests for the model-tree walk."""
+
+    def test_finds_top_level_and_nested_fields(self) -> None:
+        """A secret is found at every depth: top-level, nested, in a list."""
+        holder = Holder(
+            name="x",
+            secret=Secret(HUNTER2),
+            nested=Nested(inner=Secret("inner-value")),
+            many=[Nested(inner=Secret("list-value"))],
+        )
+        found = dict(iter_secret_fields(holder))
+        assert set(found) == {"secret", "nested.inner", "many.0.inner"}
+        assert found["secret"].resolve() == HUNTER2
+
+    def test_unset_secret_field_yields_nothing(self) -> None:
+        """An unset ``Secret | None`` field is not a secret to redact."""
+        assert list(iter_secret_fields(Holder(name="x"))) == []
+
+    def test_walks_a_workflow_to_a_target_field(
+        self, workflow_dir: Path
+    ) -> None:
+        """The walk reaches a secret nested inside a task's target."""
+        workflow = BaseWorkflow.from_yaml(workflow_dir / "workflow.yaml")
+        found = dict(iter_secret_fields(workflow))
+        assert "tasks.0.target.password" in found
+        assert found["tasks.0.target.password"].resolve() == HUNTER2
+
+
+@pytest.mark.unit
+class TestRedact:
+    """Tests for turning secret fields into ``${secret:<ref>}`` references."""
+
+    def test_replaces_literal_with_a_path_derived_ref(self) -> None:
+        """A literal with no ref of its own gets one derived from its path."""
+        holder = Holder(name="x", secret=Secret(HUNTER2))
+        data = holder.model_dump(mode="json")
+        redacted = redact(data, iter_secret_fields(holder))
+        assert redacted["secret"] == "${secret:secret}"
+        assert HUNTER2 not in str(redacted)
+        # The dict redact() was given is untouched (a deep copy is redacted).
+        assert data["secret"] == "**********"
+
+    def test_keeps_an_existing_reference(self) -> None:
+        """Redacting an already-referenced value is a no-op on its ref."""
+        holder = Holder(name="x", secret=Secret("${secret:my-ref}"))
+        data = holder.model_dump(mode="json")
+        redacted = redact(data, iter_secret_fields(holder))
+        assert redacted["secret"] == "${secret:my-ref}"
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("horus_context")
+class TestWorkflowExport:
+    """Tests that export paths never write the literal secret value."""
+
+    def test_to_yaml_never_writes_the_literal(
+        self, workflow_dir: Path
+    ) -> None:
+        """to_yaml redacts, and the reference round-trips on reload."""
+        workflow = BaseWorkflow.from_yaml(workflow_dir / "workflow.yaml")
+        out = workflow_dir / "out.yaml"
+        workflow.to_yaml(out)
+
+        text = out.read_text()
+        assert HUNTER2 not in text
+        assert "${secret:tasks_0_target_password}" in text
+
+        reimported = BaseWorkflow.from_yaml(out)
+        target = reimported.tasks[0].target
+        assert isinstance(target, SecretTarget)
+        assert target.password is not None
+        assert target.password.ref == "tasks_0_target_password"
+
+    def test_package_workflow_never_writes_the_literal(
+        self, workflow_dir: Path
+    ) -> None:
+        """The zipped workflow.yaml is redacted, byte for byte."""
+        archive, _members, _skipped = package_workflow(
+            workflow_dir / "workflow.yaml"
+        )
+        with zipfile.ZipFile(archive) as bundle:
+            text = bundle.read("workflow.yaml").decode()
+
+        assert HUNTER2 not in text
+        assert "${secret:tasks_0_target_password}" in text
+        # Nothing else about the file changed shape: it still parses as the
+        # same workflow, minus the redacted value.
+        assert "kind: horus_task" in text

--- a/tests/unit/test_secrets.py
+++ b/tests/unit/test_secrets.py
@@ -23,6 +23,7 @@ import zipfile
 from pathlib import Path
 
 import pytest
+import yaml
 from pydantic import BaseModel
 
 from horus_builtin.target.local import LocalTarget
@@ -31,7 +32,9 @@ from horus_runtime.packaging import package_workflow
 from horus_runtime.secrets import (
     Secret,
     SecretResolutionError,
+    env_key_for_ref,
     iter_secret_fields,
+    iter_secret_refs,
     redact,
 )
 
@@ -131,12 +134,7 @@ class TestSecret:
     def test_default_json_dump_masks_a_reference_without_resolving(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """
-        Pydantic's default JSON masking must not require resolution: a
-        plain ``model_dump(mode="json")`` of a workflow already carrying a
-        reference must not raise just because this process has no value
-        for it yet.
-        """
+        """model_dump never resolves; masking a reference must not raise."""
         monkeypatch.delenv("HORUS_SECRET_MY_REF", raising=False)
         monkeypatch.delenv("HORUS_SECRETS_FILE", raising=False)
         holder = Holder(name="x", secret=Secret("${secret:my-ref}"))
@@ -171,6 +169,32 @@ class TestIterSecretFields:
         found = dict(iter_secret_fields(workflow))
         assert "tasks.0.target.password" in found
         assert found["tasks.0.target.password"].resolve() == HUNTER2
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("horus_context")
+class TestIterSecretRefs:
+    """Tests for the dict-side walk tc-os runs on stored ``workflow_data``."""
+
+    def test_finds_refs_in_a_redacted_yaml_dict(
+        self, workflow_dir: Path
+    ) -> None:
+        """to_yaml -> safe_load -> iter_secret_refs finds the same path."""
+        workflow = BaseWorkflow.from_yaml(workflow_dir / "workflow.yaml")
+        out = workflow_dir / "out.yaml"
+        workflow.to_yaml(out)
+
+        data = yaml.safe_load(out.read_text())
+        found = dict(iter_secret_refs(data))
+        assert found["tasks.0.target.password"] == "tasks_0_target_password"
+        assert (
+            env_key_for_ref(found["tasks.0.target.password"])
+            == "HORUS_SECRET_TASKS_0_TARGET_PASSWORD"
+        )
+
+    def test_no_references_yields_nothing(self) -> None:
+        """A plain value is not a reference."""
+        assert list(iter_secret_refs({"name": "x", "port": 22})) == []
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Closes #193.

## Problem

A plugin target can hold a credential in a plain `str` field (e.g. `SSHTarget.password`), so it travels through every serialization path unmarked -- `to_yaml`, `package_workflow`, and downstream tc-os export routes all dump it verbatim.

## What this adds

- `Secret` (`src/horus_runtime/secrets.py`), a `SecretStr` subclass: `password: Secret | None = None`. Masked repr/str/JSON dump, `format: "password"` / `writeOnly` in the generated JSON schema.
- `iter_secret_fields(model)` -- walks a pydantic model tree, yields the dotted path of every `Secret` field.
- `iter_secret_refs(data)` -- the dict-side twin: walks a *dumped* workflow dict (no models) and yields `(path, ref)` for every `${secret:<ref>}` found. tc-os stores workflows as an opaque `workflow_data` dict, never a validated model, so this is what its backend calls to know which credentials a stored workflow needs.
- `redact(data, secret_fields)` -- replaces each secret field with a `${secret:<ref>}` reference, never a value, never pydantic's own mask (a mask round-trips back in as a literal password on re-import).
- `BaseWorkflow.to_yaml` and `packaging.package_workflow` redact before writing.
- `Secret.resolve()` looks up the real value for a reference lazily, from `HORUS_SECRET_<REF>` or `$HORUS_SECRETS_FILE`.

## Non-goals (per the issue)

Key management/rotation, encrypting the local secrets file, per-run credential scoping.

## Follow-up

The storage half -- lifting these out of tc-os's `workflow_data`, a credentials store, re-injection at run dispatch -- is tracked in temple-compute/tc-os#276.

## Testing

`tests/unit/test_secrets.py` plus the full `tests/unit` suite (766 passed). `ruff check`, `ruff format --check`, `mypy` all clean.

## Docs

https://github.com/temple-compute/horus-docs/pull/61